### PR TITLE
chore(config): Don't autocompile TS with editors.

### DIFF
--- a/app/scripts/tsconfig.json
+++ b/app/scripts/tsconfig.json
@@ -2,5 +2,6 @@
 	"compilerOptions": {
 		"target": "es6",
 		"module": "commonjs"
-	}
+	},
+	"compileOnSave": false
 }


### PR DESCRIPTION
I'm giving Atom a try and their typescript package auto runs the compiler. Turning it off so we don't have a bunch of JS files sitting around.
