### PR TITLE
Feat/oicr 235 nested field lookup

### DIFF
--- a/app/scripts/components/tables/tableicious.directive.ts
+++ b/app/scripts/components/tables/tableicious.directive.ts
@@ -68,8 +68,7 @@ module ngApp.components.tables.directives.tableicious {
          * Return either true or false, given a reference to the scope of the table it is on.
          * This overrides "visible"
          */
-        enabled?:any;
-        //enabled?(scope) : Boolean;
+        enabled?(scope:ng.IScope):boolean;
 
         /**
          * @children
@@ -104,6 +103,7 @@ module ngApp.components.tables.directives.tableicious {
 
         /**
          * If false, won't show up in the table. Will still show up in sorting.
+         * Use for the show / hide column directive.
          */
         visible? : boolean;
 
@@ -155,7 +155,8 @@ module ngApp.components.tables.directives.tableicious {
 
             $scope.getHeadingColSpan = TableService.getHeadingColSpan.bind($scope);
             $scope.getHeadingRowSpan = TableService.getHeadingRowSpan.bind($scope);
-            $scope.getTemplate = TableService.getTemplate.bind($scope);
+            $scope.getTemplate = TableService.getTemplate.bind(TableService);
+            //$scope.getTemplate = TableService.getTemplate.bind($scope);
             $scope.getHeadingEnabled = TableService.getHeadingEnabled.bind($scope);
             $scope.getSref = TableService.getSref.bind($scope);
             $scope.getHeadingClass = TableService.getHeadingClass.bind($scope);

--- a/app/scripts/components/tables/tests/table.services.test.js
+++ b/app/scripts/components/tables/tests/table.services.test.js
@@ -200,5 +200,180 @@ describe('Table Service:', function () {
         })
     });
 
+    describe("Determining when a column should be enabled",function(){
+        describe("The behaviour when the heading has no enabled property",function() {
+            it("should return true if no condition is defined", inject(function (TableService) {
+                var heading = {
+                    id: 'a',
+                    displayName: 'A',
+                };
+
+                var $scope = {};
+
+                assert.isTrue(TableService.getHeadingEnabled(heading, $scope));
+            }));
+        });
+
+        describe("the behavior when a property is defined",function(){
+
+            it("should return false if a condition is defined but not met",inject(function(TableService) {
+                var heading = {
+                    id:'a',
+                    displayName:'A',
+                    enabled:function($scope){
+                        return $scope.a === 'B';
+                    }
+                };
+
+                var $scope = {a:"A"};
+
+                assert.isFalse(TableService.getHeadingEnabled(heading,$scope));
+            }));
+
+            it("should return true if a condition is defined and is met",inject(function(TableService) {
+                var heading = {
+                    id:'a',
+                    displayName:'A',
+                    enabled:function($scope){
+                        return $scope.a === 'A';
+                    }
+                };
+
+                var $scope = {a:"A"};
+
+                assert.isTrue(TableService.getHeadingEnabled(heading,$scope));
+            }));
+
+            it("should return true if a condition is defined and is met",inject(function(TableService) {
+                var heading = {
+                    id:'a',
+                    displayName:'A',
+                    enabled:function($scope){
+                        return $scope.a === 'A';
+                    }
+                };
+
+                var $scope = {a:"A"};
+
+                assert.isTrue(TableService.getHeadingEnabled(heading,$scope));
+            }));
+
+            it("should throw an error if the enabled function throws an error",inject(function(TableService) {
+                var heading = {
+                    id:'a',
+                    displayName:'A',
+                    enabled:function($scope){
+                        return $scope.a === $scope.a.b.c;
+                    }
+                };
+
+                var $scope = {a:"A"};
+
+                expect(function(){
+                    TableService.getHeadingEnabled(heading,$scope);
+                }).to.throw()
+            }));
+
+        })
+    });
+
+    describe("getting the value of an entity in an array of tuples",function(){
+        it ("should return the right value when passed a valid array and ID",inject(function(TableService){
+            var tuples = [{
+                id:"a",
+                val:"A"
+            },{
+                id:"b",
+                val:"B"
+            }];
+
+            expect(TableService.getValueFromRow(tuples,'a')).to.equal('A');
+            expect(TableService.getValueFromRow(tuples,'b')).to.equal('B');
+        }));
+
+        it ("should return undefined if the tuple with that ID can't be found",inject(function(TableService){
+            var tuples = [{
+                id:"c",
+                val:"C"
+            },{
+                id:"d",
+                val:"D"
+            }];
+
+            expect(TableService.getValueFromRow(tuples,'a')).to.be.undefined();
+            expect(TableService.getValueFromRow(tuples,'b')).to.be.undefined();
+        }));
+
+    });
+
+    describe('extracting nested values from tuples using a string',function(){
+        it("should be the same as just finding a value if the string has no delimiters",inject(function(TableService){
+            var tuples = [{
+                id:"bin",
+                val:"baz"
+            }];
+
+            expect(TableService.delimitedStringToValue('bin',tuples)).to.be.equal('baz');
+        }))
+
+        it("should dig into the values to find the correct one if there is a delimited string",inject(function(TableService){
+            var tuples = [{
+                id:"bin",
+                val:"baz"
+            },{
+                id:"quo",
+                val:{
+                    foo:'bar'
+                }
+            },{
+                id:"nim",
+                val:{
+                    foo:{
+                        zab:"zoo"
+                    }
+                }
+            }];
+
+            expect(TableService.delimitedStringToValue('quo.foo',tuples)).to.be.equal('bar');
+            expect(TableService.delimitedStringToValue('nim.foo.zab',tuples)).to.be.equal('zoo');
+        }))
+
+        it("should accept a custom delimiter",inject(function(TableService){
+            var tuples = [{
+                id:"quo",
+                val:{
+                    foo:'bar'
+                }
+            }];
+
+            expect(TableService.delimitedStringToValue('quo!foo',tuples,'!')).to.be.equal('bar');
+        }))
+
+        it("should return undefined if the path defined is impossible",inject(function(TableService){
+            var tuples = [{
+                id:"quo",
+                val:{
+                    foo:{
+                        zab:"zoo"
+                    }
+                }
+            }];
+
+            expect(TableService.delimitedStringToValue('quo.zim.gir',tuples)).to.be.undefined;
+        }))
+    });
+
+    describe("templating the contents of a cell",function(){
+        // todo
+        //it ("should return the value of that cell if no template is defined",inject(function(TableService){
+        //    var heading = [{
+        //        id:"foo",
+        //        displayName:"FOO"
+        //    }];
+        //
+        //    expect(TableService.getTemplate(heading,{id:'foo',val:'bar'},[{id:'foo',val:'bar'}]).to.equal('bar'));
+        //}));
+    })
+
 
 });

