### PR TITLE
chore(home): Update GDC Doc Links

### DIFF
--- a/app/scripts/components/header/templates/header.html
+++ b/app/scripts/components/header/templates/header.html
@@ -154,7 +154,7 @@
               </tr>
               <tr>
                 <td>
-                  <a href="https://gdc-docs-dev.nci.nih.gov/" title="GDC Docs" target="_blank">
+                  <a href="https://gdc-docs.nci.nih.gov/" title="GDC Docs" target="_blank">
                   <span class="icon icon-gdc-docs">
                     <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                   </span>

--- a/app/scripts/home/templates/home.html
+++ b/app/scripts/home/templates/home.html
@@ -184,7 +184,7 @@
             </tr>
             <tr>
               <td>
-                <a href="https://gdc-docs-dev.nci.nih.gov/" target="_blank"><strong>Visit the Documentation Website <i class="fa fa-angle-double-right"></i></strong></a>
+                <a href="https://gdc-docs.nci.nih.gov/" target="_blank"><strong>Visit the Documentation Website <i class="fa fa-angle-double-right"></i></strong></a>
               </td>
             </tr>
             </tbody>
@@ -251,7 +251,7 @@
             <tr>
               <td>
                 <div data-uib-tooltip="GDC Docs">
-                  <a href="https://gdc-docs-dev.nci.nih.gov/ " target="_blank" title="GDC Docs">
+                  <a href="https://gdc-docs.nci.nih.gov/ " target="_blank" title="GDC Docs">
                     <span class="icon icon-gdc-docs">
                       <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                     </span>

--- a/app/styles/home.less
+++ b/app/styles/home.less
@@ -485,6 +485,14 @@
       min-width: 42rem;
       padding-right: 0.5rem;
       padding-left: 0.5rem;
+
+      a {
+        text-decoration: none;
+
+        p {
+          text-decoration: underline;
+        }
+      }
     }
 
     .info-table:last-child {
@@ -516,7 +524,7 @@
         border: none;
         font-size: 1.2rem;
         text-align: center;
-        padding: 1rem 0.3rem 0.2rem 0.3rem;
+        padding: 1rem 0.2rem 0.2rem 0.2rem;
 
         a {
 


### PR DESCRIPTION
- Change all gdc doc links to point to staging version.
- Remove underline on icons in the GDC Applications Table
- Fix overflow of table in GDC Application Table under certain viewport
  widths.

Closes #1916
