### PR TITLE
feat(annotation): Add Entity and Case searches.

### DIFF
--- a/app/scripts/annotations/templates/annotations.facets.html
+++ b/app/scripts/annotations/templates/annotations.facets.html
@@ -1,4 +1,10 @@
-<facets-free-text data-field="annotation_id" data-title="Annotation" placeholder="{{ 'Annotation ID' | translate }}"
+<facets-free-text data-field="annotation_id" data-title="Annotation ID" placeholder="{{ 'Annotation ID' | translate }}"
+                  entity="annotations"
+                  data-template="components/facets/templates/typeahead-annotations.html"></facets-free-text>
+<facets-free-text data-field="entity_id" data-title="Entity ID" placeholder="{{ 'Entity ID' | translate }}"
+                  entity="annotations"
+                  data-template="components/facets/templates/typeahead-annotations.html"></facets-free-text>
+<facets-free-text data-field="annotation.case_id" data-title="Case ID" placeholder="{{ 'Case ID' | translate }}"
                   entity="annotations"
                   data-template="components/facets/templates/typeahead-annotations.html"></facets-free-text>
 <terms data-name="annotations.project.primary_site"


### PR DESCRIPTION
- Basic UI suggested by Phuong-My for now having individual search
  boxes for each because we don't want to apply the annotation_id
  when searching by case_id. Ideally we could have one search input
  that is 'smart'.

Closes #1053
