### PR TITLE
feat(app): Cancel Requests.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -47,8 +47,8 @@
 <a href="#skip" tabindex="1" class="skip-to-content" data-translate>Skip to Main Content</a>
 
 <div id="wrapper" aria-busy="true" aria-live="assertive" tabindex="0">
-  <div data-ng-if="!loaded" class="app-loading">
-    <i class="fa fa-spinner fa-spin fa-5x"></i>
+  <div data-ng-if="!loaded || !modelLoaded" class="app-loading">
+    <i class="fa fa-spinner fa-spin fa-5x" data-ng-click="cancelRequest()"></i>
   </div>
 
   <div id="header">

--- a/app/scripts/annotations/templates/annotations.html
+++ b/app/scripts/annotations/templates/annotations.html
@@ -28,9 +28,6 @@
     </div>
 
     <div class="col-lg-9 col-md-8">
-      <div data-ng-if="!modelLoaded" class="app-loading table-loader">
-        <i class="fa fa-spinner fa-spin fa-5x"></i>
-      </div>
 
       <div class="alert alert-info clearfix">
         <span data-ng-if="!cfc.currentFilters.length">

--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -18,6 +18,7 @@ declare module ngApp {
     modelLoaded: boolean;
     config: IGDCConfig;
     undoClicked(action: string): void;
+    cancelRequest(): void;
   }
 }
 
@@ -46,8 +47,6 @@ function appRun(gettextCatalog: any, Restangular: restangular.IProvider,
                 $cookieStore: ng.cookies.ICookieStoreService,
                 UserService: IUserService) {
   gettextCatalog.debug = true;
-
-  //debugger;
 
   $rootScope.config = config;
   Restangular.setErrorInterceptor((response) => {

--- a/app/scripts/components/location/location.services.ts
+++ b/app/scripts/components/location/location.services.ts
@@ -19,6 +19,7 @@ module ngApp.components.location.services {
     pagination(): any;
     setPaging(pagination: any): ng.ILocationService;
     setHref(href: string): void;
+    getHref(href: string): string;
   }
 
   class LocationService implements ILocationService {
@@ -108,6 +109,10 @@ module ngApp.components.location.services {
 
     setHref(href: string): void {
       this.$window.location.href = href;
+    }
+
+    getHref(href: string): string {
+      return this.$window.location.href;
     }
 
   }

--- a/app/scripts/components/tables/templates/export-modal.html
+++ b/app/scripts/components/tables/templates/export-modal.html
@@ -1,0 +1,8 @@
+<div class="modal-body">
+  <h4>Generating File ...</h4>
+</div>
+<div class="modal-footer">
+  <button class="btn btn-warning" ng-click="etmc.cancel()" data-translate>
+    Cancel the Download
+  </button>
+</div>

--- a/app/scripts/core/core.controller.ts
+++ b/app/scripts/core/core.controller.ts
@@ -24,7 +24,11 @@ module ngApp.core.controllers {
 
       this.$rootScope.undoClicked = (action: string): void => {
         this.$rootScope.$broadcast("undo", action);
-      }
+      };
+
+      this.$rootScope.cancelRequest = (): void => {
+        this.$rootScope.$broadcast("gdc-cancel-request");
+      };
 
     }
 

--- a/app/scripts/participant/participants.services.ts
+++ b/app/scripts/participant/participants.services.ts
@@ -4,6 +4,7 @@ module ngApp.participants.services {
   import IParticipant = ngApp.participants.models.IParticipant;
   import ILocationService = ngApp.components.location.services.ILocationService;
   import IUserService = ngApp.components.user.services.IUserService;
+  import IRootScope = ngApp.IRootScope;
 
   export interface IParticipantsService {
     getParticipant(id: string, params: Object): ng.IPromise<IParticipant>;
@@ -15,7 +16,8 @@ module ngApp.participants.services {
 
     /* @ngInject */
     constructor(Restangular: restangular.IService, private LocationService: ILocationService,
-                private UserService: IUserService, private CoreService: ICoreService) {
+                private UserService: IUserService, private CoreService: ICoreService,
+                private $rootScope: IRootScope, private $q: ng.IQService) {
       this.ds = Restangular.all("participants");
     }
 
@@ -56,10 +58,22 @@ module ngApp.participants.services {
       defaults.filters = this.UserService.addMyProjectsFilter(defaults.filters, "participants.admin.disease_code");
       this.CoreService.setSearchModelState(false);
 
-      return this.ds.get("", angular.extend(defaults, params)).then((response): IParticipants => {
+      var abort = this.$q.defer();
+      var prom: ng.IPromise<IParticipants> = this.ds.withHttpConfig({
+        timeout: abort.promise
+      })
+      .get("", angular.extend(defaults, params)).then((response): IParticipants => {
         this.CoreService.setSearchModelState(true);
         return response["data"];
       });
+
+      var eventCancel = this.$rootScope.$on("gdc-cancel-request", () => {
+        abort.resolve();
+        eventCancel();
+        this.CoreService.setSearchModelState(true);
+      });
+
+      return prom;
     }
   }
 

--- a/app/scripts/query/templates/query.html
+++ b/app/scripts/query/templates/query.html
@@ -1,9 +1,6 @@
 <div class="container-fluid full-page">
   <div class="row search-panel">
     <div class="col-lg-12">
-      <div data-ng-if="!modelLoaded" class="app-loading table-loader">
-        <i class="fa fa-spinner fa-spin fa-5x"></i>
-      </div>
 
       <search-bar></search-bar>
 

--- a/app/scripts/search/templates/search.html
+++ b/app/scripts/search/templates/search.html
@@ -13,9 +13,6 @@
       </tabset>
     </div>
     <div class="col-lg-9 col-md-8">
-      <div data-ng-if="!modelLoaded" class="app-loading table-loader">
-        <i class="fa fa-spinner fa-spin fa-5x"></i>
-      </div>
 
       <div class="alert alert-info clearfix">
         <div class="col-lg-10 col-md-10">

--- a/app/styles/utils.less
+++ b/app/styles/utils.less
@@ -64,6 +64,7 @@
     vertical-align: bottom;
     height: 100px;
     width: 100px;
+    cursor: pointer;
   }
 
   &.ng-enter,


### PR DESCRIPTION
- Adds tricky mechanism to cancel request by clicking on
  loading spinner. If this occurs before it completes
  any previous data that existed will be used instead.
- Reverts logic on tableicious handling turning off
  loading spinner to prevent complications.

Closes #277
