### PR TITLE
chore(app): Add alert on error for user.

### DIFF
--- a/app/scripts/core/exceptions.decorator.ts
+++ b/app/scripts/core/exceptions.decorator.ts
@@ -31,6 +31,7 @@ function exceptionDecorator($provide: ng.auto.IProvideService) {
         $log.debug("ERROR", post);
         var Restangular: restangular.IService = $injector.get("Restangular");
         Restangular.all('errors').post(post);
+        $window.alert(exception.message + ". Error report sent.");
         $delegate(exception, cause);
       };
     }


### PR DESCRIPTION
Closes #878

After investigating because of the step in which the `$exceptionHandler` is registered I can't have access to things like bootstraps modals. I also can't listen to top level errors in other places in the app since they will hit the exception handler first.

Basically it looks like the only possible UI I can give the user is a `window.alert` which is really awful but I'm not certain what other options I actually have.
