### PR TITLE
add to cart perfromance

### DIFF
--- a/app/scripts/cart/cart.table.model.ts
+++ b/app/scripts/cart/cart.table.model.ts
@@ -76,7 +76,7 @@ module ngApp.cart.models {
       },
       {
         displayName: "Cases",
-        id: "participantId",
+        id: "participantIds",
         visible: true,
         template: function (field, row, scope) {
           var participants = field.val;

--- a/app/scripts/cart/tests/cart.tests.js
+++ b/app/scripts/cart/tests/cart.tests.js
@@ -77,16 +77,6 @@ describe('Cart:', function () {
       expect(ret.length).to.eq(2);
     }));
 
-    it('should return selected files', inject(function (CartService) {
-      var addCallback = sinon.spy(CartService, 'getSelectedFiles');
-      var fs = [fileA, fileB];
-      CartService.addFiles(fs);
-      CartService.getFiles()[0].selected = false;
-      var ret = CartService.getSelectedFiles();
-      expect(addCallback).to.have.been.calledOnce;
-      expect(ret.length).to.eq(1);
-    }));
-
     it('should check if file in cart', inject(function (CartService) {
       var addCallback = sinon.spy(CartService, 'add');
       CartService.add(fileA);


### PR DESCRIPTION
this isn't ready for merge yet, opening PR to post findings. Turns out that the slow step is LZString.compress. Here are some times recorded from adding 2501 files to the cart:

| desc | time from chrome cpu profile |
| --- | --- |
| master | 2335.9ms |
| addFiles, with compress, simplified loop | 2506.3ms |
| addFiles, with compress, no loops just concat (can't detect dups) | 2431ms |
| addFiles, simplified loop, w/o compress | 8.1ms |
| LZCompress itself | 25372.ms |

maybe we should get rid of LZCompress for the cart.

or actually going to try only compressing in a $destroy event now.
