### PR TITLE
fix(paging): set pg to 1 when facet added

### DIFF
--- a/app/scripts/components/facets/facets.services.ts
+++ b/app/scripts/components/facets/facets.services.ts
@@ -140,6 +140,7 @@ module ngApp.components.facets.services {
 
     addTerm(facet: string, term: string, op: string = 'in') {
       var filters = this.ensurePath(this.LocationService.filters());
+
       // TODO - not like this
       var found = false;
       var cs = filters["content"];

--- a/app/scripts/components/location/location.services.ts
+++ b/app/scripts/components/location/location.services.ts
@@ -40,6 +40,15 @@ module ngApp.components.location.services {
       } else {
         delete search.filters;
       }
+
+      //move the user back to pg1
+      var paging = this.pagination();
+      if (paging) {
+        _.each(paging, (page) => {
+          page.from = 0;
+        });
+        search['pagination'] = paging;
+      }
       return this.setSearch(search);
     }
 
@@ -60,13 +69,13 @@ module ngApp.components.location.services {
     }
 
     pagination(): any {
-      var f = this.search()["pagination"];
-      return f ? angular.fromJson(f) : {};
+      var f = _.get(this.search(), "pagination", "{}");
+      return angular.fromJson(f);
     }
 
     setPaging(pagination: {[key: string]: string}): ng.ILocationService {
       var search: ISearch = this.search();
-      
+
       if (pagination) {
         search.pagination = angular.toJson(pagination);
       } else if (_.isEmpty(search.pagination)) {


### PR DESCRIPTION
When user is on a page beyond the first page and then a facet is added that causes the num results to be < then his current page, the site becomes blank because there are no results to show on that page. To fix, always send the user back to the first page when a new facet is added.

Closes #1129
