### PR TITLE
feat(githut): tooltips for primary site

### DIFF
--- a/app/scripts/projects/projects.githut.config.ts
+++ b/app/scripts/projects/projects.githut.config.ts
@@ -279,13 +279,6 @@ angular.module('projects.githut.config',[])
        */
       dimensions:columns.filter(function(c){return c.dimensional}).map(function(c){return c.id}),
 
-      /**
-       *  Name for each column.
-       **/
-      column_map:columns.reduce(function(a,b){
-         a[b.id] = b.display_name || ['Untitled'];
-         return a;
-      },{}),
       urlMap:columns.reduce(function(a,b){
         a[b.id] = b.href;
         return a;

--- a/app/scripts/reports/reports.githut.config.ts
+++ b/app/scripts/reports/reports.githut.config.ts
@@ -14,7 +14,7 @@ angular.module("reports.githut.config",[])
       if (!_.contains(primary_sites, b.primary_site)) {
         primary_sites.push(b.primary_site);
       }
-      
+
       if (a[b.project_id]) {
         var c = a[b.project_id];
         c.file_size += b.size_in_mb;
@@ -43,7 +43,7 @@ angular.module("reports.githut.config",[])
 
     var data_types = data.reduce(function(a,b){return a.concat(b.data_types)}, []);
     var nest = d3.nest().key(function(a){return a.data_type}).entries(data_types);
-    
+
     var types = nest.map(function(a){
       return {
         id: a.key,
@@ -53,7 +53,7 @@ angular.module("reports.githut.config",[])
         dimensional: true
       };
     });
-    
+
     types = types.sort(function(a,b){return order.indexOf(a) - order.indexOf(b)});
 
     types.forEach(function(a) {
@@ -65,23 +65,23 @@ angular.module("reports.githut.config",[])
       start: types[types.length - 1].id,
       text: "File count per data type"
     };
-   
+
     ReportsGithutConfig.columns = columns.map(function(c){return c.id});
     ReportsGithutConfig.scale_map = columns.reduce(function(a, b) {
       a[b.id] = b.scale || "ordinal";
       return a;
     },{});
-      
+
     ReportsGithutConfig.color_group_map = columns.reduce(function(a,b){
       a[b.id] = b.colorgroup;
       return a;
     },{});
-      
+
     ReportsGithutConfig.column_map = columns.reduce(function(a,b){
       a[b.id] = b.display_name || ["Untitled"];
       return a;
     },{});
-      
+
     ReportsGithutConfig.dimensions = columns.filter(function(c){return c.dimensional}).map(function(c){return c.id});
 
     return {
@@ -141,7 +141,7 @@ angular.module("reports.githut.config",[])
     },
     formats:{
       "primary_site":"d"
-    },  
+    },
     color_group_map:undefined,
     color_groups:{
       "file_count":color(0),
@@ -149,7 +149,6 @@ angular.module("reports.githut.config",[])
       "participant_count":color(2)
     },
     dimensions:undefined,
-    column_map:undefined,
     duration:1000,
     filters:{
       file_size: $filter("size")

--- a/app/styles/tooltip.less
+++ b/app/styles/tooltip.less
@@ -18,6 +18,35 @@
     display: none;
   }
 
+  /* d3-tip Northward tooltips */
+  &.n:after, &.n:before {
+    box-sizing: border-box;
+    display: inline;
+    font-size: 10px;
+    width: 100%;
+    line-height: 1;
+    color: #fff;
+    position: absolute;
+    pointer-events: none;
+  }
+
+  &.n:after {
+    content: "\25BC";
+    margin: -7px 0 0 0;
+    top: 100%;
+    left: 0;
+    text-align: center;
+  }
+
+  &.n:before {
+    content: "\25BC";
+    margin: -7px -2px 1px 0;
+    top: 100%;
+    left: 0;
+    color: #b3b3b3;
+    text-align: center;
+  }
+
   &:after, &:before {
     border: solid transparent;
     content: " ";


### PR DESCRIPTION
![screen shot 2015-03-30 at 6 26 04 pm](https://cloud.githubusercontent.com/assets/1314446/6908448/18fec6c2-d70b-11e4-8388-f3604065d01b.png)
this is probably not good enough, used the #tooltip style that came with githut. Better to use the d3-tip plugin that's already included in the project?
