### PR TITLE
feat(projects): Project links & minor home updates

### DIFF
--- a/app/scripts/components/header/templates/header.html
+++ b/app/scripts/components/header/templates/header.html
@@ -97,7 +97,7 @@
              </tr>
              <tr>
                <td>
-                 <a href="http://172.17.1.159:8000/" title="GDC Docs" target="_blank">
+                 <a href="https://gdc-docs.nci.nih.gov/" title="GDC Docs" target="_blank">
                   <span class="icon icon-gdc-docs">
                     <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                   </span>

--- a/app/scripts/components/quick-search/styles.less
+++ b/app/scripts/components/quick-search/styles.less
@@ -86,7 +86,7 @@
 /** Quick Search Home Directive Styles **/
 .quick-search-directive-container {
   position: relative;
-  z-index: 10000;
+  z-index: 1000;
 
   .quick-search-results-container {
     position: absolute;

--- a/app/scripts/components/tables/templates/tableicious.html
+++ b/app/scripts/components/tables/templates/tableicious.html
@@ -30,12 +30,12 @@
         data-ng-repeat="h in dataCols track by h.id">
       </td>
     </tr>
-    <!--<tr>
+    <tr>
       <td data-ng-repeat="h in dataCols track by h.name"
           data-ng-if="h.total"
           colspan="{{h.colSpan}}"
           data-ng-class="h.tdClassName"
           ng-bind-html="h.total(data, this)"></td>
-    </tr>-->
+    </tr>
   </tbody>
 </table>

--- a/app/scripts/components/ui/search/styles.less
+++ b/app/scripts/components/ui/search/styles.less
@@ -1,9 +1,35 @@
 .search-bar {
+
+  .search-bar-header {
+    padding: 1rem 1rem;
+
+    > div {
+      display: inline-block;
+      padding: 0rem 0rem;
+      margin: 0rem 0rem;
+      line-height: 3.5rem;
+    }
+
+    label {
+      margin: 0rem 0rem;
+    }
+
+    .btn-search-query {
+      float: right;
+    }
+    
+    .btn-search-query-help {
+      float: right;
+      margin: 0rem 1rem;
+      color: inherit;
+    }
+  }
+
   button {
     margin-right: 5px;
 
     &:first-child {
-      margin-right: 0;
+      margin-left: 0;
     }
   }
 

--- a/app/scripts/components/ui/search/templates/search-bar.html
+++ b/app/scripts/components/ui/search/templates/search-bar.html
@@ -1,38 +1,42 @@
 <div class="row search-bar">
   <div class="col-lg-8">
     <div class="panel panel-default">
-      <div data-ng-if="!sb.gql.filters && !!sb.Error" style="padding: 1rem;" class="text-danger">
-        <i class="fa fa-exclamation-circle"></i> 
-          <span data-ng-hide="showErrors">Invalid Query</span></span>  
-          <span data-ng-show="showErrors">{{sb.Error.human}}</span>
-            (<a href="" data-ng-click="showErrors = !showErrors">{{showErrors ? "hide" : "see"}} errors</a>)
-      </div>
-      <div data-ng-if="!sb.Error" style="padding: 1rem;" class="text-success">
-        <label for="gql"><i class="fa fa-check-circle"></i> Valid Query</label>
+      <div class="search-bar-header clearfix">
+        <div data-ng-if="!sb.gql.filters && !!sb.Error" class="text-danger">
+          <i class="fa fa-exclamation-circle"></i>
+            <span data-ng-hide="showErrors">Invalid Query</span></span>
+            <span data-ng-show="showErrors">{{sb.Error.human}}</span>
+              (<a href="" data-ng-click="showErrors = !showErrors">{{showErrors ? "hide" : "see"}} errors</a>)
+        </div>
+        <div data-ng-if="!sb.Error" class="text-success">
+          <label for="gql"><i class="fa fa-check-circle"></i> Valid Query</label>
+        </div>
+        <a class="btn-search-query-help btn btn-default"
+           target="_blank"
+           href="http://gdc-docs.nci.nih.gov/Data_Portal/Users_Guide/Advanced_Search/"
+           data-translate>
+          <i class="fa fa-question"></i>
+        </a>
+        <a class="btn btn-search-query btn-primary" data-ui-sref="search.summary"
+           data-ng-disabled="sb.query" data-translate>
+          <i class="fa fa-search"></i> Facet Search
+        </a>
       </div>
       <gql data-gql="sb.gql" data-query="sb.query" data-error="sb.Error"></gql>
       <div class="panel-footer text-right">
-        <a target="_blank"
-          href="https://gdc.nci.nih.gov/node/8191/" style="margin-right: 15px"
-           data-translate>
-          Help
-        </a>
-        <a data-ui-sref="search.summary" style="margin-right: 15px"
-           data-ng-disabled="sb.query" data-translate>
-          Facet
-        </a>
         <a style="margin-right: 15px"
                 data-ng-click="sb.resetQuery()"
                 aria-label="{{ 'Clear Query' | translate }}">
           Reset
         </a>
         <button
-            data-ng-disabled="sb.Error"
-            class="btn btn-primary"
-            ng-class="{'btn-success': !sb.Error}" 
-            data-ng-click="sb.sendQuery()">
+          data-ng-disabled="sb.Error"
+          class="btn btn-primary "
+          ng-class="{'btn-success': !sb.Error}"
+          data-ng-click="sb.sendQuery()">
           <i class="fa fa-search"></i> Search
         </button>
+
       </div>
     </div>
   </div>

--- a/app/scripts/core/core.filters.ts
+++ b/app/scripts/core/core.filters.ts
@@ -21,6 +21,11 @@ module ngApp.core.filters {
           };
         });
 
+
+        if (contentArray.length === 0) {
+          return angular.toJson({});
+        }
+
         var ret = angular.toJson({
           "op": "and",
           "content": contentArray

--- a/app/scripts/home/home.controllers.ts
+++ b/app/scripts/home/home.controllers.ts
@@ -82,7 +82,7 @@ module ngApp.home.controllers {
           fileCount: null
         },
         {
-          description: "All Asian cases with disease type Thyroid Carcinoma project",
+          description: "All Asian cases with disease type Thyroid Carcinoma",
           filters: {"op":"and","content":[{"op":"in","content":{"field":"cases.project.disease_type","value":["Thyroid Carcinoma"]}},{"op":"in","content":{"field":"cases.clinical.race","value":["asian"]}}]},
           caseCount: null,
           fileCount: null

--- a/app/scripts/home/templates/home.html
+++ b/app/scripts/home/templates/home.html
@@ -128,28 +128,28 @@
             <tbody>
             <tr>
               <td>
-                <a href="http://gdc-docs-dev.nci.nih.gov/Data_Portal/Users_Guide/Advanced_Search/" target="_blank">Searching Data with Facets and Smart Search Technology</a>
+                <a href="https://gdc-docs.nci.nih.gov/Data_Portal/Users_Guide/Advanced_Search/" target="_blank">Searching Data with Facets and Smart Search Technology</a>
               </td>
             </tr>
             <tr>
               <td>
-                <a href="http://gdc-docs-dev.nci.nih.gov/Data_Portal/Users_Guide/Cart/" target="_blank">Downloading files with the Personalized Cart</a>
+                <a href="https://gdc-docs.nci.nih.gov/Data_Portal/Users_Guide/Cart/" target="_blank">Downloading files with the Personalized Cart</a>
               </td>
             </tr>
             <tr>
               <td>
-                <a href="http://gdc-docs-dev.nci.nih.gov/" target="_blank">Data Portal Troubleshooting Tips</a>
+                <a href="https://gdc-docs.nci.nih.gov/" target="_blank">Data Portal Troubleshooting Tips</a>
                 </li>
               </td>
             </tr>
             <tr>
               <td>
-                <a href="http://gdc-docs-dev.nci.nih.gov/Commons/About_the_Data/#controlled-access-data" target="_blank">Controlled Access Data</a>
+                <a href="https://gdc-docs.nci.nih.gov/Commons/About_the_Data/#controlled-access-data" target="_blank">Controlled Access Data</a>
               </td>
             </tr>
             <tr>
               <td>
-                <a href="http://gdc-docs-dev.nci.nih.gov/" target="_blank"><strong>Visit the Documentation Website <i class="fa fa-angle-double-right"></i></strong></a>
+                <a href="https://gdc-docs-dev.nci.nih.gov/" target="_blank"><strong>Visit the Documentation Website <i class="fa fa-angle-double-right"></i></strong></a>
               </td>
             </tr>
             </tbody>
@@ -216,7 +216,7 @@
             <tr>
               <td>
                 <div data-uib-tooltip="GDC Docs Text">
-                  <a href="http://172.17.1.159:8000/ " title="GDC Docs">
+                  <a href="https://gdc-docs.nci.nih.gov/ " title="GDC Docs">
                     <span class="icon icon-gdc-docs">
                       <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                     </span>

--- a/app/scripts/projects/templates/projects.html
+++ b/app/scripts/projects/templates/projects.html
@@ -19,11 +19,14 @@
             </span>
           </span>
         </div>
-        <!--<div class="col-sm-2 text-right">
+      </div>
+
+      <div class="row" data-ng-if="cfc.currentFilters.length">
+        <div class="col-sm-12 text-right">
           <a class="btn btn-primary" data-translate data-ng-click="prsc.gotoQuery()">
-            <i class="fa fa-gears"></i> <span data-translate>Data Search</span>
+            <i class="fa fa-gears"></i> <span data-translate>Open Query in Data Page</span>
           </a>
-        </div>-->
+        </div>
       </div>
 
       <h3 class="col-lg-9 col-md-8" data-ng-if="prsc.projects.hits.length === 0" data-translate>


### PR DESCRIPTION
- Moved search and help up to top right hand corner of advanced search
  (AS)
- Anchored help to corresponding (AS) doc page.
- Home page anchor fixes
- Home page style fixes
- Added facet query button to data page
- Update doc links to point to prod.
- Fix filters for certain total columns where data page breaks or
  query is not correct (in terms of what a user would expect).
- Lowered z-index of search input field on home page so it doesn't
  override portal agreement modal
- Tweaked already existing project page functionality to replicate
  filtered queries to the data page.

Closes #738, #1359
