### PR TITLE
Search Table Header Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Installing NPM dependencies...
 Setup Successful!
 ```
 
+### ElasticSearch
+Edit path-to-elastic-search/config/elasticsearch.yml, find the line with http.max_content_length, add
+```
+http.max_initial_line_length: 1000mb
+```
+to increase the max length of a HTTP URL
+
 ### Git hooks
 
 Git commit-msg hook is based on Angular's [Guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#)

--- a/app/scripts/cart/cart.services.ts
+++ b/app/scripts/cart/cart.services.ts
@@ -22,9 +22,10 @@ module ngApp.cart.services {
     removeFiles(files: IFile[]): void;
     buildAddedMsg(addedAndAlreadyIn: Object): string;
     buildRemovedMsg(removedFiles: IFile[]): string;
-    //undo(): void;
     undoAdded(): void;
     undoRemoved(): void;
+    getMaxSize(): number;
+    isFull(): boolean;
   }
 
   class CartService implements ICartService {
@@ -34,6 +35,7 @@ module ngApp.cart.services {
 
     private static GDC_CART_KEY = "gdc-cart-items";
     private static GDC_CART_UPDATE = "gdc-cart-updated";
+    private static MAX_SIZE: number = 1000;
 
     /* @ngInject */
     constructor(private $window: IGDCWindowService,
@@ -43,6 +45,14 @@ module ngApp.cart.services {
 
       this.lastModified = local_time ? $window.moment(local_time) : $window.moment();
       this.files = local_files ? JSON.parse(local_files) : [];
+    }
+
+    getMaxSize(): number {
+      return CartService.MAX_SIZE;
+    }
+
+    isFull(): boolean {
+      return this.files.length >= CartService.MAX_SIZE;
     }
 
     getFiles(): IFile[] {
@@ -151,6 +161,7 @@ module ngApp.cart.services {
           classes: "alert-warning"
       });
       this.files = remaining;
+      this._sync();
     }
 
     removeFiles(files: IFile[]): void {

--- a/app/scripts/search/templates/search.files.html
+++ b/app/scripts/search/templates/search.files.html
@@ -1,5 +1,3 @@
-<div class="panel panel-default">
-
   <div class="panel-heading clearfix">
     <h3 class="panel-title pull-left" data-translate>Files</h3>
     <div class="pull-right">
@@ -16,7 +14,8 @@
             <i class="fa fa-check-circle"></i>
           </button>
           <button data-ng-if="!sc.CartService.areInCart(sc.files.hits)" type="button" class="btn btn-primary"
-                  data-ng-click="sc.CartService.addFiles(sc.files.hits)">
+                  data-ng-click="sc.CartService.addFiles(sc.files.hits)" 
+                  data-ng-disabled="(sc.CartService.getFiles().length + sc.files.hits.length) > sc.CartService.getMaxSize()">
             <i class="fa fa-shopping-cart"></i>
           </button>
           <button type="button" class="btn btn-default dropdown-toggle">
@@ -24,13 +23,21 @@
           </button>
           <ul class="dropdown-menu" role="menu">
             <li>
-              <a>
+              <a data-ng-if="sc.CartService.isFull()">
+                <i class="fa fa-shopping-cart fa-stack"></i>
+                <span data-translate>Cart Full</span>
+              </a>
+              <a data-ng-if="(sc.CartService.getFiles().length + sc.files.pagination.total) > sc.CartService.getMaxSize()" disabled>
+                <i class="fa fa-shopping-cart fa-stack"></i>
+                <span data-translate>Cart can only hold {{sc.CartService.getMaxSize() - sc.CartService.getFiles().length }} more items</span>
+              </a>
+              <a data-ng-if="(sc.CartService.getFiles().length + sc.files.pagination.total) <= sc.CartService.getMaxSize()" data-ng-click="sc.addAll()">
                 <i class="fa fa-shopping-cart fa-stack"></i>
                 <span data-translate>Add all in Search Result</span>
               </a>
             </li>
             <li>
-              <a>
+              <a data-ng-click="sc.removeAllInSearchResult()">
                 <i class="fa fa-shopping-cart fa-stack"></i>
                 <span data-translate>Remove all in Search Result</span>
               </a>


### PR DESCRIPTION
![screen shot 2015-01-12 at 4 58 47 pm](https://cloud.githubusercontent.com/assets/1314446/5712016/eadd7236-9a7c-11e4-85ec-14cb2912d492.png)
-Disabled the blue cart button, such that the user must use the drop down actions because it's difficult to express "Cart can only hold n more files" etc on the button.
-"Remove all in search result" works, until the HTTP call to ElasticSearch exceeds 4K bytes. Then ES gives this error `org.elasticsearch.common.netty.handler.codec.frame.TooLongFrameException: An HTTP line is larger than 4096 bytes.` Could configure http.max_initial_line_length to a longer value?
