### PR TITLE
Feat/oicr 160 fix tables

### DIFF
--- a/app/scripts/annotations/templates/annotations.html
+++ b/app/scripts/annotations/templates/annotations.html
@@ -80,7 +80,7 @@
               </td>
               <td>{{ ::annotation.itemType }}</td>
               <td>tbc</td>
-              <td>{{ ::annotation.item }}</td>
+              <td>{{ ::annotation.item | ellipsicate:50 }}</td>
               <td>{{ ::annotation.annotationClassificationName }}</td>
               <td>{{ ::annotation.categoryName }}</td>
               <td>{{ ::annotation.dateCreated | date }}</td>

--- a/app/scripts/cart/templates/cart.html
+++ b/app/scripts/cart/templates/cart.html
@@ -16,7 +16,7 @@
               &#35;
               <span data-translate data-translate-comment="number of">of files</span>
             </th>
-            <td>{{ cc.files.hits.length }}</td>
+            <td>{{ cc.files.hits.length | number:0 }}</td>
           </tr>
           <tr>
             <th scope="row" data-translate>Size</th>

--- a/app/scripts/components/facets/templates/facet.html
+++ b/app/scripts/components/facets/templates/facet.html
@@ -18,7 +18,7 @@
           <i class="fa fa-square-o" aria-controls="data-table" aria-checked="false"></i>
           {{ term.key | translate }}
         </span>
-        <span class="label label-primary pull-right">{{ term.doc_count }}</span>
+        <span class="label label-primary pull-right">{{ term.doc_count| number:0}}</span>
       </p>
 
 

--- a/app/scripts/components/ui/ellipsicate/ellipsicate.filters.ts
+++ b/app/scripts/components/ui/ellipsicate/ellipsicate.filters.ts
@@ -1,0 +1,13 @@
+module ngApp.components.ui.ellipsicate {
+
+  class Ellipsicate {
+    constructor() {
+      return function(fullstring: string, length: number = 50) {
+        return (fullstring.length <= length) ? fullstring : fullstring.substring(0, length) + "…";
+      };
+    }
+  }
+
+  angular.module("ellipsicate.filters", [])
+  .filter("ellipsicate", Ellipsicate);
+}

--- a/app/scripts/components/ui/ellipsicate/module.ts
+++ b/app/scripts/components/ui/ellipsicate/module.ts
@@ -1,0 +1,7 @@
+module ngApp.components.ui.ellipsicate {
+
+  angular.module("ui.ellipsicate", [
+    "ellipsicate.filters"
+  ]);
+
+}

--- a/app/scripts/components/ui/ellipsicate/tests/ellipsicatefilter.tests.js
+++ b/app/scripts/components/ui/ellipsicate/tests/ellipsicatefilter.tests.js
@@ -1,0 +1,35 @@
+describe("Ellipsictae Filter:", function() {
+  // Initialization of the AngularJS application before each test case
+  beforeEach(module("ngApp.components"));
+
+  var sampleString = "Cake liquorice bear claw wafer marzipan pudding. Cupcake chocolate bar dessert wafer. Lemon drops applicake pastry fruitcake pastry icing tart unerdwear.com cotton candy. Donut carrot cake apple pie apple pie jelly-o toffee oat cake cookie lollipop.";
+
+  it("should have an ellipsicate filter", inject(function ($filter) {
+    expect($filter("ellipsicate")).not.to.equal(null);
+  }));
+
+  it("should truncate to default length+1 chars with no length param", inject(function ($filter) {
+    var ellipsicated = $filter("ellipsicate")(sampleString);
+    expect(ellipsicated).to.have.length(51);
+  }));
+
+  it("should truncate to 1 char (the length of …) with length 0", inject(function ($filter) {
+    var ellipsicated = $filter("ellipsicate")(sampleString, 0);
+    expect(ellipsicated).to.have.length(1);
+  }));
+
+  it("should truncate to the specified length + 1 (the length of …)", inject(function ($filter) {
+    var length = Math.floor((Math.random() * 100) + 1);
+    var ellipsicated = $filter("ellipsicate")(sampleString, length);
+    expect(ellipsicated).to.have.length(length + 1);
+  }));
+
+  it("should not do anything if the string is shorter or equal to the than the truncate length", inject(function ($filter) {
+    var fullstring = "Chocolate"
+    var ellipsicated = $filter("ellipsicate")(fullstring, 50);
+    expect(ellipsicated).to.have.length(fullstring.length);
+    ellipsicated = $filter("ellipsicate")(fullstring, fullstring.length);
+    expect(ellipsicated).to.have.length(fullstring.length);
+  }));
+
+});

