### PR TITLE
fix(search): Reduce spacing on action buttons.

### DIFF
--- a/app/scripts/components/tables/styles/styles.less
+++ b/app/scripts/components/tables/styles/styles.less
@@ -29,6 +29,15 @@
     display: inline-block;
   }
 
+  > div > a {
+    margin-left: 5px;
+  }
+}
+.table-compile-cell {
+  > div > div {
+    display: inline-block;
+  }
+
   > div > button {
     margin-left: 5px;
 

--- a/app/scripts/search/search.files.table.model.ts
+++ b/app/scripts/search/search.files.table.model.ts
@@ -30,31 +30,23 @@ module ngApp.search.models {
 
   var searchTableFilesModel: TableiciousConfig = {
     title: 'Files',
-    order: ['add_to_cart', 'download', 'my_projects', 'access', 'file_name', 'participants', 'participants.project.project_id', 'data_type', 'data_format', 'file_size', 'annotations'],
+    order: ['file_actions', 'my_projects', 'access', 'file_name', 'participants', 'participants.project.project_id', 'data_type', 'data_format', 'file_size', 'annotations'],
     headings: [
       {
-        displayName: "add_to_cart",
-        id: "add_to_cart",
+        displayName: "file_actions",
+        id: "file_actions",
         compile: function ($scope) {
           $scope.arrayRow = arrayToObject($scope.row);
-          var htm = '<div add-to-cart-single file="arrayRow"></div>';
+          var htm = '<div add-to-cart-single file="arrayRow"></div>' +
+                    '<a class="btn btn-primary" download-button files=file>' +
+                    '<i class="fa fa-download"></i></a>';
           return htm;
         },
         compileHead: function ($scope) {
           var htm = '<div add-to-cart-all files="data" paging="paging"></div>';
           return htm;
         },
-        noTitle: true,
-        visible: true
-      }, {
-        displayName: "download",
-        id: "download",
-        compile: function ($scope) {
-          $scope.file = arrayToObject($scope.row);
-          var htm = '<a class="btn btn-primary" download-button files=file>' +
-                    '<i class="fa fa-download"></i></a>';
-          return htm;
-        },
+        fieldClass: "table-compile-cell",
         noTitle: true,
         visible: true
       }, {


### PR DESCRIPTION
Closes #795

Sadly there isn't a lot that can be done here because this is just how `display: table` and `display: table-cell` are designed to work although obviously here it's giving weird results but it's essentially "intended".

Grouping the two buttons together does help reduce this and seems more logical however.
