### PR TITLE
fix(pagination): Fixes pagination total pages.

### DIFF
--- a/app/scripts/components/tables/templates/pagination.html
+++ b/app/scripts/components/tables/templates/pagination.html
@@ -45,7 +45,7 @@
   <pagination boundary-links="true"
               total-items="paging.total"
               data-ng-model="paging.page"
-              items-per-page="paging.count"
+              items-per-page="paging.size"
               class="pagination-sm pull-right"
               data-ng-change="pc.refresh()"
               num-pages="paging.pages"


### PR DESCRIPTION
- Pass expected size of results rather than count. This
  was causing the pagination directive to think more
  results could have been present still.

Closes #238
