### PR TITLE
fix(header): use flexbox for gdc-apps-menu

### DIFF
--- a/app/scripts/components/header/templates/header.html
+++ b/app/scripts/components/header/templates/header.html
@@ -114,77 +114,57 @@
             <span class="hidden-md hidden-sm" data-translate>GDC Apps</span>
           </a>
           <div data-uib-dropdown-menu class="dropdown-menu gdc-apps-menu-container" role="menu">
-            <table class="gdc-apps-menu-grid">
-              <tbody>
-              <tr>
-                <td>
-                  <a href="/" title="Data Portal" class="active">
+
+            <div class="gdc-apps-menu-grid">
+              <div class="menu-column">
+                <a href="/" title="Data Portal" class="active menu-item">
                       <span class="icon icon-gdc-data-portal">
                         <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                       </span>
                     <p>Data Portal</p>
-                  </a>
-                </td>
-                <td>
-                  <a href="https://gdc.nci.nih.gov/access-data/gdc-data-transfer-tool" title="GDC Data Transfer Tool" target="_blank">
-                      <span class="icon icon-gdc-data-transer-tool">
-                        <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span>
-                      </span>
-                    <p>Data Transfer Tool</p>
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="https://gdc.nci.nih.gov/developers/gdc-application-programming-interface-api" title="GDC API" target="_blank">
+                </a>
+                <a href="https://gdc.nci.nih.gov/developers/gdc-application-programming-interface-api" title="GDC API" target="_blank" class="menu-item">
                       <span class="icon icon-gdc-portal-api">
                         <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span>
                       </span>
                     <p>API</p>
-                  </a>
-                </td>
-                <td>
-                  <a href="https://gdc-portal.nci.nih.gov/submission/" title="GDC Submission Portal" target="_blank">
-                     <span class="icon icon-gdc-submission-portal">
-                      <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span>
-                    </span>
-                    <p>Data Submission Portal</p>
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="https://gdc-docs.nci.nih.gov/" title="GDC Docs" target="_blank">
+                </a>
+                <a href="https://gdc-docs.nci.nih.gov/" title="GDC Docs" target="_blank" class="menu-item">
                   <span class="icon icon-gdc-docs">
                     <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span><span class="path11"></span><span class="path12"></span><span class="path13"></span><span class="path14"></span>
                   </span>
                     <p>Documentation</p>
-                  </a>
-                </td>
-                <td>
-                  <a href="https://gdc.nci.nih.gov/" title="GDC Website" target="_blank">
-                  <span class="icon icon-gdc-website">
-                     <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span>
-                  </span>
-                    <p>Website</p>
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="https://gdc-portal.nci.nih.gov/legacy-archive" title="GDC Legacy Archive" target="_blank">
+                </a>
+                <a href="https://gdc-portal.nci.nih.gov/legacy-archive" title="GDC Legacy Archive" target="_blank" class="menu-item">
                    <span class="icon icon-gdc-legacy-archive">
                        <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span>
                     </span>
                     <p>Legacy Archive</p>
-                  </a>
-                </td>
-                <td>&nbsp;</td>
-              </tr>
-              </tbody>
-            </table>
+                </a>
+              </div>
+              <div class="menu-column">
+                <a href="https://gdc.nci.nih.gov/access-data/gdc-data-transfer-tool" class="menu-item" title="GDC Data Transfer Tool" target="_blank">
+                      <span class="icon icon-gdc-data-transer-tool">
+                        <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span>
+                      </span>
+                    <p>Data Transfer Tool</p>
+                </a>
+                <a href="https://gdc-portal.nci.nih.gov/submission/" title="GDC Submission Portal" target="_blank" class="menu-item">
+                   <span class="icon icon-gdc-submission-portal">
+                    <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span><span class="path9"></span><span class="path10"></span>
+                  </span>
+                  <p>Data Submission Portal</p>
+                </a>
+                <a href="https://gdc.nci.nih.gov/" title="GDC Website" target="_blank" class="menu-item">
+                  <span class="icon icon-gdc-website">
+                     <span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span><span class="path7"></span><span class="path8"></span>
+                  </span>
+                    <p>Website</p>
+                </a>
+                <span class="menu-item" style="height: 61px">&nbsp;</span>
+              </div>
+            </div>
           </div>
-
         </li>
       </ul>
     </nav>

--- a/app/styles/home.less
+++ b/app/styles/home.less
@@ -29,7 +29,14 @@
 
     text-align: center;
     font-size: 1.2rem;
+    display: flex;
+    justify-content: space-between;
 
+    .menu-column {
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: column;
+    }
 
     &:before {
       width: 0;
@@ -51,8 +58,11 @@
       background-color: #ccc;
     }
 
-    td {
-      padding: 0.25rem;
+    .menu-item {
+      padding: 0.5rem;
+      white-space: nowrap;
+      margin: 0.25rem;
+      flex: 1;
     }
 
     a {


### PR DESCRIPTION
closes #1933

The ticket is concerned with the table being used for the gdc-apps-menu and suggests adding role=presentation to it. The aria spec says that role=presentation is for 'A layout table and/or any of its associated rows, cells, etc.' (https://www.w3.org/TR/wai-aria/roles#presentation). The table in question is not layout only, it's a menu and the parent div has role=menu. Since we're already using flexbox elsewhere, changing it to a div would probably be best.
