### PR TITLE
fix(cart): correct case count

### DIFF
--- a/app/scripts/cart/cart.controllers.ts
+++ b/app/scripts/cart/cart.controllers.ts
@@ -31,6 +31,7 @@ module ngApp.cart.controllers {
     projectCountChartConfig: any;
     fileCountChartConfig: any;
     helpHidden: boolean = false;
+    participantCount: number;
 
     /* @ngInject */
     constructor(private $scope: ng.IScope,
@@ -99,6 +100,7 @@ module ngApp.cart.controllers {
     }
 
     getSummary() {
+      this.participantCount = _.unique(_.flatten(_.pluck(this.files, "participantIds"))).length;
       var filters = {
         op: "and",
         content: [

--- a/app/scripts/cart/templates/cart.html
+++ b/app/scripts/cart/templates/cart.html
@@ -6,7 +6,7 @@
       <div data-ng-if="cc.files.length">
         <div class="col-lg-3 col-sm-6">
           <count-card title="Files" icon="fa-file-o" data="cc.files.length | number"></count-card>
-          <count-card title="Cases" icon="fa-user" data="cc.summary.participants.doc_count | number"></count-card>
+          <count-card title="Cases" icon="fa-user" data="cc.participantCount | number"></count-card>
           <count-card title="File Size" icon="fa-save" data="cc.summary.fs.value | size"></count-card>
         </div>
         <div class="col-lg-3 col-sm-6">


### PR DESCRIPTION
attempted to get ES to count distinct participants with https://www.elastic.co/guide/en/elasticsearch/guide/current/cardinality.html on the ui/search/summary endpoint api side, but that slowed down that endpoint a lot and wasn't even correct :/ Something to do with the precision_threshold parameter? Not sure but I figure it's better to count on the front end anyway, there's no noticeable slow down of the cart load time.
