### PR TITLE
fix(rangeFacets): show default selected input

### DIFF
--- a/app/scripts/components/facets/templates/range-facet.html
+++ b/app/scripts/components/facets/templates/range-facet.html
@@ -14,6 +14,8 @@
          data-ng-repeat="unitMap in unitsMap">
         <label data-ng-click="$parent.unitClicked(unitMap)">
           <input type="radio"
+                 data-ng-model="$parent.selectedUnit"
+                 data-ng-value="unitMap"
                  name="{{field}}">
             {{ unitMap.label | humanify }}
         </label>


### PR DESCRIPTION
Broke this when making the ng-change -> ng-click change to range facet years <-> days radio buttons. Now shows "years" selected by default again.
