### PR TITLE
fix(search): Maintain bolded case in matched terms

### DIFF
--- a/app/scripts/components/quick-search/quick-search.directives.ts
+++ b/app/scripts/components/quick-search/quick-search.directives.ts
@@ -61,11 +61,12 @@ module ngApp.components.quickSearch.directives {
       link: function($scope) {
         $scope.$watch("terms", (newVal) => {
           if (newVal) {
-            var boldedQuery = "<span class='bolded'>" + $scope.query + "</span>";
-            var boldedTerms = [];
             var regex = new RegExp("[" + $scope.query.replace(/\-/g, "\\-") + "]{" + $scope.query.length + "}", "gi");
-            _.forEach(newVal, (item) => {
-              boldedTerms.push(item.replace(regex, boldedQuery));
+
+            var boldedTerms = _.map(newVal, (item) => {
+              var matchedText = item.match(regex)[0];
+              var boldedQuery = "<span class='bolded'>" + matchedText + "</span>";
+              return item.replace(regex, boldedQuery);
             });
 
             $scope.matchedTerms = _.assign([], boldedTerms);


### PR DESCRIPTION
Example:

Searching `br` brings up matches for things like `Brain` or `BREAD_p_TCGAb_430_431_NSP_GenomeWideSNP_6_A09_1537930.byallele.copynumber.data.txt`.

In it's current state it will replace all `br` instances with that in the case it was typed in. This forces it to maintain the case that is present in the matched term.
