### PR TITLE
fix(search): Fix days to death facet.

### DIFF
--- a/app/scripts/components/facets/templates/range-facet.html
+++ b/app/scripts/components/facets/templates/range-facet.html
@@ -10,6 +10,7 @@
   </h4>
   <div data-ng-show="!rfc.collapsed">
     <div class="radio-inline"
+         data-ng-if="unitsMap.length > 1"
          data-ng-repeat="unitMap in unitsMap">
         <label class="">
           <input type="radio"
@@ -17,7 +18,7 @@
                  data-ng-model="$parent.selectedUnit"
                  data-ng-value="unitMap"
                  data-ng-change="$parent.unitClicked()">
-            {{ unitMap.label }}
+            {{ unitMap.label | humanify }}
         </label>
       </div>
     <bar-chart data-data="dataUnitConverted"

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -83,15 +83,21 @@ module ngApp.search.controllers {
       this.refresh();
       this.chartConfigs = SearchChartConfigs;
       this.ageAtDiagnosisUnitsMap = [
-                            {
-                              "label": "years",
-                              "conversionDivisor": 365,
-                            },
-                            {
-                              "label": "days",
-                              "conversionDivisor": 1,
-                            }
-                          ];
+        {
+          "label": "years",
+          "conversionDivisor": 365,
+        },
+        {
+          "label": "days",
+          "conversionDivisor": 1,
+        }
+      ];
+      this.daysToDeathUnitsMap = [
+        {
+          "label": "days",
+          "conversionDivisor": 1,
+        }
+      ];
 
     }
 

--- a/app/scripts/search/templates/search.participants.facets.html
+++ b/app/scripts/search/templates/search.participants.facets.html
@@ -21,6 +21,7 @@
        data-collapsed="true"></terms>
 <range-facet data-field="cases.clinical.days_to_death" data-title="Days to death"
        data-facet="sc.participants.aggregations['clinical.days_to_death']"
+       data-units-map="sc.daysToDeathUnitsMap"
        data-collapsed="true"></range-facet>
 <terms data-name="cases.clinical.race" data-title="Race"
        data-facet="sc.participants.aggregations['clinical.race']"


### PR DESCRIPTION
- Default to still providing one unit for the facet so
  value calculating logic works and is easier.
