### PR TITLE
fix(gql): better handling of trailing val in list

### DIFF
--- a/app/scripts/components/gql/module.ts
+++ b/app/scripts/components/gql/module.ts
@@ -116,9 +116,7 @@ module ngApp.components.gql {
     
     getComplexParts(s: string, n: number): IParts {
       var parts = this.getParts(s.substring(0, n));
-      
       parts.needle = this.getNeedleFromList(s.substring(n));
-      console.log('here', parts);
       return parts;
     }
     
@@ -284,11 +282,14 @@ module ngApp.components.gql {
     }
     
     rhsRewriteList(right: string): string {
-      var rFirstBracket = right.indexOf(this.GqlTokens.RBRACKET);
-      var rFirstComma = right.indexOf(this.GqlTokens.COMMA);
-      var rFirstToken = rFirstComma < rFirstBracket ? rFirstComma : rFirstBracket;
-      rFirstToken = rFirstToken === -1 ? right.length : rFirstToken;
-      return right.substring(rFirstToken);
+      var bracket = right.indexOf(this.GqlTokens.RBRACKET);
+      var comma = right.indexOf(this.GqlTokens.COMMA);
+      // is there a comma before the ] - if yes use that
+      var pos = comma >= 0 && comma < bracket ? comma : bracket;
+      // other wise is there a ] at all - then use that
+      // else end of line
+      pos = pos === -1 ? right.length : pos;
+      return right.substring(pos);
     }
   }
   
@@ -472,7 +473,7 @@ module ngApp.components.gql {
 
           var left = $scope.left;
           var right = $scope.right;
-  	      console.log('her?E?RE');
+
           if ([Mode.Field, Mode.Op, Mode.Unquoted].indexOf($scope.mode) !== -1) {
             var newLeft = GqlService.lhsRewrite(left, needleLength);
             var newRight = GqlService.rhsRewrite(right);

--- a/app/scripts/components/gql/tests/gql.service.tests.js
+++ b/app/scripts/components/gql/tests/gql.service.tests.js
@@ -362,6 +362,10 @@ describe("GQL Parser", function() {
       it("[OICR-928] return empty string when just unquoted value", inject(function (GqlService) {
         expect(GqlService.rhsRewriteList("otected")).to.eq("");
       }));
+      it("[OICR-940] not remove trailing list items", inject(function (GqlService) {
+        expect(GqlService.rhsRewriteList("trolled]")).to.eq("]");
+        expect(GqlService.rhsRewriteList("en, controlled]")).to.eq(", controlled]");
+      }));
     });
   });
 });


### PR DESCRIPTION
1.
files.access in [open, controlled]
move cursor into controlled:
files.access in [open, con|trolled]
select controlled from autosuggest:
files.access in [open, controlled
closing bracket gone
2.
files.access in [open, controlled]
move cursor into open:
files.access in [op|en, controlled]
select open from autosuggest:
files.access in [open
rest of list gone
- Closes #940
