### PR TITLE
fix(gdctable): restore default works after refresh

### DIFF
--- a/app/scripts/components/tables/tables.controllers.ts
+++ b/app/scripts/components/tables/tables.controllers.ts
@@ -179,9 +179,12 @@ module ngApp.components.tables.controllers {
     sortingHeadings: any[] = [];
     displayedData: any[];
     tableRendered: boolean = false;
+    defaultHeadings: any[] = [];
 
     /* @ngInject */
     constructor(private $scope: IGDCTableScope, $window: ng.IWindowService) {
+      this.defaultHeadings = _.cloneDeep($scope.config.headings);
+
       this.sortingHeadings = _.filter($scope.config.headings, (heading: any) => {
         return heading && heading.sortable;
       });

--- a/app/scripts/components/tables/tables.directives.ts
+++ b/app/scripts/components/tables/tables.directives.ts
@@ -14,6 +14,7 @@ module ngApp.components.tables.directives {
       scope: {
         title: "@",
         headings:"=",
+        defaultHeadings: "=",
         saved: "="
       },
       replace: true,
@@ -26,7 +27,7 @@ module ngApp.components.tables.directives {
           $window.localStorage.setItem($scope.title + '-col', angular.toJson(save));
         }
 
-        var defaults = _.cloneDeep($scope.headings);
+        var defaults = $scope.defaultHeadings;
 
         $scope.headings = $scope.saved.length ?
           _.map($scope.saved, s => _.merge(_.find($scope.headings, {id: s.id}), s)) :

--- a/app/scripts/components/tables/templates/gdc-table.html
+++ b/app/scripts/components/tables/templates/gdc-table.html
@@ -22,6 +22,7 @@
                     data-paging="paging" data-page="{{ page }}"></sort-table>
         <arrange-columns data-title="{{ config.title }}"
                          data-saved="saved"
+                         data-default-headings="gtc.defaultHeadings"
                          data-headings="config.headings"></arrange-columns>
         <export-table data-size="{{ paging.total }}"
                       data-endpoint="{{ endpoint }}"


### PR DESCRIPTION
Closes #1769

Problem was the tableicous directive also changes config.headings but the reset function is in ArrangeColumns directive so _.cloneDeep there cloned the version that was already restored from localstorage, meaning after refreshing there is no way to restore the original default. This commit moves _.cloneDeep to before tablecious gets to it.
