### PR TITLE
fix(case): adds taget=_blank to xml links

### DIFF
--- a/app/scripts/components/ui/biospecimen/templates/biospecimen.html
+++ b/app/scripts/components/ui/biospecimen/templates/biospecimen.html
@@ -4,10 +4,10 @@
       <div class="panel-heading clearfix">
         <h3 class="panel-title pull-left" data-translate>Biospecimen</h3>
         <a class="btn btn-default pull-right"
+           target="_blank"
            data-ng-if="bc.bioSpecimenFileId"
            data-ng-href="{{ [bc.bioSpecimenFileId] | makeDownloadLink:false }}"
            data-translate>Download Biospecimen XML</a>
-
       </div>
       <div class="panel-body">
         <div class="col-lg-5 col-md-5">

--- a/app/scripts/participant/templates/participant.html
+++ b/app/scripts/participant/templates/participant.html
@@ -113,6 +113,7 @@
             </h3>
             <a class="btn btn-default pull-right"
                data-ng-if="pc.clinicalFileId"
+               target="_blank"
                data-ng-href="{{ [pc.clinicalFileId] | makeDownloadLink:false }}"
                data-translate>Download Clinical XML</a>
           </div>


### PR DESCRIPTION
- Opens xml files in new tab because the ng router is catching the link
  because it using the same domain and causing a 404 to routes back to
  /projects

Closes #1138, #1124
