### PR TITLE
Show current filters even when no results

### DIFF
--- a/app/scripts/annotations/templates/annotations.html
+++ b/app/scripts/annotations/templates/annotations.html
@@ -27,11 +27,7 @@
 
     </div>
 
-    <h4 class="col-lg-9 col-md-8" data-ng-if="asc.annotations.hits.length === 0" data-translate>
-      No annotations found using those filters.
-    </h4>
-
-    <div class="col-lg-9 col-md-8" data-ng-if="asc.annotations.hits.length > 0">
+    <div class="col-lg-9 col-md-8">
       <div data-ng-if="!modelLoaded" class="app-loading table-loader">
         <i class="fa fa-spinner fa-spin fa-5x"></i>
       </div>
@@ -43,13 +39,18 @@
         <current-filters></current-filters>
       </div>
 
+      <h3 class="col-lg-9 col-md-8" data-ng-if="asc.annotations.hits.length === 0" data-translate>
+            No annotations found using those filters.
+      </h3>
+
       <gdc-table data-data="asc.annotations.hits"
                  data-config="tableConfig"
                  data-paging="asc.annotations.pagination"
                  data-page="annotations"
                  data-heading="Annotations ({{asc.annotations.pagination.total}})"
                  data-id="annotation-table"
-                 data-sort-columns="asc.sortColumns">
+                 data-sort-columns="asc.sortColumns"
+                 data-ng-if="asc.annotations.hits.length">
       </gdc-table>
 
     </div>

--- a/app/scripts/projects/templates/projects.html
+++ b/app/scripts/projects/templates/projects.html
@@ -27,11 +27,8 @@
     <h4 class="col-lg-9 col-md-8" data-ng-if="!prsc.projects">
       <i class="fa fa-spinner fa-spin"></i> Loading projects...
     </h4>
-    <h4 class="col-lg-9 col-md-8" data-ng-if="prsc.projects.hits.length === 0">
-      No projects found using those filters.
-    </h4>
 
-    <div class="col-lg-9 col-md-8" data-ng-if="prsc.projects.hits.length > 0">
+    <div class="col-lg-9 col-md-8">
       <div class="alert alert-info clearfix">
         <span data-ng-if="!cfc.currentFilters.length">
           <i class="fa fa-long-arrow-left"></i> Start searching by selecting a facet
@@ -39,11 +36,17 @@
         <current-filters></current-filters>
       </div>
 
+      <h3 class="col-lg-9 col-md-8" data-ng-if="prsc.projects.hits.length === 0">
+            No projects found using those filters.
+      </h3>
+
       <gdc-table data-data="prsc.projects.hits"
                  data-config="tableConfig"
                  data-heading="Projects ({{prsc.projects.pagination.total}})"
-                 data-id="project-table">
+                 data-id="project-table"
+                 data-ng-if="prsc.projects.hits.length">
       </gdc-table>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
For annotations and projects page. Already doing this on search page.

Closes #224