--- a/app/scripts/components/ui/module.ts
+++ b/app/scripts/components/ui/module.ts
@@ -18,7 +18,8 @@ module ngApp.components.ui {
     "ui.scroll",
     "ui.date",
     "ui.file",
-    "ui.search"
+    "ui.search",
+    "ui.ellipsicate"
   ]);
 
 }

--- a/app/scripts/participant/templates/participant.html
+++ b/app/scripts/participant/templates/participant.html
@@ -65,7 +65,7 @@
                         name: 'participants.bcr_patient_uuid', value: pc.participant.bcr_patient_uuid
                       }
                     ])})">
-                  {{ ::pc.participant.files.length }}
+                  {{ ::pc.participant.files.length | number:0 }}
                 </a>
               </td>
             </tr>
@@ -73,7 +73,7 @@
               <th scope="row" data-translate>Annotations</th>
               <td>
                 <a data-scroll-to href="#annotations">
-                  {{ ::pc.participant.participant_annotations.length }}
+                  {{ ::pc.participant.participant_annotations.length | number:0 }}
                 </a>
               </td>
             </tr>
@@ -84,7 +84,10 @@
           <div class="panel-heading">
             <h3 class="panel-title" data-translate>Experimental Strategy</h3>
           </div>
-          <table class="table table-striped table-hover table-condensed table-bordered table-vertical">
+          <div class="panel-body" data-ng-if="!pc.participant.experiments.length">
+            <h4 class="list-group-item-heading" data-translate>No experimental strategies were found.</h4>
+          </div>
+          <table class="table table-striped table-hover table-condensed table-bordered table-vertical" data-ng-if="pc.participant.experiments.length">
             <thead>
             <tr>
               <th scope="col" data-translate>Analysis</th>
@@ -95,14 +98,14 @@
             <tbody>
             <tr data-ng-repeat="experiment in pc.participant.experiments">
               <td>tbc {{ ::experiment.name }}</td>
-              <td>tbc {{ ::experiment.samples }}</td>
-              <td>
+              <td class="text-right">tbc {{ ::experiment.samples | number:0 }}</td>
+              <td class="text-right">
                 <a data-ui-sref="search.files({ 'filters': makeFilter([
                       {
                         name: 'participant_id', value: pc.participant.bcr_patient_uuid
                       }
                     ])})">
-                  tbc {{ ::experiment.files }}
+                  tbc {{ ::experiment.files | number:0 }}
                 </a>
               </td>
             </tr>
@@ -115,13 +118,16 @@
           <div class="panel-heading">
             <h3 class="panel-title" data-translate>Available Data</h3>
           </div>
-          <table class="table table-striped table-hover table-condensed table-bordered table-vertical">
+          <div class="panel-body" data-ng-if="!pc.participant.data.length">
+            <h4 class="list-group-item-heading" data-translate>No available data.</h4>
+          </div>
+          <table class="table table-striped table-hover table-condensed table-bordered table-vertical" data-ng-if="pc.participant.data.length">
             <tbody>
             <tr data-ng-repeat="item in pc.participant.data">
               <th scope="row">{{ item.name }}</th>
               <td>
                 <a data-ui-sref="search.files">
-                  {{ item.files }}
+                  {{ item.files | number:0 }}
                 </a>
               </td>
             </tr>

--- a/app/scripts/projects/templates/project.html
+++ b/app/scripts/projects/templates/project.html
@@ -80,7 +80,7 @@
                             name: 'participants.admin.disease_code',value: prc.project.project_code
                           }
                         ])})">
-                  tbc {{ prc.project._summary.file_count }}
+                  tbc {{ prc.project._summary.file_count | number:0 }}
                 </a>
               </td>
             </tr>
@@ -91,7 +91,10 @@
           <div class="panel-heading">
             <h3 class="panel-title" data-translate>Experimental Strategy</h3>
           </div>
-          <table class="table table-striped table-hover table-condensed table-bordered">
+          <div class="panel-body" data-ng-if="!prc.project._summary._experimental_data">
+            <h4 class="list-group-item-heading" data-translate>No experimental strategies were found.</h4>
+          </div>
+          <table class="table table-striped table-hover table-condensed table-bordered" data-ng-if="prc.project._summary._experimental_data">
             <thead>
             <tr>
               <th scope="col" data-translate>Analysis</th>
@@ -103,7 +106,7 @@
             <tbody>
             <tr data-ng-repeat="(experiment, counts) in prc.project._summary._experimental_data">
               <td>{{ ::experiment }}</td>
