### PR TITLE
feat(user): support auth/user returning roles

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -8,5 +8,6 @@ angular.module("ngApp.config", [])
     "auth":"__AUTH__",
     "supportedAPI": "1",
     "tag": "https://github.com/NCI-GDC/portal-ui/releases/tag/__VERSION__",
-    "production": __PRODUCTION__
+    "production": __PRODUCTION__,
+    "fake_auth": __FAKE_AUTH__,
   });

--- a/app/scripts/annotations/tests/annotations.tests.js
+++ b/app/scripts/annotations/tests/annotations.tests.js
@@ -6,6 +6,7 @@ describe('Annotations:', function () {
   beforeEach(module('ngApp.annotations', 'core.services', 'ngProgressLite'));
   beforeEach(module(function ($provide) {
      $provide.value('AuthRestangular', {});
+     $provide.value('config', {});
   }));
 
   // Injection of dependencies, $http will be mocked with $httpBackend

--- a/app/scripts/cart/tests/cart.tests.js
+++ b/app/scripts/cart/tests/cart.tests.js
@@ -11,6 +11,7 @@ describe('Cart:', function () {
 
   beforeEach(module(function ($provide) {
       $provide.value('AuthRestangular', {});
+      $provide.value('config', {});
   }));
 
   // Injection of dependencies, $http will be mocked with $httpBackend

--- a/app/scripts/components/header/tests/header.tests.js
+++ b/app/scripts/components/header/tests/header.tests.js
@@ -5,6 +5,7 @@ describe('Header:', function () {
 
   beforeEach(module(function ($provide) {
      $provide.value('AuthRestangular', {});
+     $provide.value('config', {});
   }));
 
   describe('Controller:', function () {

--- a/app/scripts/components/user/user.models.ts
+++ b/app/scripts/components/user/user.models.ts
@@ -1,7 +1,7 @@
 module ngApp.components.user.models {
   export interface IUser {
     username: string;
-    projects: {gdc_ids: string[]};
+    projects: {gdc_ids: Object};
     token: string;
     isFiltered: boolean;
   }

--- a/app/scripts/components/user/user.services.ts
+++ b/app/scripts/components/user/user.services.ts
@@ -26,7 +26,24 @@ module ngApp.components.user.services {
                 private $cookies: ng.cookies.ICookiesService,
                 private $window: ng.IWindowService,
                 private $modal: any,
-                private $log: ng.ILogService) {}
+                private config: IGDCConfig,
+                private $log: ng.ILogService) {
+      if (config.fake_auth) {
+        this.setUser({
+          username: "DEV_USER",
+          projects: {
+            phs_ids: {
+              phs000178: ["_member_", "read", "delete"]
+            },
+            gdc_ids: {
+              "TCGA-LAML": ["read", "delete", "read_report", "_member_"],
+              "CGCI-BLGSP": ["read_report"],
+              "TCGA-DEV1": ["read", "delete", "_member_"]
+            }
+          }
+        });
+      }
+    }
 
     login(): void {
       this.AuthRestangular.all("user")
@@ -81,7 +98,15 @@ module ngApp.components.user.services {
     }
 
     setUser(user: IUser): void {
-      this.currentUser = user;
+      this.currentUser = { username: user.username,
+                           projects: {
+                            gdc_ids: _.reduce(user.projects.gdc_ids || {}, (acc, p, key) => {
+                             if (p.indexOf("_member_") !== -1) {
+                              acc.push(key);
+                             }
+                             return acc;
+                           }, [])}
+                         };
       this.$rootScope.$broadcast("gdc-user-reset");
     }
 

--- a/app/scripts/files/tests/files.tests.js
+++ b/app/scripts/files/tests/files.tests.js
@@ -11,6 +11,7 @@ describe('Files:', function () {
 
   beforeEach(module(function ($provide) {
       $provide.value('AuthRestangular', {});
+      $provide.value('config', {});
   }));
 
   // Injection of dependencies, $http will be mocked with $httpBackend

--- a/app/scripts/participant/tests/participants.tests.js
+++ b/app/scripts/participant/tests/participants.tests.js
@@ -7,6 +7,7 @@ describe('Participants:', function () {
 
   beforeEach(module(function ($provide) {
      $provide.value('AuthRestangular', {});
+     $provide.value('config', {});
   }));
 
   // Injection of dependencies, $http will be mocked with $httpBackend

--- a/app/scripts/projects/tests/projects.tests.js
+++ b/app/scripts/projects/tests/projects.tests.js
@@ -8,6 +8,7 @@ describe('Projects:', function () {
 
   beforeEach(module(function ($provide) {
       $provide.value('AuthRestangular', {});
+      $provide.value('config', {});
   }));
 
   // Injection of dependencies, $http will be mocked with $httpBackend

--- a/app/scripts/query/tests/query.tests.js
+++ b/app/scripts/query/tests/query.tests.js
@@ -9,6 +9,7 @@ describe('Query:', function () {
 
   beforeEach(module(function ($provide) {
       $provide.value('AuthRestangular', {});
+      $provide.value('config', {});
   }));
 
   describe('Controller:', function () {

--- a/app/scripts/search/tests/search.tests.js
+++ b/app/scripts/search/tests/search.tests.js
@@ -9,6 +9,7 @@ describe('Search:', function () {
 
   beforeEach(module(function ($provide) {
       $provide.value('AuthRestangular', {});
+      $provide.value('config', {});
   }));
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,8 @@ var env = {
   api: process.env.GDC_API || "http://localhost:5000",
   auth: process.env.GDC_AUTH || "https://gdc-portal.nci.nih.gov/auth",
   base: process.env.GDC_BASE || "/",
-  port: process.env.GDC_PORT || 3000
+  port: process.env.GDC_PORT || 3000,
+  fake_auth: process.env.GDC_FAKE_AUTH || false,
 };
 
 var AUTOPREFIXER_BROWSERS = [
@@ -141,6 +142,7 @@ gulp.task("config", function () {
       content = content.replace(/__API__/, env.api);
       content = content.replace(/__AUTH__/, env.auth);
       content = content.replace(/__PRODUCTION__/, production);
+      content = content.replace(/__FAKE_AUTH__/, env.fake_auth);
 
       // Ensures path is in place, as I've had occurances where it may not be.
       mkdirp("dist/js", function (err) {


### PR DESCRIPTION
- add GDC_FAKE_AUTH to config for dev

Closes #561 

`GDC_FAKE_AUTH=true npm start` now starts the data ui with DEV_USER logged in similar to the sub ui

🗒Live on dev
