### PR TITLE
Feat/oicr 161 files dropdown

### DIFF
--- a/app/scripts/files/files.models.ts
+++ b/app/scripts/files/files.models.ts
@@ -10,20 +10,14 @@ module ngApp.files.models {
   }
 
   export interface IArchive {
-    folderUrl: string;
-    name: string;
-    url: string;
-    uuid: string;
-    batch: string;
-    archive_uuid: string;
-    centerName: string;
-    centerType: string;
-    dataLevel: string;
-    dataTypeInUrl: string;
-    dateArchiveAdded: string;
-    diseaseCode: string;
+    archive_center_name: string;
+    archive_center_type: string;
+    archive_data_level: string;
+    archive_data_type_in_url: string;
+    date_archive_added: string;
+    disease_code: string;
     platform: string;
-    platformInUrl: string;
+    platform_in_url: string;
     protected: boolean;
     revision: number;
   }

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -91,6 +91,8 @@ module ngApp.search.controllers {
           "updated",
           "archive.disease_code",
           "archive.revision",
+          "archive.archive_name",
+          "archive.archive_uuid",
           "participants.bcr_patient_uuid"
         ],
         facets: [

--- a/app/scripts/search/templates/search.files.html
+++ b/app/scripts/search/templates/search.files.html
@@ -2,8 +2,6 @@
   <div class="panel-heading">
     <h3 class="panel-title">Files</h3>
   </div>
-  <div class="table-responsive">
-
     <table id="file-table" class="table table-striped table-hover table-condensed table-bordered">
       <thead>
       <tr>
@@ -87,16 +85,19 @@
                 </a>
               </li>
               <li class="divider"></li>
-              <li role="listitem"
-                  aria-label="{{ 'View Files in same Archive' | translate }}">
-                <a>
+              <li data-ng-if="file.archive.archive_uuid" role="listitem"
+                  aria-label="{{ 'Find Files in same archive' | translate }}">
+                <a data-ng-href="search/f?filters={{ makeFilter([
+                    { name: 'files.archive.archive_uuid', value: file.archive.archive_uuid }
+                    ])}}">
                   <i class="fa fa-file-zip-o fa-stack "></i>
-                  <span data-translate>View Files in same Archive</span>
+                  <span data-translate>Find Files in same archive</span>
                 </a>
               </li>
+              <li class="divider"></li>
               <li role="listitem"
                   aria-label="{{ 'View Metadata Files' | translate }}">
-                <a>
+                <a data-ng-href="/files/{{ file.file_uuid }}#files">
                   <i class="fa fa-file-text-o fa-stack "></i>
                   <span data-translate>View Metadata Files</span>
                 </a>
@@ -190,5 +191,4 @@
                     first-text="&laquo;"
                     last-text="&raquo;"></pagination>
       </div>
-    </div>
   </div>

--- a/app/scripts/search/templates/search.participants.html
+++ b/app/scripts/search/templates/search.participants.html
@@ -2,8 +2,6 @@
   <div class="panel-heading">
     <h3 class="panel-title">Participants</h3>
   </div>
-  <div class="table-responsive">
-
     <table id="participant-table" class="table table-striped table-hover table-condensed table-bordered">
       <thead>
       <tr>
@@ -128,5 +126,4 @@
                   first-text="&laquo;"
                   last-text="&raquo;"></pagination>
     </div>
-  </div>
 </div>

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -125,3 +125,4 @@ table .btn {
     white-space: normal;
   }
 }
+


### PR DESCRIPTION
Fixes table-responsive covering dropdown menu when the table itself is shorter than the menu. Also updates the "View files in same archive" and "view metadata files" links, but having trouble getting "View files in same archive" to reload (see line comment on line 97) and used ng-href instead of ui-sref because linking to hash anchors is not supported (This PR https://github.com/angular-ui/ui-router/pull/1187 was never merged).
