### PR TITLE
feat(auth): Implement proper logout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ It is important that this keeps in sync with the host the API is set to. Changin
 
 #### Modifying /etc/hosts
 In order to support local use of the login system we need to add the following
-to your `/etc/hosts` file.
+to your `/etc/hosts` file:
 
 `127.0.0.1 portal.gdc.nci.nih.gov`
+`192.170.230.212 gdc.nci.nih.gov`
 
 ### ElasticSearch
 Edit path-to-elastic-search/config/elasticsearch.yml, find the line with http.max_content_length, add

--- a/app/scripts/components/header/header.controller.ts
+++ b/app/scripts/components/header/header.controller.ts
@@ -13,14 +13,11 @@ module ngApp.components.header.controllers {
     addedLanguages: boolean;
     setLanguage(): void;
     getNumCartItems(): number;
-    logout(): void;
-    loginQuery: string;
   }
 
   class HeaderController implements IHeaderController {
     isCollapsed: boolean = true;
     currentLang: string = "en";
-    loginQuery: string = "";
     addedLanguages: boolean = false;
     languages: any = {
       "en": "English",
@@ -34,17 +31,6 @@ module ngApp.components.header.controllers {
                 private UserService: IUserService, private $modal: any,
                 private $window: ng.IWindowService) {
       this.addedLanguages = !!_.keys(gettextCatalog.strings).length;
-
-      if ($window.location.port) {
-        this.loginQuery = "?next=:" + $window.location.port;
-      } else {
-        this.loginQuery = "?next=/";
-      }
-    }
-
-    logout(): void {
-      this.UserService.logout();
-      this.$window.location.reload();
     }
 
     getToken(): void {

--- a/app/scripts/components/header/templates/header.html
+++ b/app/scripts/components/header/templates/header.html
@@ -33,7 +33,7 @@
           </select>
         </li>
         <li data-ng-if="!hc.UserService.currentUser">
-          <a login-button>
+          <a auth-button data-redirect="https://gdc.nci.nih.gov">
             <i class="fa fa-sign-in"></i>
             <span data-translate>Login</span>
           </a>
@@ -60,7 +60,7 @@
                   </a>
                 </li>
                 <li>
-                  <a data-ng-click="hc.logout()">
+                  <a auth-button data-redirect="https://gdc.nci.nih.gov/logout">
                     <i class="fa fa-sign-out"></i>
                     <span data-translate>Logout</span>
                   </a>

--- a/app/scripts/components/user/user.services.ts
+++ b/app/scripts/components/user/user.services.ts
@@ -6,7 +6,6 @@ module ngApp.components.user.services {
 
   export interface IUserService {
     login(): void;
-    logout(): void;
     setUser(user: IUser): void;
     toggleFilter(): void;
     addMyProjectsFilter(filters: any, key: string): any;
@@ -73,16 +72,6 @@ module ngApp.components.user.services {
     setUser(user: IUser): void {
       this.currentUser = user;
       this.$rootScope.$broadcast("gdc-user-reset");
-    }
-
-    logout(): void {
-      // Angular's $cookies/$cookieStore services abstract away the ability to set
-      // the expiration time. Manual manipulation seems to be required.
-      // See: http://stackoverflow.com/questions/12624181/angularjs-how-to-set-expiration-date-for-cookie-in-angularjs
-      this.$window.document.cookie = "X-Auth-Token= ;expires=" + new Date().toGMTString() +
-                                     ";domain=.nci.nih.gov;path= /";
-      this.$window.document.cookie = "X-Auth-Username= ;expires=" + new Date().toGMTString() +
-                                     ";domain=.nci.nih.gov;path= /";
     }
 
     toggleFilter(): void {

--- a/app/scripts/core/core.controller.ts
+++ b/app/scripts/core/core.controller.ts
@@ -1,6 +1,7 @@
 module ngApp.core.controllers {
   import ICartService = ngApp.cart.services.ICartService;
   import INotifyService = ng.cgNotify.INotifyService;
+  import IUserService = ngApp.components.user.services.IUserService;
 
   export interface ICoreController {
     showWarning: boolean;
@@ -73,27 +74,29 @@ module ngApp.core.controllers {
   }
 
   angular
-      .module("core.controller", ["ngCookies"])
+      .module("core.controller", ["ngCookies", "user.services"])
       .controller("WarningController", WarningController)
-      .directive('loginButton',function(){
+      .directive('authButton', function(){
         return {
           restrict:'A',
+          scope: {
+            redirect: "@"
+          },
           controller:function($scope,$element,$window){
             $element.on('click',function(){
-              var loginQuery;
+              var authQuery;
 
               if ($window.location.port) {
-                loginQuery = "?next=" + ":" + $window.location.port + $window.location.pathname;
+                authQuery = "?next=" + ":" + $window.location.port + $window.location.pathname;
               } else {
-                loginQuery = "?next=" + $window.location.pathname;
+                authQuery = "?next=" + $window.location.pathname;
               }
 
-              $window.location = 'https://gdc.nci.nih.gov' + loginQuery;
+              $window.location = $scope.redirect + authQuery;
 
             });
           }
         }
-
       })
       .controller("CoreController", CoreController);
 }


### PR DESCRIPTION
- Uses logout redirect to properly logout of eRA commons.

Note: Until a similar `?next` query param is supported like login this won't 100% work but the plumbing is there. I've made note to @philloooo that we will need something similar since the logout redirect assumes port 80 currently.