-              <td>
+              <td class="text-right">
                 <a data-ui-sref="search.participants({ 'filters': makeFilter([
                           {
                             name: 'participants.admin.disease_code',value: prc.project.project_code
@@ -112,10 +115,10 @@
                             name: 'files.experimental_strategy', value: experiment
                           }
                         ])})">
-                  {{ ::counts.participant_count }}
+                  {{ ::counts.participant_count | number:0 }}
                 </a>
               </td>
-              <td>tbc {{ ::experiment.sample_count }}</td>
+              <td class="text-right">tbc {{ ::experiment.sample_count | number:0 }}</td>
               <td>
                 <a data-ui-sref="search.files({ 'filters': makeFilter([
                           {
@@ -125,7 +128,7 @@
                             name: 'files.experimental_strategy', value: experiment
                           }
                         ])})">
-                  {{ ::counts.file_count }}
+                  {{ ::counts.file_count | number:0 }}
                 </a>
               </td>
             </tr>
@@ -138,7 +141,10 @@
           <div class="panel-heading">
             <h3 class="panel-title" data-translate>Available Data</h3>
           </div>
-          <table class="table table-striped table-hover table-condensed table-bordered">
+          <div class="panel-body" data-ng-if="!prc.project._summary._analyzed_data">
+            <h4 class="list-group-item-heading" data-translate>No available data.</h4>
+          </div>
+          <table class="table table-striped table-hover table-condensed table-bordered" data-ng-if="prc.project._summary._analyzed_data">
             <thead>
             <tr>
               <th scope="col" data-translate>Data Type</th>
@@ -149,7 +155,7 @@
             <tbody>
             <tr data-ng-repeat="(dataCategory, counts) in prc.project._summary._analyzed_data">
               <td>{{ ::dataCategory }}</td>
-              <td>
+              <td class="text-right">
                 <a data-ui-sref="search.participants({ 'filters': makeFilter([
                       {
                         name: 'participants.admin.disease_code',value: prc.project.project_code
@@ -158,10 +164,10 @@
                         name: 'files.data_type', value: dataCategory
                       }
                     ])})">
-                  {{ counts.participant_count ? counts.participant_count : "-" }}
+                    {{ counts.participant_count | number:0 }}
                 </a>
               </td>
-              <td>
+              <td class="text-right">
                 <a data-ui-sref="search.files({ 'filters': makeFilter([
                       {
                         name: 'participants.admin.disease_code',value: prc.project.project_code
@@ -170,7 +176,7 @@
                         name: 'files.data_type', value: dataCategory
                       }
                     ])})">
-                  {{ counts.file_count ? counts.file_count : "-" }}
+                  {{ counts.file_count | number:0 }}
                 </a>
               </td>
             </tr>

--- a/app/scripts/projects/templates/projects.html
+++ b/app/scripts/projects/templates/projects.html
@@ -75,7 +75,7 @@
                 name: 'participants.admin.disease_code', value: p.project_code
               }
             ])})">
-              {{ ::p._summary._participant_count }}
+              {{ ::p._summary._participant_count| number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -87,7 +87,7 @@
                 name: 'files.data_type', value: 'Clinical data'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["Clinical data"].file_count }}
+              {{ ::p._summary._analyzed_data["Clinical data"].file_count | number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -99,7 +99,7 @@
                 name: 'files.data_type', value: 'Simple nucleotide variant'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["Simple nucleotide variant"].file_count }}
+              {{ ::p._summary._analyzed_data["Simple nucleotide variant"].file_count | number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -111,7 +111,7 @@
                 name: 'files.data_type', value: 'mRNA expression'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["mRNA expression"].file_count }}
+              {{ ::p._summary._analyzed_data["mRNA expression"].file_count | number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -123,7 +123,7 @@
                 name: 'files.data_type', value: 'miRNA expression'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["miRNA expression"].file_count }}
+              {{ ::p._summary._analyzed_data["miRNA expression"].file_count | number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -135,7 +135,7 @@
                 name: 'files.data_type', value: 'Copy number variant'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["Copy number variant"].file_count }}
+              {{ ::p._summary._analyzed_data["Copy number variant"].file_count | number:0 }}
             </a>
           </td>
           <td class="text-right">
@@ -147,7 +147,7 @@
                 name: 'files.data_type', value: 'DNA methylation'
               }
             ])})">
-              {{ ::p._summary._analyzed_data["DNA methylation"].file_count }}
+              {{ ::p._summary._analyzed_data["DNA methylation"].file_count | number:0 }}
             </a>
           </td>
           <td>{{ ::p.status}}</td>

