### PR TITLE
fix(export): export non hidden fields

### DIFF
--- a/app/scripts/annotations/annotations.table.model.ts
+++ b/app/scripts/annotations/annotations.table.model.ts
@@ -1,7 +1,6 @@
 module ngApp.projects.models {
     var AnnotationsTableModel = {
         title: "Annotations",
-        order: ['annotation_id', 'participant_id', 'project.program.name', 'project.project_id', 'entity_type', 'entity_id', 'entity_submitter_id', 'category', 'classification', 'created_datetime', 'creator', 'status', 'notes'],
         rowId: 'annotation_id',
         headings: [
           {

--- a/app/scripts/components/tables/tableicious.directive.ts
+++ b/app/scripts/components/tables/tableicious.directive.ts
@@ -23,7 +23,7 @@ module ngApp.components.tables.directives.tableicious {
                 function hasChildren(h: IHeading): boolean {
                     return h.children && h.children.length > 0;
                 }
-                
+
                 function refresh(hs: IHeading[]): void {
                     $scope.enabledHeadings = _.reject(hs, h => {
                         return h.hidden;// || (h.inactive && h.inactive($scope))
@@ -37,12 +37,12 @@ module ngApp.components.tables.directives.tableicious {
                             return hasChildren(h) ? h.children : h;
                     }));
                 }
-                
+
                 $scope.$watch('headings', (n: IHeading[], o: IHeading[]) => {
                    if (_.isEqual(n,o)) return;
-                   refresh(n); 
+                   refresh(n);
                 }, true);
-                
+
                 
                 $scope.headings = $scope.saved.length ? 
                   _.map($scope.saved, (s: IHeading): IHeading => _.merge(_.find($scope.headings, {id: s.id}), s)) :
@@ -79,7 +79,7 @@ module ngApp.components.tables.directives.tableicious {
         headings: IHeading[];
         render(row: any): string;
     }
-    
+
     interface IHeading {
         th: string;
         id: string;
@@ -111,7 +111,7 @@ module ngApp.components.tables.directives.tableicious {
     interface ICell extends ng.IDirective {
         link(scope: ICellScope, element: ng.IAugmentedJQuery): void;
     }
-    
+
     interface ICellScope extends ng.IScope {
         cell: string;
     }

--- a/app/scripts/components/tables/tables.directives.ts
+++ b/app/scripts/components/tables/tables.directives.ts
@@ -20,25 +20,25 @@ module ngApp.components.tables.directives {
       templateUrl: "components/tables/templates/arrange-columns.html",
       link:function($scope) {
         $scope.UserService = UserService;
+
         function saveSettings() {
           var save = _.map($scope.headings, h => _.pick(h, 'id', 'hidden'));
           $window.localStorage.setItem($scope.title + '-col', angular.toJson(save));
         }
-        
+
         var defaults = _.cloneDeep($scope.headings);
         $scope.headings = $scope.saved.length ? 
           _.map($scope.saved, s => _.merge(_.find($scope.headings, {id: s.id}), s)) :
           $scope.headings;
-        
         $scope.restoreDefaults = function() {
-          $scope.headings = _.cloneDeep(defaults); 
-        } 
-        $scope.toggleVisibility = function (item) { 
+          $scope.headings = _.cloneDeep(defaults);
+        }
+        $scope.toggleVisibility = function (item) {
           item.hidden = !item.hidden;
-          saveSettings(); 
+          saveSettings();
         };
-        $scope.sortOptions = { 
-          orderChanged: saveSettings 
+        $scope.sortOptions = {
+          orderChanged: saveSettings
         };
       }
     };
@@ -48,9 +48,9 @@ module ngApp.components.tables.directives {
     return {
       restrict: "EA",
       scope: {
-        endpoint:"@",
         size: "@",
-        fields: "="
+        headings: "=",
+        endpoint: "@"
       },
       replace: true,
       templateUrl: "components/tables/templates/export-table.html",

--- a/app/scripts/components/tables/tables.services.ts
+++ b/app/scripts/components/tables/tables.services.ts
@@ -285,5 +285,5 @@ module ngApp.components.tables.services {
 
 angular
     .module("tables.services",[])
-    .service("TableService", TableService)
+    .service("TableService", TableService);
 }

--- a/app/scripts/components/tables/templates/arrange-columns.html
+++ b/app/scripts/components/tables/templates/arrange-columns.html
@@ -1,8 +1,8 @@
 <div class="btn-group Columns" data-dropdown auto-close="outsideClick">
-    <button type="button" class="btn btn-default dropdown-toggle" 
+    <button type="button" class="btn btn-default dropdown-toggle"
             dropdown-toggle aria-expanded="false"
-            data-tooltip-popup-delay=1000 
-            data-tooltip="Arrange Columns" 
+            data-tooltip-popup-delay=1000
+            data-tooltip="Arrange Columns"
             data-tooltip-append-to-body="true">
         <span class="fa fa-bars"></span>
     </button>
@@ -33,10 +33,9 @@
               data-ng-hide="item.inactive(this)">
               <i class="fa fa-stack fa-{{item.hidden ? 'square-o' : 'check-square-o'}}" data-ng-click="toggleVisibility(item)"></i>
               {{ item.name | ellipsicate:18 }}
-              <i class="pull-right text-right fa fa-bars fa-stack" 
+              <i class="pull-right text-right fa fa-bars fa-stack"
                 as-sortable-item-handle 
                 data-ng-class="{ 'fa-disabled': search.th }"></i>
-              
           </li>
          </ul>
        </li>

--- a/app/scripts/components/tables/templates/gdc-table.html
+++ b/app/scripts/components/tables/templates/gdc-table.html
@@ -22,17 +22,18 @@
         <arrange-columns data-title="{{ config.title }}"
                          data-saved="saved"
                          data-headings="config.headings"></arrange-columns>
-        <export-table data-endpoint="{{ endpoint }}" data-size="{{ paging.total }}"
-                      data-fields="config.fields" data-ng-if="endpoint"></export-table>
+        <export-table data-size="{{ paging.total }}"
+                      data-endpoint="{{ endpoint }}"
+                      data-headings="config.headings" data-ng-if="endpoint"></export-table>
       </div>
     </div>
   </div>
   <div class="table-responsive" data-nng-show="gtc.tableRendered">
-    <tableicious 
+    <tableicious
         id="{{ id }}"
         data-row-id="{{ config.rowId }}"
       	data-headings="config.headings"
-        data-data="gtc.displayedData" 
+        data-data="gtc.displayedData"
         data-title="{{config.title}}"
         data-saved="saved"
         data-paging="paging"></tableicious>

--- a/app/scripts/components/tables/templates/tableicious.html
+++ b/app/scripts/components/tables/templates/tableicious.html
@@ -6,7 +6,7 @@
         data-data="data"
         data-paging="paging"
         data-ng-class="h.thClassName"
-        rowspan="{{::h.children ? 1 : 2}}" 
+        rowspan="{{::h.children ? 1 : 2}}"
         colspan="{{::h.children ? h.children.length : 1}}"
         data-ng-hide="h.inactive(this)"
         data-ng-repeat="h in enabledHeadings">
@@ -21,7 +21,7 @@
   </thead>
   <tbody>
     <tr data-ng-repeat="d in data track by d[rowId]">
-      <td 
+      <td
         data-cell="::getCell(h,d)"
         data-row="d"
         data-ng-class="h.tdClassName"

--- a/app/scripts/projects/projects.table.model.ts
+++ b/app/scripts/projects/projects.table.model.ts
@@ -16,19 +16,19 @@ module ngApp.projects.models {
                 ];
     return withFilter(getDataType(row.summary.data_types, dataType), fs, $filter);
   }
-  
+
   var projectTableModel = {
     title: 'Projects',
-    order: ['project_id', 'disease_type', 'primary_site', 'program.name', 'summary.participant_count', 'data_types', 'summary.file_count', 'file_size'],
     rowId: 'project_id',
+
     headings: [
       {
         name: "ID",
         id: "project_id",
-        td: row => '<a href="projects/'+row.project_id + 
+        td: row => '<a href="projects/'+row.project_id +
                      '" data-tooltip="' + row.name +
-                     '" data-tooltip-append-to-body="true" data-tooltip-placement="right">' + 
-                     row.project_id + 
+                     '" data-tooltip-append-to-body="true" data-tooltip-placement="right">' +
+                     row.project_id +
                    '</a>',
         sortable: true,
         hidden: false,
@@ -69,7 +69,7 @@ module ngApp.projects.models {
         tdClassName: 'text-right'
       }, {
         name: "Available Cases per Data Type",
-        id: "data_types",
+        id: "summary.data_types",
         thClassName: 'text-center',
         hidden: false,
         children: [

--- a/app/scripts/search/search.files.table.model.ts
+++ b/app/scripts/search/search.files.table.model.ts
@@ -93,7 +93,7 @@ module ngApp.search.models {
         tdClassName: 'text-right'
       }, {
         name: "Annotations",
-        id: "annotations",
+        id: "annotations.annotation_id",
         td: (row, $scope) => {
           function getAnnotations(row, $scope) {
             return row.annotations.length == 1 ?

--- a/app/scripts/search/search.participants.table.model.ts
+++ b/app/scripts/search/search.participants.table.model.ts
@@ -26,7 +26,6 @@ module ngApp.search.models {
 
     var searchParticipantsModel = {
         title: 'Cases',
-        order: ['add_to_cart_filtered', 'my_projects', 'participant_id', 'project.project_id', 'project.primary_site', 'clinical.gender', 'files', 'summary.data_types', 'annotations'],
         rowId: 'participant_id',
         headings: [{
             name: "Cart",
@@ -48,7 +47,7 @@ module ngApp.search.models {
         }, {
             name: "Case ID",
             id: "participant_id",
-            td: row => '<a href="participants/'+row.participant_id + '">' +
+            td: row => '<a href="participants/'+ row.participant_id + '">' +
                          row.participant_id +
                        '</a>',
             tdClassName: 'truncated-cell'
@@ -149,7 +148,7 @@ module ngApp.search.models {
         ]
         }, {
           name: "Annotations",
-          id: "annotations",
+          id: "annotations.annotation_id",
           td: (row, $scope) => {
             function getAnnotations(row, $filter) {
               return row.annotations.length == 1 ?


### PR DESCRIPTION
caveats: 
- doesn't do client side processing on data returned so field names are es field names, and annotation counts show up as list of annotation ids and order is not preserved
- if user hides all columns and exports, the default fields are returned
