### PR TITLE
chore(search): add cart icon to th

### DIFF
--- a/app/scripts/search/templates/search.files.html
+++ b/app/scripts/search/templates/search.files.html
@@ -8,6 +8,7 @@
   <thead>
   <tr>
     <th>
+      <i class="fa fa-shopping-cart fa-2x"></i>
       <div class="btn-group pull-right" dropdown>
         <button type="button" class="btn btn-default action-button dropdown-toggle">
           A


### PR DESCRIPTION
![screen shot 2014-11-26 at 3 00 50 pm](https://cloud.githubusercontent.com/assets/1314446/5207922/139a7a18-757d-11e4-9302-217c469d0f85.png)
It's a bit unintuitive that the check box beside the file rows on the search page add the files to the cart. At least I keep forgetting. How about adding an chart icon to the table header?