--- a/app/scripts/search/templates/search.files.html
+++ b/app/scripts/search/templates/search.files.html
@@ -37,12 +37,12 @@
         </th>
         <th scope="col" class="text-center" data-translate>Access</th>
         <th scope="col" class="text-center" data-translate>File Name</th>
-        <th scope="col" class="text-center" data-translate>Participant ID</th>
+        <th scope="col" class="text-center" data-translate>File type</th>
+        <th scope="col" class="text-center" data-translate>Participants</th>
         <th scope="col" class="text-center" data-translate>Annotations</th>
         <th scope="col" class="text-center" data-translate>Project</th>
         <th scope="col" class="text-center" data-translate>Data Category</th>
         <th scope="col" class="text-center" data-translate>Status</th>
-        <th scope="col" class="text-center" data-translate>File type</th>
         <th scope="col" class="text-center" data-translate>Size</th>
         <th scope="col" class="text-center" data-translate>Revision</th>
         <th scope="col" class="text-center" data-translate>Update date</th>
@@ -110,13 +110,14 @@
         </td>
         <td>
           <a data-ui-sref="file({ fileId: file.file_uuid })">
-            {{ ::file.file_name }}
+            {{ ::file.file_name | ellipsicate }}
           </a>
         </td>
-        <td>
-          {{ ::file.participants.length }}
+        <td>{{ ::file.file_extension }}</td>
+        <td class="text-right">
+          {{ ::file.participants.length | number:0 }}
         </td>
-        <td>0{{ ::file.annotations.length }}</td>
+        <td class="text-right">{{ ::file.annotations.length | number:0 }}</td>
         <td>
           <a data-ui-sref="project({ projectId: file.project.id })">
             {{ ::file.archive.disease_code}}
@@ -124,7 +125,6 @@
         </td>
         <td>{{ ::file.data_type }}</td>
         <td>tbc {{ ::file.state }}</td>
-        <td>{{ ::file.file_extension }}</td>
         <td>{{ file.file_size | size }}</td>
         <td>{{ ::file.archive.revision }}</td>
         <td>{{ file.modified | date }}</td>

--- a/app/scripts/search/templates/search.html
+++ b/app/scripts/search/templates/search.html
@@ -26,12 +26,12 @@
         <li role="presentation"
             data-ng-class="{ active: sc.State.tabs.files.active }"
             data-ng-click="sc.select('tabs', 'files')">
-          <a>{{ 'Files' | translate }} ({{sc.files.pagination.total}})</a>
+          <a>{{ 'Files' | translate }} ({{sc.files.pagination.total| number:0}})</a>
         </li>
         <li role="presentation"
             data-ng-class="{ active: sc.State.tabs.participants.active }"
             data-ng-click="sc.select('tabs', 'participants')">
-          <a>{{ 'Participants' | translate }} ({{sc.participants.pagination.total}})</a>
+          <a>{{ 'Participants' | translate }} ({{sc.participants.pagination.total| number:0}})</a>
         </li>
       </ul>
       <div class="pane-section"

--- a/app/scripts/search/templates/search.participants.html
+++ b/app/scripts/search/templates/search.participants.html
@@ -50,18 +50,18 @@
         <td>{{ ::p.admin.disease_code }}</td>
         <td>{{ ::p.gender }}</td>
         <td>{{ ::p.person_neoplasm_cancer_status }}</td>
-        <td>
+        <td class="text-right">
           <a data-ui-sref="search.files({ 'filters': makeFilter([
         {
           name: 'participant_id', value: p.bcr_patient_uuid
         }
       ])})">
-            tbc {{ ::p.files.length }}
+            tbc {{ ::p.files.length | number:0 }}
           </a>
         </td>
-        <td>
+        <td class="text-right">
           <a data-ui-sref="annotations({ participantId: p.id })">
-            tbc {{ ::p.annotations.length }}
+            tbc {{ ::p.annotations.length | number:0 }}
           </a>
         </td>
       </tr>


### PR DESCRIPTION
Use built in angular filter to separate numbers with commas, custom filter to truncate long text with ellipsis. The filenames are quite similar at the beginning though - maybe we want to add ellipsis in the middle of the string? eg. nationwide(...)TCGA-OR-A5J3.xml or start from the end eg ...TCGA-OR-A5J3.xml
![screen shot 2014-12-16 at 2 39 51 pm](https://cloud.githubusercontent.com/assets/1314446/5460502/7325a08e-8531-11e4-993f-41a47b88833b.png)
Added no data msgs
![screen shot 2014-12-16 at 2 40 31 pm](https://cloud.githubusercontent.com/assets/1314446/5460512/84364ff4-8531-11e4-89f0-8d6e4162eb54.png)
