### PR TITLE
fix(githut): change project order

### DIFF
--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -197,15 +197,15 @@ function githutTable(data,config){
          dimensional:true,
         colorgroup:'file_count'
     },{
-        id:'Other',
-        display_name:['Other'],
+        id:'DNA methylation',
+        display_name:['Meth'],
         scale:'ordinal',
         is_subtype:true,
          dimensional:true,
         colorgroup:'file_count'
     },{
-        id:'DNA methylation',
-        display_name:['Meth'],
+        id:'Other',
+        display_name:['Other'],
         scale:'ordinal',
         is_subtype:true,
          dimensional:true,
@@ -229,6 +229,7 @@ function githutTable(data,config){
          dimensional:true
     }
   ];
+  
       
   var aggregations = d3.keys(project_ids).reduce(function(a,key){
     var group = project_ids[key];

--- a/app/scripts/reports/reports.controllers.ts
+++ b/app/scripts/reports/reports.controllers.ts
@@ -170,18 +170,26 @@ module ngApp.reports.controllers {
             scale:'linear',
             dimensional:true
           }];
+        
+        var order = ["Clinical", "Raw microarray data", "Raw sequencing data", "Simple nucleotide variation", "Copy number variation", "Structural rearrangement", "Gene expression", "Protein expression", "DNA methylation", "Other"];
 
         var data_types = dummymap.reduce(function(a,b){return a.concat(b.data_types)},[])
         var nest = d3.nest().key(function(a){return a.data_type}).entries(data_types);
-
-        nest.forEach(function(a){
-          columns.splice(2,0,{
+        
+        var types = nest.map(function(a){
+          return {
             id:a.key,
             display_name:[a.key],
             colorgroup:'file_count',
             scale:'ordinal',
             dimensional:true
-          });
+          };
+        });
+        
+        types = types.sort(function(a,b){return order.indexOf(a) - order.indexOf(b)});
+
+        types.forEach(function(a){
+          columns.splice(2,0,a);
         });
 
 


### PR DESCRIPTION
fix(githut): change project order
- move "Other" to end of Githut graph
- automatically orders `Report` graph based on predefs

Closes 509
