### PR TITLE
feat(a11y): Use label elem for heading.

### DIFF
--- a/app/scripts/components/facets/templates/facets-free-text.html
+++ b/app/scripts/components/facets/templates/facets-free-text.html
@@ -1,15 +1,16 @@
 <div class="list-group-item">
-  <h4 class="list-group-item-heading facet-title"
+  <label class="list-group-item-heading h4 facet-title"
       data-ng-click="ftc.toggle($event, 'collapsed')"
       data-ng-keypress="ftc.toggle($event, 'collapsed')"
       aria-expanded="{{ !ftc.collapsed }}"
       aria-label="{{ facet.value | translate }} Facet Collapse Toggle"
-      role="button">
+      role="button"
+      for="{{ 'autocomplete-' + title }}">
     <i class="fa" data-ng-class="{ 'fa-angle-down': !ftc.collapsed, 'fa-angle-right': ftc.collapsed }"></i>
     {{ title | translate }}
-  </h4>
+  </label>
 
-  <p class="text-success" data-ng-repeat="active in ftc.actives">
+  <p class="text-success facet-title" data-ng-repeat="active in ftc.actives">
     <span data-ng-click="ftc.remove(active)"
           data-ng-keypress="ftc.remove(active)">
       <i class="fa fa-check-circle-o" aria-controls="data-table" aria-checked="true"></i>
@@ -17,15 +18,16 @@
     </span>
   </p>
 
-  <p class="input-group" data-ng-if="!ftc.collapsed">
+  <div class="input-group" data-ng-if="!ftc.collapsed">
     <input type="text" data-ng-model="ftc.searchTerm" placeholder="{{ placeholder }}"
            data-typeahead="id for id in ftc.autoComplete($viewValue) | limitTo: 10"
            data-typeahead-on-select="ftc.termSelected()"
            data-typeahead-min-length="2"
+           id="{{ 'autocomplete-' + title }}"
            typeahead-template-url="{{ template }}"
            class="form-control">
     <span class="input-group-addon">
       <span class="fa fa-search" data-ng-click="ftc.termSelected($event)"></span>
     </span>
-  </p>
+  </div>
 </div>


### PR DESCRIPTION
- Allows us to use built in a11y features for screen readers
  with use of 'for' attribute.
- Input will auto receive focus when expanding the facet.

Closes #282
