### PR TITLE
feat(auth): Pass any search params on login/logout

### DIFF
--- a/app/scripts/core/core.controller.ts
+++ b/app/scripts/core/core.controller.ts
@@ -2,6 +2,7 @@ module ngApp.core.controllers {
   import ICartService = ngApp.cart.services.ICartService;
   import INotifyService = ng.cgNotify.INotifyService;
   import IUserService = ngApp.components.user.services.IUserService;
+  import ILocationService = ngApp.components.location.services.ILocationService;
 
   export interface ICoreController {
     showWarning: boolean;
@@ -74,15 +75,15 @@ module ngApp.core.controllers {
   }
 
   angular
-      .module("core.controller", ["ngCookies", "user.services"])
+      .module("core.controller", ["ngCookies", "user.services", "location.services"])
       .controller("WarningController", WarningController)
-      .directive('authButton', function(){
+      .directive('authButton', function(LocationService: ILocationService, $window: ng.IWindowService){
         return {
           restrict:'A',
           scope: {
             redirect: "@"
           },
-          controller:function($scope,$element,$window){
+          controller:function($scope,$element){
             $element.on('click',function(){
               var authQuery;
 
@@ -92,8 +93,22 @@ module ngApp.core.controllers {
                 authQuery = "?next=" + $window.location.pathname;
               }
 
-              $window.location = $scope.redirect + authQuery;
+              if (!_.isEmpty(LocationService.search())) {
+                authQuery += "?";
+                _.each(LocationService.search(), (v, k) => {
+                  authQuery += k + "=";
 
+                  if (_.isObject(angular.fromJson(v))) {
+                    authQuery += $window.encodeURIComponent(v);
+                  } else {
+                    authQuery += v;
+                  }
+
+                  authQuery += "&";
+                });
+              }
+
+              $window.location = $scope.redirect + authQuery;
             });
           }
         }


### PR DESCRIPTION
@philloooo I think there is some double escaping going in with your end of the login. How do you handle the `next` param that we send in? Should we just instead have a list of known/accepted params to pass rather than be tacking it all on like that? As it stands right now it looks like we wind up getting double escaping going on.
