### PR TITLE
Feat/oicr 247 integrate sorting visibility reordering

### DIFF
--- a/app/scripts/annotations/annotations.controllers.ts
+++ b/app/scripts/annotations/annotations.controllers.ts
@@ -16,28 +16,6 @@ module ngApp.annotations.controllers {
 
   class AnnotationsController implements IAnnotationsController {
     annotations: IAnnotations;
-    sortColumns: any = [
-      {
-        key: "itemType",
-        name: "Item Type"
-      },
-      {
-        key: "annotationClassificationName",
-        name: "Classification"
-      },
-      {
-        key: "categoryName",
-        name: "Category"
-      },
-      {
-        key: "createdBy",
-        name: "Annotator"
-      },
-      {
-        key: "status",
-        name: "Status"
-      }
-    ];
 
 
     /* @ngInject */
@@ -50,6 +28,17 @@ module ngApp.annotations.controllers {
       });
 
       $scope.tableConfig = AnnotationsTableModel;
+      this.sortColumns = AnnotationsTableModel.headings.reduce(function(a,b){
+
+        if (b.sortable) {
+          a.push({
+            key:b.id,
+            name:b.displayName
+          })
+        }
+
+        return a;
+      },[]);
 
       this.refresh();
     }

--- a/app/scripts/annotations/annotations.table.model.ts
+++ b/app/scripts/annotations/annotations.table.model.ts
@@ -15,15 +15,18 @@ module ngApp.projects.models {
             id: "itemType",
             template: function (x) {
                 return x && x.val || "tbc";
-            }
+            },
+            sortable: true
         },
         {
             displayName: "Item Barcode",
             id: "item",
+            sortable: true
         },
         {
             displayName: "Classification",
             id: "annotationClassificationName",
+            sortable: true
         },
         {
             displayName: "Category",
@@ -40,6 +43,7 @@ module ngApp.projects.models {
         {
             displayName: "Status",
             id: "status",
+            sortable: true
         }
         ]
     }

--- a/app/scripts/components/tables/tableicious.directive.ts
+++ b/app/scripts/components/tables/tableicious.directive.ts
@@ -101,11 +101,7 @@ module ngApp.components.tables.directives.tableicious {
          */
         icon?(field:TableiciousEntryDefinition, row:TableiciousEntryDefinition[],scope:ITableicousScope) : string
 
-        /**
-         * If false, won't show up in the table. Will still show up in sorting.
-         * Use for the show / hide column directive.
-         */
-        visible? : boolean;
+
 
         /**
          * A class or space-delimited list of classes to be applied only to the heading of the column.
@@ -137,6 +133,30 @@ module ngApp.components.tables.directives.tableicious {
          * this will be compiled into a directive and inserted in the head of the column.
          */
         compileHead?(scope):string;
+
+        /**
+         * Does this heading show up in the sort/hide directive?
+         * Defaults to true if undefined;
+         */
+        canReorder?:boolean;
+
+        /**
+         * Determines if the header is hidden by default. If so, it will need to be unhidden in the menu to be displayed.
+         * Use for the show / hide column directive.
+         * Defaults to false if undefined;
+         */
+        hidden? : boolean;
+
+        /**
+         * Does this heading appear in the sort-ascending/descending plugin?
+         * Defaults to false if undefined;
+         */
+
+        sortable? : boolean;
+
+
+
+
     }
 
     class TableiciousController {

--- a/app/scripts/components/tables/tables.directives.ts
+++ b/app/scripts/components/tables/tables.directives.ts
@@ -21,8 +21,8 @@ module ngApp.components.tables.directives {
         function init() {
           scope.listMap = scope.list.map(function (elem) {
             var composite = _.pick(elem, "id", "displayName", "hidden", "sortable", "canReorder");
-            if (!composite.canReorder === false) {
-              composite.canReoder = true;
+            if (composite.canReorder !== false) {
+              composite.canReorder = true;
             }
             return composite;
           });

--- a/app/scripts/components/tables/templates/arrange-columns.html
+++ b/app/scripts/components/tables/templates/arrange-columns.html
@@ -8,6 +8,7 @@
     <ul dnd-list="listMap" class="dropdown-menu pull-right" role="menu">
         <li ng-repeat="item in listMap"
             ng-class="{'selected': models.selected === item}"
+            ng-if="item.canReorder"
             class="column-heading">
 
             <a dnd-draggable="item"

--- a/app/scripts/components/tables/templates/sort-table.html
+++ b/app/scripts/components/tables/templates/sort-table.html
@@ -3,7 +3,6 @@
     <span data-translate>Sort</span>
     <span class="caret"></span>
   </button>
-
   <ul class="dropdown-menu sort-menu pull-right" role="menu">
     <li data-ng-repeat="item in sortColumns">
       <div class="sort-item">

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -112,6 +112,28 @@ module ngApp.search.controllers {
       $scope.fileTableConfig = this.SearchTableFilesModel;
       $scope.participantTableConfig = this.SearchTableParticipantsModel;
 
+      this.fileSortColumns = SearchTableFilesModel.headings.reduce(function(a,b){
+        if (b.sortable) {
+          a.push({
+            key:b.id,
+            name:b.displayName
+          })
+        }
+        return a;
+      },[]);
+
+      this.participantSortColumns = SearchTableParticipantsModel.headings.reduce(function(a,b){
+
+        if (b.sortable) {
+          a.push({
+            key:b.id,
+            name:b.displayName
+          })
+        }
+
+        return a;
+      },[]);
+
 
       this.refresh();
 

--- a/app/scripts/search/search.files.table.model.ts
+++ b/app/scripts/search/search.files.table.model.ts
@@ -61,7 +61,8 @@ module ngApp.search.models {
             sref:function(field,row){
                 var uuid = _.find(row,function(a:TableiciousEntryDefinition){return a.id === 'file_uuid'});
                 return "file({ fileId: '"+uuid.val+"' })";
-            }
+            },
+                sortable: true
         },{
             displayName: "Participants",
             id: "participants",
@@ -93,15 +94,18 @@ module ngApp.search.models {
 
                 return "project({ 'projectId':'" + code + "'})";
 
-            }
+            },
+                sortable: true
         }, {
             displayName: "Data Type",
             id: "data_type",
-                visible: true
+                visible: true,
+                sortable: true
         }, {
             displayName: "Data Format",
             id: "data_format",
-                visible: true
+                visible: true,
+                sortable: true
         }, {
             displayName: "Size",
             id: "file_size",
@@ -109,7 +113,8 @@ module ngApp.search.models {
             template:function(field,row,scope){
                 //debugger;
                 return scope.$filter('size')(field.val);
-            }
+            },
+                sortable: true
         },{
             displayName: "Revision",
             id: "archive.revision",

--- a/app/scripts/search/search.participants.table.model.ts
+++ b/app/scripts/search/search.participants.table.model.ts
@@ -50,11 +50,13 @@ module ngApp.search.models {
                 });
 
                 return "participant({ participantId : '"+uuid.val+"' })";
-            }
+            },
+            sortable: true
         }, {
             displayName: "Disease Type",
             id: "admin.disease_code",
-            enabled: true
+            enabled: true,
+            sortable: true
         }, {
             displayName: "Gender",
             id: "gender",


### PR DESCRIPTION
feat(table): sort, visibility reorder
- add `hidden` property to table columns to set a default 
  hidden property on any column
- add `canReorder` property which if enabled hides 
  the field from 
  column reordering (good for `add_to_cart`, etc)
- add `sortable` property to heading which makes it 
  appear in `sort table`
- updated existing `sort table directives` to 
  use new method

Closes #247
