### PR TITLE
fix(case): no biospecimen broke case entity page

### DIFF
--- a/app/scripts/cases/cases.directives.ts
+++ b/app/scripts/cases/cases.directives.ts
@@ -12,7 +12,8 @@ module ngApp.cases.directives {
       textNormal: '@',
       textInProgress: '@',
       styleClass: '@',
-      icon: '@'
+      icon: '@',
+      ngDisabled: '='
     },
     template: '<a ng-class="[styleClass || \'btn btn-primary\']" data-downloader> \
               <i class="fa {{icon || \'fa-download\'}}" ng-class="{\'fa-spinner\': active, \'fa-pulse\': active}" /> \
@@ -50,11 +51,13 @@ module ngApp.cases.directives {
         size: scope.size || 10000
       }, scope.filename ? {filename: scope.filename} : {});
 
-      $element.on('click', () => {
-        const checkProgress = scope.download(params, url, () => $element, 'POST');
+      if (! scope.ngDisabled) {
+        $element.on('click', () => {
+          const checkProgress = scope.download(params, url, () => $element, 'POST');
 
-        checkProgress(inProgress, done);
-      });
+          checkProgress(inProgress, done);
+        });
+      }
       scope.active = false;
     }
   });

--- a/app/scripts/components/ui/biospecimen/biospecimen.controllers.ts
+++ b/app/scripts/components/ui/biospecimen/biospecimen.controllers.ts
@@ -29,7 +29,7 @@ module ngApp.components.ui.biospecimen.controllers {
       });
 
       const participant = $scope.participant;
-      this.hasBiospecimen = !participant.samples;
+      this.hasNoBiospecimen = _.size(participant.samples) < 1;
       this.biospecimenDataExportFilters = {
         'cases.case_id': participant.case_id
       };

--- a/app/scripts/components/ui/biospecimen/templates/biospecimen.html
+++ b/app/scripts/components/ui/biospecimen/templates/biospecimen.html
@@ -5,7 +5,7 @@
         <h3 class="panel-title pull-left" data-translate>Biospecimen</h3>
 
         <export-cases-button
-          ng-disabled="bc.hasBiospecimen"
+          ng-disabled="bc.hasNoBiospecimen"
           data-filter-key-values=bc.biospecimenDataExportFilters
           data-expands=bc.biospecimenDataExportExpands
           data-filename=bc.biospecimenDataExportFileName
@@ -15,7 +15,13 @@
           data-style-class="btn pull-right">
         </export-cases-button>
       </div>
-      <div class="panel-body">
+
+      <div ng-if="bc.hasNoBiospecimen"
+        class="table table-striped table-hover table-condensed table-bordered table-vertical"
+        style="border-top: 0; padding-left: 2rem">
+        <h3>No biospecimen found.</h3>
+      </div>
+      <div class="panel-body" ng-if="! bc.hasNoBiospecimen">
         <div class="col-lg-5 col-md-5">
           <div class="row biospecimen-tree-action-bar">
             <div class="col-xs-8">

--- a/app/scripts/participant/templates/participant.html
+++ b/app/scripts/participant/templates/participant.html
@@ -367,7 +367,7 @@
                 </div>
                 <div ng-if="! pc.participant.diagnoses[ $index ].treatments.length"
                   style="margin-bottom: 1rem;">
-                  <strong>No treatments found.</strong>
+                  <h3>No treatments found.</h3>
                 </div>
               </div>
             </uib-tab>
@@ -376,8 +376,8 @@
         <div id="clinical-table"
           ng-if="pc.activeClinicalTab === 'diagnoses' && ! pc.participant.diagnoses.length"
           class="table table-striped table-hover table-condensed table-bordered table-vertical"
-          style="border-top: 0; padding-top: 1rem; padding-left: 1rem">
-          <h2>No diagnoses found.</h2>
+          style="border-top: 0; padding-top: 0.2rem; padding-left: 2rem">
+          <h3>No diagnoses found.</h3>
         </div>
 
         <div id="clinical-table"
@@ -445,8 +445,8 @@
         <div id="clinical-table"
           ng-if="pc.activeClinicalTab === 'family_histories' && ! pc.participant.family_histories.length"
           class="table table-striped table-hover table-condensed table-bordered table-vertical"
-          style="border-top: 0; padding-top: 1rem; padding-left: 1rem">
-          <h2>No family histories found.</h2>
+          style="border-top: 0; padding-top: 0.2rem; padding-left: 2rem">
+          <h3>No family histories found.</h3>
         </div>
 
         <div id="clinical-table"
@@ -522,8 +522,8 @@
         <div id="clinical-table"
           ng-if="pc.activeClinicalTab === 'exposures' && ! pc.participant.exposures.length"
           class="table table-striped table-hover table-condensed table-bordered table-vertical"
-          style="border-top: 0; padding-top: 1rem; padding-left: 1rem">
-          <h2>No exposures found.</h2>
+          style="border-top: 0; padding-top: 0.2rem; padding-left: 2rem">
+          <h3>No exposures found.</h3>
         </div>
 
       </div>


### PR DESCRIPTION
1) Displays "No biospecimen found" when there is no biospecimen samples;
2) Use consistent styles for all "No ... found" messages in entity page;
3) Fixed issue w/ button being clickable when ngDisabled is true.

Closes #2007
