### PR TITLE
fix(app): put login() back in appRun

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -152,6 +152,8 @@ function appRun(gettextCatalog: any,
     });
   });
 
+  UserService.login();
+
   ProjectsService.getProjects({
     size: 100
   })


### PR DESCRIPTION
- add isFetching check in UserService.login()

The 'My Project' filter's still broken sometimes, but that was probably always been a bug. When I'm logged in, pg1 of the files on the 'Data' tab, which are all in 'My Projects' sometimes shows up as 'x' on initial load. Changing to pg2 and going back to pg1 shows them as '✓' (correct). The change where UserService.login() was removed from appRun() made this always the case. Putting it back makes it 'sometimes' - usually the login call returns before isUserProject() is called, sometimes not.
