### PR TITLE
fix(search): don't add removed facets on tabswitch

### DIFF
--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -199,7 +199,7 @@ module ngApp.search.controllers {
       // Changing tabs and then navigating to another page
       // will cause this to fire.
       if (tab && (this.$state.current.name.match("search."))) {
-        this.$state.go("search." + tab, this.LocationService.search(), {inherit: true});
+        this.$state.go("search." + tab, this.LocationService.search(), {inherit: false});
       }
     }
 


### PR DESCRIPTION
On the search page, removing all selected facets and then switching tabs will cause the removed facets to come back. Changing inherit to false in $state.go seems to solve this issue, it doesn't need to inherit params from the URL anyway as $location.search() is passed in as params.
