### PR TITLE
fix(search): disease_type doesn't autofilter

### DIFF
--- a/app/scripts/components/ui/date/tests/datefilter.tests.js
+++ b/app/scripts/components/ui/date/tests/datefilter.tests.js
@@ -10,7 +10,7 @@ describe("Date Filter:", function () {
   it("should filter date with no given format", inject(function ($filter) {
     var date = new Date();
     var day = (date.getDate() < 10 ? '0' : '') + date.getDate();
-    var month = (date.getMonth() < 10 ? '0' : '') + (date.getMonth() + 1);
+    var month = (date.getMonth() + 1 < 10 ? '0' : '') + (date.getMonth() + 1);
     var formattedDate = $filter("date")(date.toString());
     var expectedDate = month + "/" + day + "/" + date.getFullYear();
 

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -152,7 +152,7 @@ module ngApp.search.controllers {
           "project.name",
           "project.project_id",
           "project.primary_site",
-          "project.program.name"
+          "project.disease_type"
         ]
       };
 

--- a/app/scripts/search/templates/search.participants.facets.html
+++ b/app/scripts/search/templates/search.participants.facets.html
@@ -9,7 +9,7 @@
 <terms data-name="cases.project.project_id" data-title="Project"
        data-facet="sc.participants.aggregations['project.project_id']"></terms>
 <terms data-name="cases.project.disease_type" data-title="Disease Type"
-       data-facet="sc.participants.aggregations['project.name']"></terms>
+       data-facet="sc.participants.aggregations['project.disease_type']"></terms>
 <terms data-name="cases.clinical.gender" data-title="Gender"
        data-facet="sc.participants.aggregations['clinical.gender']"
        data-collapsed="true"></terms>


### PR DESCRIPTION
disease_type field was being called program.name in some places and disease_type in others, when it got to the api it wasn't in the facets list so it got filtered.
