### PR TITLE
Feat/705 persist tbl config

### DIFF
--- a/app/scripts/annotations/annotations.table.model.ts
+++ b/app/scripts/annotations/annotations.table.model.ts
@@ -3,7 +3,7 @@ module ngApp.projects.models {
 
     var AnnotationsTableModel:TableiciousConfig = {
         title: "Annotations",
-        order: ['annotation_id', 'participant_id', 'project.program.name', 'project.project_id', 'entity_id', 'entity_type', 'category', 'classification', 'dateCreated', 'creator', 'status', 'entity_submitter_id'],
+        order: ['annotation_id', 'participant_id', 'project.program.name', 'project.project_id', 'entity_type', 'entity_id', 'entity_submitter_id', 'category', 'classification', 'created_datetime', 'creator', 'status'],
         headings: [{
             displayName: "ID",
             id: "annotation_id",

--- a/app/scripts/cart/cart.table.model.ts
+++ b/app/scripts/cart/cart.table.model.ts
@@ -13,6 +13,7 @@ module ngApp.cart.models {
 
   var CartTableModel: TableiciousConfig = {
     title: 'Cart',
+    order: ['select_file', 'download', 'my_projects', 'download', 'my_projects', 'access', 'file_name', 'participantId', 'projects', 'data_type', 'data_format', 'file_size', 'annotationIds'],
     headings: [
       {
         displayName: "select_file",

--- a/app/scripts/components/tables/tables.directives.ts
+++ b/app/scripts/components/tables/tables.directives.ts
@@ -1,5 +1,7 @@
 module ngApp.components.tables.directives {
 
+  import IGDCWindowService = ngApp.models.IGDCWindowService;
+
   interface ITableDirectiveScope extends ng.IScope {
      filtersRevealed:boolean;
   }
@@ -16,57 +18,8 @@ module ngApp.components.tables.directives {
       },
       replace: true,
       templateUrl: "components/tables/templates/arrange-columns.html",
-      link:function(scope:any){
-
-        function init() {
-          scope.listMap = scope.list.map(function (elem) {
-            var composite = _.pick(elem, "id", "displayName", "hidden", "sortable", "canReorder");
-            if (composite.canReorder !== false) {
-              composite.canReorder = true;
-            }
-            return composite;
-          });
-        }
-
-        init();
-
-        scope.onMoved = function($index){
-          scope.listMap.splice($index,1);
-          scope.list = scope.listMap.map(function(elem){
-            return _.find(scope.list,function(li){
-              return li.id === elem.id;
-            });
-          });
-
-          scope.list.pristine = false;
-        };
-
-        scope.$watch('listMap',function(newval){
-          if (newval) {
-
-            scope.listMap.forEach(function (listElem) {
-              var matchingHeader = _.find(scope.list, function (li) {
-                return li.id === listElem.id;
-              });
-              matchingHeader.hidden = listElem.hidden;
-
-              if (matchingHeader.children) {
-                matchingHeader.children.forEach(function(childHeader) {
-                  childHeader.hidden = listElem.hidden;
-                });
-              }
-            });
-          }
-        },true);
-
-
-        scope.$watch(function(){
-          return scope.list && scope.list.pristine;
-        },function(pristine){
-          if (pristine) {
-            init();
-          }
-        });
+      controller: "ArrangeColumnsController as acc",
+      link:function(scope:any, window: IGDCWindowService) {
       }
     };
   }
@@ -121,36 +74,6 @@ module ngApp.components.tables.directives {
     }
   }
 
-  function ResetTable($log: ng.ILogService): ng.IDirective {
-    return {
-      restrict: "EA",
-      scope: {
-        target:"=",
-        config:'='
-      },
-      replace:true,
-      templateUrl: "components/tables/templates/reset-table.html",
-      controller: function($scope,$element){
-        var config = $scope.config;
-        var originalOrder = _.pluck(config.headings,'id');
-        $log.log("Reset table init...");
-        $scope.reset = function(){
-          $log.log("Reset...",config);
-
-          config.headings = originalOrder.map(function(id){
-            var heading = _.find(config.headings,function(head){return head.id === id});
-            if (heading) {
-              heading.hidden = false;
-              return heading;
-            }
-          });
-
-          config.headings.pristine = true;
-        };
-      }
-    }
-  }
-
   function EntityPageCountsTable(): ng.IDirective {
     return {
       restrict: "EA",
@@ -198,7 +121,6 @@ module ngApp.components.tables.directives {
   angular.module("tables.directives", ["tables.controllers"])
       .directive("exportTable", ExportTable)
       .directive("sortTable", SortTable)
-      .directive("resetTable", ResetTable)
       .directive("gdcTable", GDCTable)
       .directive("arrangeColumns", ArrangeColumns)
       .directive("entityPageCountsTable", EntityPageCountsTable);

--- a/app/scripts/components/tables/templates/arrange-columns.html
+++ b/app/scripts/components/tables/templates/arrange-columns.html
@@ -6,7 +6,6 @@
     </button>
 
     <ul  class="dropdown-menu pull-right" role="menu" >
-      
       <li class="column-heading">
         <div class="input-group input-group-sm">
           <span class="input-group-addon" id="sizing-addon3">
@@ -17,10 +16,11 @@
                  data-ng-model="search.displayName" />
         </div>
         </li>
-        <li class="column-heading"><a>
-            <reset-table target="list" config="config"></reset-table>
-        </a></li>
-       
+        <li class="column-heading">
+          <a data-ng-click="acc.reset()" class="reset-table-span" data-translate>
+            Restore Defaults
+          </a>
+      </li>
        <li>
          <ul dnd-list="listMap" class="column-dnd-list">
 
@@ -31,7 +31,7 @@
               style="padding-left: 10px">
 
               <a dnd-draggable="item"
-                 dnd-moved="onMoved($index)"
+                 dnd-moved="acc.onMoved($index)"
                  effect-allowed="move"
                  dnd-disable-if="search.displayName.length > 0"
                  data-ng-if="true"
@@ -39,15 +39,11 @@
                  dnd-selected="models.selected = item">
                   <i class="fa fa-bars fa-stack fa-lg" data-ng-class="{ 'fa-disabled': search.displayName }"></i>
                   {{ item.displayName | humanify | ellipsicate:18 }}
-                  <i class="fa fa-stack fa-{{item.hidden ? 'eye-slash' : 'eye'}} fa-lg hide-icon" ng-click="item.hidden = !item.hidden"></i>
+                  <i class="fa fa-stack fa-{{item.hidden ? 'eye-slash' : 'eye'}} fa-lg hide-icon" data-ng-click="acc.toggleVisibility($index)"></i>
               </a>
 
           </li>
          </ul>
        </li>
-
-<!--        <li class="divider"></li>-->
-         
-
     </ul>
 </div>

--- a/app/scripts/components/tables/templates/reset-table.html
+++ b/app/scripts/components/tables/templates/reset-table.html
@@ -1,5 +1,0 @@
-<!--<button class="btn btn-default" data-ng-click="reset()"><i class="fa fa-lg fa-minus-circle"></i>&nbsp;-->
-<span data-ng-click="reset()" class="reset-table-span" data-translate>
-    Restore Defaults
-</span>
-<!--</button>-->

--- a/app/scripts/components/tables/tests/table.sort.tests.js
+++ b/app/scripts/components/tables/tests/table.sort.tests.js
@@ -11,6 +11,7 @@ describe('Tables:', function () {
         sort: "file_size:asc,file_name:desc"
       };
       scope.config = {
+        title: 'test',
         headings:[{
           name: 'File Size',
           id:'file_size',
@@ -24,10 +25,12 @@ describe('Tables:', function () {
       };
 
       var wc = $controller('TableSortController', { $scope: scope, LocationService: LocationService });
-      expect(wc.$scope.sortColumns[0].sort).to.equal(true);
-      expect(wc.$scope.sortColumns[1].sort).to.equal(true);
-      expect(wc.$scope.sortColumns[0].order).to.equal("asc");
-      expect(wc.$scope.sortColumns[1].order).to.equal("desc");
+      var fileSizeSort = _.find(wc.$scope.sortColumns, function(col) { return col.key === 'file_size'; });
+      var fileNameSort = _.find(wc.$scope.sortColumns, function(col) { return col.key === 'file_name'; });
+      expect(fileSizeSort.sort).to.equal(true);
+      expect(fileNameSort.sort).to.equal(true);
+      expect(fileSizeSort.order).to.equal("asc");
+      expect(fileNameSort.order).to.equal("desc");
     }));
 
     it('should update sorting', inject(function ($rootScope, $controller, LocationService) {
@@ -35,6 +38,7 @@ describe('Tables:', function () {
       scope.paging = {};
       scope.page = "test";
       scope.config = {
+        title: "test",
         headings:[
           {
             name: 'File Size',
@@ -54,8 +58,7 @@ describe('Tables:', function () {
       wc.toggleSorting(wc.$scope.sortColumns[1]);
 
       var paging = LocationService.pagination()[wc.$scope.page];
-
-      expect(paging.sort).to.equal("file_size:asc,file_name:asc");
+      expect(paging.sort).to.equal("file_name:asc");
     }));
 
   });

--- a/app/scripts/projects/projects.table.model.ts
+++ b/app/scripts/projects/projects.table.model.ts
@@ -31,7 +31,7 @@ module ngApp.projects.models {
 
   var projectTableModel: TableiciousConfig = {
     title: 'Projects',
-    order: ['project_id', 'primary_site', 'program', 'participants', 'disease_type', 'file_size', 'files', 'last_update'],
+    order: ['project_id', 'disease_type', 'primary_site', 'program.name', 'summary.participant_count', 'data_types', 'summary.file_count', 'file_size'],
     headings: [
       {
         displayName: "ID",

--- a/app/scripts/search/search.files.table.model.ts
+++ b/app/scripts/search/search.files.table.model.ts
@@ -30,7 +30,7 @@ module ngApp.search.models {
 
   var searchTableFilesModel: TableiciousConfig = {
     title: 'Files',
-    order: ['file_type', 'participants', 'project_id', 'availableData', 'state', 'last_update'],
+    order: ['add_to_cart', 'download', 'my_projects', 'access', 'file_name', 'participants', 'participants.project.project_id', 'data_type', 'data_format', 'file_size', 'annotations'],
     headings: [
       {
         displayName: "add_to_cart",

--- a/app/scripts/search/search.participants.table.model.ts
+++ b/app/scripts/search/search.participants.table.model.ts
@@ -42,7 +42,7 @@ module ngApp.search.models {
 
     var searchParticipantsModel:TableiciousConfig = {
         title: 'Participants',
-        order: ['disease_type', 'gender', 'tumor_stage', 'files', 'last_update'],
+        order: ['add_to_cart_filtered', 'my_projects', 'participant_id', 'project.project_id', 'project.primary_site', 'clinical.gender', 'files', 'summary.data_types', 'annotations'],
         headings: [{
             displayName: "Add to Cart",
             id: "add_to_cart_filtered",


### PR DESCRIPTION
This is working.
- saves tbl config data to localstorage and restores for sort-columns and arrange-columns
- changed $scope.$watches in arrange-columns to ng-click methods to improve performance in digest cycle

todos for a future ticket
- optimize the data saved to localstorage so not to run out of space (save true as 1 etc)
- automatically populate config.order