--- a/app/scripts/projects/projects.table.model.ts
+++ b/app/scripts/projects/projects.table.model.ts
@@ -38,15 +38,8 @@ module ngApp.projects.models {
         },
         {
             displayName: "Participants",
-            id: "participants",
+            id: "summary.participant_count",
             enabled: true,
-            template: function (field, row) {
-                //debugger;
-                var summary:TableiciousEntryDefinition = _.find(row,function(x:TableiciousEntryDefinition){
-                    return x.id === 'summary';
-                });
-                return summary.val.participant_count
-            },
             sref: function (field:TableiciousEntryDefinition,row:TableiciousEntryDefinition[], scope, $filter: ng.IFilterService) {
 
                 var projectCode = _.find(row,function(elem){
@@ -165,14 +158,8 @@ module ngApp.projects.models {
                 }]
             }, {
                 displayName: "Files",
-                id: "data_file_count",
+                id: "summary.data_file_count",
                 enabled: true,
-                template: function (field, row) {
-                    var summary:TableiciousEntryDefinition = _.find(row,function(x:TableiciousEntryDefinition){
-                        return x.id === 'summary';
-                    });
-                    return summary.val.data_file_count
-                },
                 sref: function (field:TableiciousEntryDefinition,row:TableiciousEntryDefinition[], scope, $filter: ng.IFilterService) {
                     var projectCode = _.find(row,function(elem){
                         return elem.id === 'project_code';
@@ -191,13 +178,6 @@ module ngApp.projects.models {
                     });
                     return scope.$filter('size')(summary.val.file_size);
                 }
-            //}, {
-            //    displayName: "Last Update",
-            //    id: "last_updated",
-            //    enabled: true,
-            //    template: function (field) {
-            //        return field && field.val || 0;
-            //    }
             }
         ]
     };

--- a/app/scripts/search/search.files.table.model.ts
+++ b/app/scripts/search/search.files.table.model.ts
@@ -84,13 +84,8 @@ module ngApp.search.models {
             }
         }, {
             displayName: "Project",
-            id: "disease_code",
-                visible: true,
-            template:function(field:TableiciousEntryDefinition,row:TableiciousEntryDefinition[],scope){
-                var arch:TableiciousEntryDefinition = _.find(row,function(a:TableiciousEntryDefinition){return a.id === 'archive'});
-                var code:any = arch.val.disease_code;
-                return code;
-            },
+            id: "archive.disease_code",
+            visible: true,
             sref:function (field:TableiciousEntryDefinition,row:TableiciousEntryDefinition[],scope) {
 
                 var arch:TableiciousEntryDefinition = _.find(row,function(a:TableiciousEntryDefinition){return a.id === 'archive'});
@@ -117,14 +112,9 @@ module ngApp.search.models {
             }
         },{
             displayName: "Revision",
-            id: "revision",
-                visible: true,
-            template: function(field,row) {
-                var archive:TableiciousEntryDefinition = _.find(row,function(x:TableiciousEntryDefinition){
-                    return x.id === 'archive';
-                });
-                return archive.val.revision
-            }
+            id: "archive.revision",
+            visible: true,
+
         },{
             displayName: "Update date",
             id: "updated",

--- a/app/scripts/search/search.participants.table.model.ts
+++ b/app/scripts/search/search.participants.table.model.ts
@@ -53,15 +53,8 @@ module ngApp.search.models {
             }
         }, {
             displayName: "Disease Type",
-            id: "disease_type",
-            enabled: true,
-            template:function(elem:TableiciousEntryDefinition,row:TableiciousEntryDefinition[],scope){
-                var admin:TableiciousEntryDefinition = _.find(row,function(elem:TableiciousEntryDefinition){
-                    return elem.id === 'admin';
-                });
-
-                return admin && admin.val && admin.val.disease_code;
-            }
+            id: "admin.disease_code",
+            enabled: true
         }, {
             displayName: "Gender",
             id: "gender",


### PR DESCRIPTION
feat(table): nested field lookup
- allows automatic templating of nested fields by using dot notation in ID
- for example the data found in summary.participant_count can now be accessed through a heading with an id `summary.participant_count`
- updated all schema to use new way

Closes OICR-235.
