### PR TITLE
chore(facets): Fix terms displayed.

### DIFF
--- a/app/scripts/components/facets/templates/facet.html
+++ b/app/scripts/components/facets/templates/facet.html
@@ -15,7 +15,7 @@
             data-ng-keypress="add(tc.name, term.key, $event)"
             class="facet-term-label">
         <i class="fa fa-square-o" aria-controls="data-table" aria-checked="false"></i>
-        {{ ::term.key | translate | humanify }}
+        {{ ::term.key | translate | humanify: true:true }}
       </span>
       <span class="label label-primary pull-right">{{ term.doc_count | number:0}}</span>
     </p>

--- a/app/scripts/components/ui/string/string.filters.ts
+++ b/app/scripts/components/ui/string/string.filters.ts
@@ -14,7 +14,7 @@ module ngApp.components.ui.string {
 
   class Humanify {
     constructor() {
-      return function (original: string, capitalize: boolean = true) {
+      return function (original: string, capitalize: boolean = true, facetTerm: boolean = false) {
         if (!angular.isDefined(original) || (angular.isString(original) && !original.length)) {
           return '--';
         }
@@ -22,13 +22,27 @@ module ngApp.components.ui.string {
           return original;
         }
 
-        var split = original.split(".");
-        var humanified = split[split.length - 1].replace(/_/g, " ").trim();
-        var words, cWords = [];
+        var split;
+        var humanified;
+
+        if (facetTerm) {
+          humanified = original.replace(/\./g, " ").trim();
+        } else {
+          split = original.split(".");
+          humanified = split[split.length - 1].replace(/_/g, " ").trim();
+        }
+
+        var words = humanified.split(' '),
+            cWords = [];
+
         if (capitalize) {
-          words = humanified.split(' ');
           words.forEach(function (word) {
-            cWords.push(word.charAt(0).toUpperCase() + word.slice(1));
+            // Specialcase miRNA instances
+            if (word.indexOf("miRNA") === -1) {
+              cWords.push(word.charAt(0).toUpperCase() + word.slice(1));
+            } else {
+              cWords.push(word);
+            }
           });
           humanified = cWords.join(' ');
         }

--- a/app/scripts/components/ui/string/tests/humanifyfilter.tests.js
+++ b/app/scripts/components/ui/string/tests/humanifyfilter.tests.js
@@ -1,34 +1,40 @@
 describe("Humanify Filter:", function() {
-// Initialization of the AngularJS application before each test case
-beforeEach(module("ngApp.components"));
+  // Initialization of the AngularJS application before each test case
+  beforeEach(module("ngApp.components"));
 
-var sampleString = "file.archive.archive_uuid";
-var startsWith_ = "_missing";
+  var sampleString = "file.archive.archive_uuid";
+  var startsWith_ = "_missing";
 
-it("should have a humanify filter", inject(function ($filter) {
-  expect($filter("humanify")).not.to.be.null;
-}));
+  it("should have a humanify filter", inject(function ($filter) {
+    expect($filter("humanify")).not.to.be.null;
+  }));
 
-it("should split on . ", inject(function ($filter) {
-  var humanified = $filter("humanify")(sampleString);
-  expect(humanified).to.not.contain(".");
-}));
+  it("should split on . ", inject(function ($filter) {
+    var humanified = $filter("humanify")(sampleString);
+    expect(humanified).to.not.contain(".");
+  }));
 
-it("should replace _ with spaces", inject(function ($filter) {
-  var humanified = $filter("humanify")(sampleString);
-  expect(humanified).to.not.contain("_");
-}));
+  it("should replace _ with spaces", inject(function ($filter) {
+    var humanified = $filter("humanify")(sampleString);
+    expect(humanified).to.not.contain("_");
+  }));
 
-it("should remove _ if it is the first character", inject(function($filter) {
-  var humanified2 = $filter("humanify")(startsWith_);
-  expect(humanified2).to.not.contain("_");
-  expect(humanified2[0]).to.not.equal(" ");
-}));
+  it("should remove _ if it is the first character", inject(function($filter) {
+    var humanified2 = $filter("humanify")(startsWith_);
+    expect(humanified2).to.not.contain("_");
+    expect(humanified2[0]).to.not.equal(" ");
+  }));
 
-it("capitalize the first letter", inject(function ($filter) {
-  var humanified = $filter("humanify")(sampleString);
-  var split = sampleString.split(".");
-  expect(humanified[0]).to.equal(split[split.length-1].charAt(0).toUpperCase());
-}));
+  it("capitalize the first letter", inject(function ($filter) {
+    var humanified = $filter("humanify")(sampleString);
+    var split = sampleString.split(".");
+    expect(humanified[0]).to.equal(split[split.length-1].charAt(0).toUpperCase());
+  }));
+
+  it("should not split when dealing with facets", inject(function ($filter) {
+    var humanified = $filter("humanify")(sampleString, true, true);
+    var split = sampleString.replace(/\./, " ").trim();
+    expect(humanified).to.equal("File Archive Archive_uuid");
+  }));
 
 });


### PR DESCRIPTION
- Humanified filter wasn't flexible enough for our facets.
  It assumed it was getting in strings that the desired value
  was after a '.' (I.E. a nested value). With facet terms we
  were passing that value directly causing part of terms not
  to be displayed.

Closes #374
