### PR TITLE
fix(summaryCard): use % in max-width

### DIFF
--- a/app/scripts/components/summary-card/styles.less
+++ b/app/scripts/components/summary-card/styles.less
@@ -7,7 +7,7 @@
 
 .summary-card {
   h4 {
-    max-width: 220px;
+    max-width: 90%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
- so that the title's not cut off on large screens
  Closes #914
