### PR TITLE
Fix/data category casing

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -247,6 +247,14 @@ angular
       "templates"
     ])
     .config(appConfig)
+    .constant('DATA_CATEGORIES', {
+      SEQ: { full: "Raw Sequencing Data", abbr: "Seq" },
+      EXP: { full: "Gene Expression", abbr: "Exp" },
+      SNV: { full: "Simple Nucleotide Variation", abbr: "SNV" },
+      CNV: { full: "Copy Number Variation", abbr: "CNV" },
+      CLINICAL: { full: "Clinical", abbr: "Clinical" },
+      BIOSPECIMEN: { full: "Biospecimen", abbr: "Biospecimen" },
+    })
     .factory('RestFullResponse', function(Restangular: restangular.IService) {
       return Restangular.withConfig(function(RestangularConfigurer: restangular.IProvider) {
         RestangularConfigurer.setFullResponse(true);

--- a/app/scripts/components/facets/facets.services.ts
+++ b/app/scripts/components/facets/facets.services.ts
@@ -234,8 +234,11 @@ module ngApp.components.facets.services {
                  datum.field !== 'archive.revision' &&
                  !_.includes(datum.field, "_id") &&
                  !_.includes(current, datum.field) &&
-                 !_.includes(docType === 'files' ? _.pluck(this.SearchTableFilesModel.facets, "name") : _.pluck(this.SearchTableParticipantsModel.facets, "name"), datum.field);
-                 }), f => _.merge(f, {'description': 'this is a description'}));
+                 !_.includes(docType === 'files'
+                  ? _.pluck(this.SearchTableFilesModel.facets, "name")
+                  : _.pluck(this.SearchTableParticipantsModel.model().facets, "name"), datum.field
+                 );
+        }), f => _.merge(f, {'description': 'this is a description'}));
       });
     }
 

--- a/app/scripts/home/home.controllers.ts
+++ b/app/scripts/home/home.controllers.ts
@@ -90,7 +90,7 @@ module ngApp.home.controllers {
       ];
 
       this.defaultParams =  {
-        fields: this.ProjectTableModel.fields,
+        fields: this.ProjectTableModel.model().fields,
         facets: [
           "disease_type",
           "program.name",

--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -52,7 +52,7 @@ module ngApp.projects.controllers {
 
       var data = $state.current.data || {};
       this.ProjectsState.setActive("tabs", data.tab);
-      $scope.tableConfig = ProjectTableModel;
+      $scope.tableConfig = ProjectTableModel.model();
 
       this.refresh();
     }
@@ -61,8 +61,8 @@ module ngApp.projects.controllers {
       this.loading = true;
       if (!this.tabSwitch) {
         this.ProjectsService.getProjects({
-          fields: this.ProjectTableModel.fields,
-          facets: this.FacetService.filterFacets(this.ProjectTableModel.facets),
+          fields: this.ProjectTableModel.model().fields,
+          facets: this.FacetService.filterFacets(this.ProjectTableModel.model().facets),
           size: 100
         }).then((data) => {
           this.loading = false;

--- a/app/scripts/projects/projects.table.model.ts
+++ b/app/scripts/projects/projects.table.model.ts
@@ -18,259 +18,230 @@ module ngApp.projects.models {
 
   type Rows = Row[];
 
-  function filterFactory(url: string) : IWithFilterFn {
-      return function(value: number, filters: Object[], $filter: ng.IFilterService)  {
-        var filterString = _.isObject(filters) ? $filter("makeFilter")(filters, true) : null;
-        var href = url + (filterString ? "?filters=" + filterString : "");
-        var val = $filter("number")(value);
-        return value ? "<a href='" + href + "'>" + val + '</a>' : '0';
-      };
-  }
+  class ProjectsTableModelService {
 
-  var withFilterF : IWithFilterFn = filterFactory("search/f"),
-      withFilter : IWithFilterFn = filterFactory("search/c");
+    /* @ngInject */
+    constructor(private DATA_CATEGORIES) {}
 
-  function getdataCategory(dataCategories: DataCategory[], dataCategory:string): number {
-    var data = _.find(dataCategories, {data_category: dataCategory});
-    return data ? data.case_count : 0;
-  }
+    filterFactory(url: string) : IWithFilterFn {
+        return function(value: number, filters: Object[], $filter: ng.IFilterService)  {
+          var filterString = _.isObject(filters) ? $filter("makeFilter")(filters, true) : null;
+          var href = url + (filterString ? "?filters=" + filterString : "");
+          var val = $filter("number")(value);
+          return value ? "<a href='" + href + "'>" + val + '</a>' : '0';
+        };
+    }
 
-  function dataCategoryWithFilters(dataCategory: string, row: Row, $filter: ng.IFilterService): string {
-    var fs = [{field: 'cases.project.project_id', value: row.project_id},
-              {field: 'files.data_category', value: dataCategory}];
-    return withFilter(getdataCategory(row.summary.data_categories, dataCategory), fs, $filter);
-  }
+    withFilterF : IWithFilterFn = this.filterFactory("search/f");
+    withFilter : IWithFilterFn = this.filterFactory("search/c");
 
-  function dataCategoryTotalWithFilters(dataCategory: string, data: Rows, $filter: ng.IFilterService): string {
-  var fs = [{field: 'files.data_category', value: [dataCategory]},
-            {field: 'cases.project.project_id', value: data.map(d => d.project_id)}];
-    return withFilter(_.sum(_.map(data, row => getdataCategory(row.summary.data_categories, dataCategory))), fs, $filter);
-  }
+    getdataCategory(dataCategories: DataCategory[], dataCategory:string): number {
+      var data = _.find(dataCategories, {data_category: dataCategory});
+      return data ? data.case_count : 0;
+    }
 
-  function withCurrentFilters(value: number, $filter: ng.IFilterService, LocationService: ILocationService) {
-    var fs = _.map(LocationService.filters().content, x => ({
-      field: x.content.field.indexOf("summary") === 0 ? "files." + x.content.field.split(".")[2] : "cases.project." + x.content.field,
-      value: x.content.value
-    }));
-    return withFilter(value, fs, $filter);
-  }
+    dataCategoryWithFilters(dataCategory: string, row: Row, $filter: ng.IFilterService): string {
+      var fs = [{field: 'cases.project.project_id', value: row.project_id},
+                {field: 'files.data_category', value: dataCategory}];
+      return this.withFilter(this.getdataCategory(row.summary.data_categories, dataCategory), fs, $filter);
+    }
 
-  function hasFilters(LocationService: ILocationService) : boolean {
-    var filters = _.get(LocationService.filters(), 'content', null),
-        hasFiltersFlag = false;
+    dataCategoryTotalWithFilters(dataCategory: string, data: Rows, $filter: ng.IFilterService): string {
+    var fs = [{field: 'files.data_category', value: [dataCategory]},
+              {field: 'cases.project.project_id', value: data.map(d => d.project_id)}];
+      return this.withFilter(_.sum(_.map(data, row => this.getdataCategory(row.summary.data_categories, dataCategory))), fs, $filter);
+    }
 
-    if (! filters) {
+    withCurrentFilters(value: number, $filter: ng.IFilterService, LocationService: ILocationService) {
+      var fs = _.map(LocationService.filters().content, x => ({
+        field: x.content.field.indexOf("summary") === 0 ? "files." + x.content.field.split(".")[2] : "cases.project." + x.content.field,
+        value: x.content.value
+      }));
+      return this.withFilter(value, fs, $filter);
+    }
+
+    hasFilters(LocationService: ILocationService) : boolean {
+      var filters = _.get(LocationService.filters(), 'content', null),
+          hasFiltersFlag = false;
+
+      if (! filters) {
+        return hasFiltersFlag;
+      }
+
+      for (var i = 0; i < filters.length; i++) {
+        var field = _.get(filters[i], 'content.field', false);
+
+        if (! field) {
+          continue;
+        }
+
+        hasFiltersFlag = true;
+        break;
+      }
+
       return hasFiltersFlag;
     }
 
-    for (var i = 0; i < filters.length; i++) {
-      var field = _.get(filters[i], 'content.field', false);
+    withProjectFilters(data: Object[], $filter: ng.IFilterService, LocationService: ILocationService, withFilterFn?: IWithFilterFn) : string {
 
-      if (! field) {
-        continue;
+      var projectIDs = [],
+          totalCount = 0,
+          wFilterFn : IWithFilterFn = withFilterFn || this.withFilter,
+          fs = [];
+
+      _.map(data, function(d) {
+
+
+        if (! _.has(d, 'project_id')) {
+          return;
+        }
+
+        projectIDs.push(d.project_id);
+
+        var countKey = 'summary.case_count';
+
+        if ( withFilterFn !== this.withFilter ) {
+          countKey = 'summary.file_count';
+        }
+
+        totalCount += _.get(d, countKey, 0);
+
+      });
+
+      if (this.hasFilters(LocationService) && projectIDs.length) {
+        fs.push({field: 'cases.project.project_id', value: projectIDs});
       }
 
-      hasFiltersFlag = true;
-      break;
+      return wFilterFn(totalCount, fs, $filter);
     }
 
-    return hasFiltersFlag;
-  }
-
-  function withProjectFilters(data: Object[], $filter: ng.IFilterService, LocationService: ILocationService, withFilterFn?: IWithFilterFn) : string {
-
-    var projectIDs = [],
-        totalCount = 0,
-        wFilterFn : IWithFilterFn = withFilterFn || withFilter,
-        fs = [];
-
-    _.map(data, function(d) {
-
-
-      if (! _.has(d, 'project_id')) {
-        return;
-      }
-
-      projectIDs.push(d.project_id);
-
-      var countKey = 'summary.case_count';
-
-      if ( withFilterFn !== withFilter ) {
-        countKey = 'summary.file_count';
-      }
-
-      totalCount += _.get(d, countKey, 0);
-
-    });
-
-    if (hasFilters(LocationService) && projectIDs.length) {
-      fs.push({field: 'cases.project.project_id', value: projectIDs});
-    }
-
-    return wFilterFn(totalCount, fs, $filter);
-  }
-
-  var projectTableModel = {
-    title: 'Projects',
-    rowId: 'project_id',
-    headings: [
-      {
-        name: "ID",
-        id: "project_id",
-        td: row => '<a href="projects/'+row.project_id +
-                     '" data-uib-tooltip="' + row.name +
-                     '" data-tooltip-append-to-body="true" data-tooltip-placement="right">' +
-                     row.project_id +
-                   '</a>',
-        sortable: true,
-        hidden: false,
-        draggable: true,
-        total: data => '<strong>Total</strong>',
-        colSpan: 4
-      }, {
-        name: "Disease Type",
-        id: "disease_type",
-        tdClassName: 'truncated-cell',
-        td: row => row.disease_type,
-        toolTipText: row => row.disease_type,
-        sortable: true,
-        hidden: false,
-        draggable: true
-      }, {
-        name: "Primary Site",
-        id: "primary_site",
-        tdClassName: 'truncated-cell',
-        td: row => row.primary_site,
-        sortable: true,
-        hidden: false,
-        canReorder: true,
-        enabled: true
-      }, {
-        name: "Program",
-        id: "program.name",
-        td: row => row.program && row.program.name,
-        sortable: true,
-        hidden: false
-      }, {
-        name: "Cases",
-        id: "summary.case_count",
-        td: (row, $scope) => {
-          var fs = [{field: 'cases.project.project_id', value: row.project_id}]
-          return withFilter(row.summary.case_count, fs, $scope.$filter);
-        },
-        sortable: true,
-        hidden: false,
-        thClassName: 'text-right',
-        tdClassName: 'text-right',
-        total: (data, $scope) => withProjectFilters(data, $scope.$filter, $scope.LocationService, withFilter)
-      }, {
-        name: "Available Cases per Data Category",
-        id: "summary.data_categories",
-        thClassName: 'text-center',
-        hidden: false,
-        children: [
+    model() {
+      return {
+        title: 'Projects',
+        rowId: 'project_id',
+        headings: [
           {
-            name: 'Seq',
-            th: '<abbr data-uib-tooltip="Raw Sequencing Data">Seq</abbr>',
-            id: 'Seq',
-            td: (row, $scope) => dataCategoryWithFilters("Raw sequencing data", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters("Raw sequencing data", data, $scope.$filter)
+            name: "ID",
+            id: "project_id",
+            td: row => '<a href="projects/'+row.project_id +
+                         '" data-uib-tooltip="' + row.name +
+                         '" data-tooltip-append-to-body="true" data-tooltip-placement="right">' +
+                         row.project_id +
+                       '</a>',
+            sortable: true,
+            hidden: false,
+            draggable: true,
+            total: data => '<strong>Total</strong>',
+            colSpan: 4
           }, {
-            name: 'Exp',
-            th: '<abbr data-uib-tooltip="Transcriptome Profiling">Exp</abbr>',
-            id: 'Exp',
-            td: (row, $scope) => dataCategoryWithFilters("Gene expression", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters("Gene expression", data, $scope.$filter)
+            name: "Disease Type",
+            id: "disease_type",
+            tdClassName: 'truncated-cell',
+            td: row => row.disease_type,
+            toolTipText: row => row.disease_type,
+            sortable: true,
+            hidden: false,
+            draggable: true
           }, {
-            name: 'SNV',
-            th: '<abbr data-uib-tooltip="Simple Nucleotide Variation">SNV</abbr>',
-            id: 'SNV',
-            td: (row, $scope) => dataCategoryWithFilters("Simple nucleotide variation", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters("Simple nucleotide variation", data, $scope.$filter)
+            name: "Primary Site",
+            id: "primary_site",
+            tdClassName: 'truncated-cell',
+            td: row => row.primary_site,
+            sortable: true,
+            hidden: false,
+            canReorder: true,
+            enabled: true
           }, {
-            name: 'CNV',
-            th: '<abbr data-uib-tooltip="Copy Number Variation">CNV</abbr>',
-            id: 'CNV',
-            td: (row, $scope) => dataCategoryWithFilters("Copy number variation", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters("Copy number variation", data, $scope.$filter)
-          },{
-            name: 'Clinical',
-            id: 'clinical',
-            td: (row, $scope) => dataCategoryWithFilters("Clinical", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters('Clinical', data, $scope.$filter)
+            name: "Program",
+            id: "program.name",
+            td: row => row.program && row.program.name,
+            sortable: true,
+            hidden: false
           }, {
-            name: 'Biospecimen',
-            id: 'biospecimen',
-            td: (row, $scope) => dataCategoryWithFilters("Biospecimen", row, $scope.$filter),
+            name: "Cases",
+            id: "summary.case_count",
+            td: (row, $scope) => {
+              var fs = [{field: 'cases.project.project_id', value: row.project_id}]
+              return this.withFilter(row.summary.case_count, fs, $scope.$filter);
+            },
+            sortable: true,
+            hidden: false,
             thClassName: 'text-right',
             tdClassName: 'text-right',
-            total: (data, $scope) => dataCategoryTotalWithFilters('Biospecimen', data, $scope.$filter)
+            total: (data, $scope) => this.withProjectFilters(data, $scope.$filter, $scope.LocationService, this.withFilter)
+          }, {
+            name: "Available Cases per Data Category",
+            id: "summary.data_categories",
+            thClassName: 'text-center',
+            hidden: false,
+            children: Object.keys(this.DATA_CATEGORIES).map(key => ({
+              name: this.DATA_CATEGORIES[key].abbr,
+              th:
+                '<abbr data-uib-tooltip="' + this.DATA_CATEGORIES[key].full + '">'
+              + this.DATA_CATEGORIES[key].abbr + '</abbr>',
+              id: this.DATA_CATEGORIES[key].abbr,
+              td: (row, $scope) => this.dataCategoryWithFilters(this.DATA_CATEGORIES[key].full, row, $scope.$filter),
+              thClassName: 'text-right',
+              tdClassName: 'text-right',
+              total: (data, $scope) => this.dataCategoryTotalWithFilters(this.DATA_CATEGORIES[key].full, data, $scope.$filter)
+            }))
+          }, {
+            name: "Files",
+            id: "summary.file_count",
+            td: (row, $scope) => {
+              var fs = [{field: 'cases.project.project_id', value: row.project_id}]
+              return this.withFilterF(row.summary.file_count, fs, $scope.$filter);
+            },
+            sortable: true,
+            thClassName: 'text-right',
+            tdClassName: 'text-right',
+            total: (data, $scope) =>  this.withProjectFilters(data, $scope.$filter, $scope.LocationService, this.withFilterF)
+          }, {
+            name: "File Size",
+            id: "file_size",
+            td: (row, $scope) => row.summary && $scope.$filter("size")(row.summary.file_size),
+            sortable: true,
+            thClassName: 'text-right',
+            tdClassName: 'text-right',
+            total: (data, $scope) => $scope.$filter("size")(_.sum(_.pluck(data, "summary.file_size")))
           }
-        ]
-      }, {
-        name: "Files",
-        id: "summary.file_count",
-        td: (row, $scope) => {
-          var fs = [{field: 'cases.project.project_id', value: row.project_id}]
-          return withFilterF(row.summary.file_count, fs, $scope.$filter);
-        },
-        sortable: true,
-        thClassName: 'text-right',
-        tdClassName: 'text-right',
-        total: (data, $scope) =>  withProjectFilters(data, $scope.$filter, $scope.LocationService, withFilterF)
-      }, {
-        name: "File Size",
-        id: "file_size",
-        td: (row, $scope) => row.summary && $scope.$filter("size")(row.summary.file_size),
-        sortable: true,
-        thClassName: 'text-right',
-        tdClassName: 'text-right',
-        total: (data, $scope) => $scope.$filter("size")(_.sum(_.pluck(data, "summary.file_size")))
-      }
-    ],
-    fields: [
-      "disease_type",
-      "state",
-      "primary_site",
-      "project_id",
-      "name",
-      "program.name",
-      "summary.case_count",
-      "summary.file_count",
-      "summary.data_categories.data_category",
-      "summary.data_categories.case_count",
-    ],
-    facets: [
-      {
-        name: 'project_id',
-        facetType: 'free-text'
-      }, {
-        name: 'disease_type',
-        facetType: 'terms'
-      }, {
-        name: 'program.name',
-        facetType: 'terms'
-      }, {
-        name: 'primary_site',
-        facetType: 'terms'
-      }, {
-        name: 'summary.experimental_strategies.experimental_strategy',
-        facetType: 'terms'
-      }, {
-        name: 'summary.data_categories.data_category',
-        facetType: 'terms'
-    }]
-  };
+        ],
+        fields: [
+          "disease_type",
+          "state",
+          "primary_site",
+          "project_id",
+          "name",
+          "program.name",
+          "summary.case_count",
+          "summary.file_count",
+          "summary.data_categories.data_category",
+          "summary.data_categories.case_count",
+        ],
+        facets: [
+          {
+            name: 'project_id',
+            facetType: 'free-text'
+          }, {
+            name: 'disease_type',
+            facetType: 'terms'
+          }, {
+            name: 'program.name',
+            facetType: 'terms'
+          }, {
+            name: 'primary_site',
+            facetType: 'terms'
+          }, {
+            name: 'summary.experimental_strategies.experimental_strategy',
+            facetType: 'terms'
+          }, {
+            name: 'summary.data_categories.data_category',
+            facetType: 'terms'
+        }]
+      };
+    }
+  }
+
   angular.module("projects.table.model", [])
-      .value("ProjectTableModel", projectTableModel);
+      .service("ProjectTableModel", ProjectsTableModelService);
 }

--- a/app/scripts/query/query.controllers.ts
+++ b/app/scripts/query/query.controllers.ts
@@ -73,7 +73,7 @@ module ngApp.query.controllers {
       });
 
       $scope.fileTableConfig = this.SearchTableFilesModel;
-      $scope.participantTableConfig = this.SearchTableParticipantsModel;
+      $scope.participantTableConfig = this.SearchTableParticipantsModel.model();
 
       this.refresh();
       this.chartConfigs = SearchChartConfigs;
@@ -100,11 +100,11 @@ module ngApp.query.controllers {
       });
 
       var fileOptions = {
-        fields: this.SearchTableFilesModel.fields
+        fields: this.SearchTableFilesModel.model().fields
       };
 
       var participantOptions = {
-        fields: this.SearchTableParticipantsModel.fields,
+        fields: this.SearchTableParticipantsModel.model().fields,
       };
 
       this.FilesService.getFiles(fileOptions).then((data: IFiles) => {

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -83,7 +83,7 @@ module ngApp.search.controllers {
       });
 
       $scope.fileTableConfig = this.SearchTableFilesModel;
-      $scope.participantTableConfig = this.SearchTableParticipantsModel;
+      $scope.participantTableConfig = this.SearchTableParticipantsModel.model();
 
       this.refresh();
       this.chartConfigs = SearchChartConfigs;
@@ -132,10 +132,10 @@ module ngApp.search.controllers {
         facets: this.FacetService.filterFacets(this.FacetsConfigService.fieldsMap['files'])
       };
 
-      this.FacetsConfigService.setFields('cases', this.SearchTableParticipantsModel.facets);
+      this.FacetsConfigService.setFields('cases', this.SearchTableParticipantsModel.model().facets);
       var participantOptions = {
-        fields: this.SearchTableParticipantsModel.fields,
-        expand: this.SearchTableParticipantsModel.expand,
+        fields: this.SearchTableParticipantsModel.model().fields,
+        expand: this.SearchTableParticipantsModel.model().expand,
         facets: this.FacetService.filterFacets(this.FacetsConfigService.fieldsMap['cases'])
       };
 

--- a/app/scripts/search/search.participants.table.model.ts
+++ b/app/scripts/search/search.participants.table.model.ts
@@ -1,270 +1,247 @@
 module ngApp.search.models {
-    function withAnnotationFilter(value: number, filters: Object[], $filter: ng.IFilterService): string {
-        var filterString = $filter("makeFilter")(filters, true);
-        var href = 'annotations?filters=' + filterString;
-        var val = '{{' + value + '|number:0}}';
-        return "<a href='" + href + "'>" + val + '</a>';
-    }
 
-    function withFilter(value: number, filters: Object[], $filter: ng.IFilterService): string {
-        var filterString = $filter("makeFilter")(filters, true);
-        var href = 'search/f?filters=' + filterString;
-        var val = '{{' + value + '|number:0}}';
-        return value ? "<a href='" + href + "'>" + val + '</a>' : '0';
-    }
-    function getDataCategory(dataCategories: Object[], dataCategory: string): number {
-        var data = _.find(dataCategories, {data_category: dataCategory});
-        return data ? data.file_count : 0;
-    }
-    function dataCategoryWithFilters(dataCategory: string, row: Object[], $filter: ng.IFilterService) {
-        var fs = [
-          {field: 'cases.case_id', value: row.case_id},
-          {field: 'files.data_category', value: dataCategory}
-        ];
-        return withFilter(getDataCategory(row.summary ? row.summary.data_categories : [], dataCategory), fs, $filter);
-    }
-    function youngestDiagnosis(p: { age_at_diagnosis: number }, c: { age_at_diagnosis: number }): { age_at_diagnosis: number } {
-      return c.age_at_diagnosis < p.age_at_diagnosis ? c : p
-    }
+    class SearchParticipantsModelService {
 
-    var searchParticipantsModel = {
-        title: 'Cases',
-        rowId: 'case_id',
-        headings: [{
-            name: "Cart",
-            id: "add_to_cart_filtered",
-            td: row => '<add-to-cart-filtered row="row"></add-to-cart-filtered>',
-            tdClassName: 'text-center'
-        }, {
-            name: "My Projects",
-            id: "my_projects",
-            td: (row, $scope) => {
-                var fakeFile = {cases: [{project: row.project}]};
-                var isUserProject = $scope.UserService.isUserProject(fakeFile);
-                var icon = isUserProject ? 'check' : 'remove';
-                return '<i class="fa fa-' + icon + '"></i>';
-            },
-            inactive: $scope => !$scope.UserService.currentUser || $scope.UserService.currentUser.isFiltered,
-            hidden: false,
-            tdClassName: "text-center"
-        }, {
-            name: "Case UUID",
-            id: "case_id",
-            toolTipText: row => row.case_id,
-            td: row => '<a href="cases/'+ row.case_id + '">' + row.case_id + '</a>',
-            tdClassName: 'truncated-cell'
-        }, {
-            name: "Project",
-            id: "project.project_id",
-            toolTipText: row => row.project.name,
-            td: row => '<a href="projects/'+row.project.project_id + '">' + row.project.project_id + '</a>',
-            sortable: true,
-        }, {
-            name: "Primary Site",
-            id: "project.primary_site",
-            td: row => row.project && row.project.primary_site,
-            sortable: true
-        }, {
-            name: "Gender",
-            id: "demographic.gender",
-            td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.gender) || '--',
-            sortable: true
-        }, {
-            name: "Files",
-            id: "files",
-            td: (row, $scope) => {
-                var fs = [{field: 'cases.case_id', value: row.case_id}]
-                var sum = _.sum(_.pluck(row.summary ? row.summary.data_categories : [], 'file_count'))
-                return withFilter(sum, fs, $scope.$filter);
-            },
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-        }, {
-            name: "Available Files per Data Category",
-            id: "summary.data_categories",
-            thClassName:'text-center',
-            children: [
-          {
-            name: 'Seq',
-            th: '<abbr data-uib-tooltip="Raw Sequencing data">Seq</abbr>',
-            id: 'Seq',
-            td: (row, $scope) => dataCategoryWithFilters("Raw sequencing data", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }, {
-            name: "Exp",
-            th: '<abbr data-uib-tooltip="Transcriptome Profiling">Exp</abbr>',
-            id: "Exp",
-            td: (row, $scope) => dataCategoryWithFilters("Gene expression", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }, {
-            name: 'SNV',
-            th: '<abbr data-uib-tooltip="Simple Nucleotide Variation">SNV</abbr>',
-            id: 'SNV',
-            td: (row, $scope) => dataCategoryWithFilters("Simple nucleotide variation", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }, {
-            name: 'CNV',
-            th: '<abbr data-uib-tooltip="Copy Number Variation">CNV</abbr>',
-            id: 'cnv',
-            td: (row, $scope) => dataCategoryWithFilters("Copy number variation", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }, {
-            name: 'Clinical',
-            th: '<abbr data-uib-tooltip="Clinical">Clinical</abbr>',
-            id: 'clinical',
-            td: (row, $scope) => dataCategoryWithFilters("Clinical", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }, {
-            name: 'Biospecimen',
-            id: 'biospecimen',
-            td: (row, $scope) => dataCategoryWithFilters("Biospecimen", row, $scope.$filter),
-            thClassName: 'text-right',
-            tdClassName: 'text-right'
-          }
-        ]
-        }, {
-          name: "Annotations",
-          id: "annotations.annotation_id",
-          td: (row, $scope) => {
-            function getAnnotations(row, $filter) {
-              return row.annotations.length == 1 ?
-                     '<a href="annotations/' + row.annotations[0].annotation_id + '">' + 1 + '</a>' :
-                     withAnnotationFilter(
-                       row.annotations.length,
-                       [{field: "annotation_id", value: _.pluck(row.annotations, 'annotation_id')}],
-                       $filter);
-            }
+      /* @ngInject */
+      constructor(private DATA_CATEGORIES) {}
 
-            return row.annotations && row.annotations.length ? getAnnotations(row, $scope.$filter) : 0;
-          },
-          thClassName: 'text-right',
-          tdClassName: 'text-right'
-        }, {
-            name: 'Program',
-            id: 'project.program.name',
-            td: (row, $scope) => row.project && $scope.$filter("humanify")(row.project.program.name),
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Disease Type',
-            id: 'project.disease_type',
-            td: (row, $scope) => row.project && $scope.$filter("humanify")(row.project.disease_type),
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Age at diagnosis',
-            id: 'diagnoses.age_at_diagnosis',
+      withAnnotationFilter(value: number, filters: Object[], $filter: ng.IFilterService): string {
+          var filterString = $filter("makeFilter")(filters, true);
+          var href = 'annotations?filters=' + filterString;
+          var val = '{{' + value + '|number:0}}';
+          return "<a href='" + href + "'>" + val + '</a>';
+      }
+
+      withFilter(value: number, filters: Object[], $filter: ng.IFilterService): string {
+          var filterString = $filter("makeFilter")(filters, true);
+          var href = 'search/f?filters=' + filterString;
+          var val = '{{' + value + '|number:0}}';
+          return value ? "<a href='" + href + "'>" + val + '</a>' : '0';
+      }
+
+      getDataCategory(dataCategories: Object[], dataCategory: string): number {
+          var data = _.find(dataCategories, {data_category: dataCategory});
+          return data ? data.file_count : 0;
+      }
+
+      dataCategoryWithFilters(dataCategory: string, row: Object[], $filter: ng.IFilterService) {
+          var fs = [
+            {field: 'cases.case_id', value: row.case_id},
+            {field: 'files.data_category', value: dataCategory}
+          ];
+          return this.withFilter(this.getDataCategory(row.summary ? row.summary.data_categories : [], dataCategory), fs, $filter);
+      }
+
+      youngestDiagnosis(p: { age_at_diagnosis: number }, c: { age_at_diagnosis: number }): { age_at_diagnosis: number } {
+        return c.age_at_diagnosis < p.age_at_diagnosis ? c : p
+      }
+
+      model() {
+        return {
+          title: 'Cases',
+          rowId: 'case_id',
+          headings: [{
+              name: "Cart",
+              id: "add_to_cart_filtered",
+              td: row => '<add-to-cart-filtered row="row"></add-to-cart-filtered>',
+              tdClassName: 'text-center'
+          }, {
+              name: "My Projects",
+              id: "my_projects",
+              td: (row, $scope) => {
+                  var fakeFile = {cases: [{project: row.project}]};
+                  var isUserProject = $scope.UserService.isUserProject(fakeFile);
+                  var icon = isUserProject ? 'check' : 'remove';
+                  return '<i class="fa fa-' + icon + '"></i>';
+              },
+              inactive: $scope => !$scope.UserService.currentUser || $scope.UserService.currentUser.isFiltered,
+              hidden: false,
+              tdClassName: "text-center"
+          }, {
+              name: "Case UUID",
+              id: "case_id",
+              toolTipText: row => row.case_id,
+              td: row => '<a href="cases/'+ row.case_id + '">' + row.case_id + '</a>',
+              tdClassName: 'truncated-cell'
+          }, {
+              name: "Project",
+              id: "project.project_id",
+              toolTipText: row => row.project.name,
+              td: row => '<a href="projects/'+row.project.project_id + '">' + row.project.project_id + '</a>',
+              sortable: true,
+          }, {
+              name: "Primary Site",
+              id: "project.primary_site",
+              td: row => row.project && row.project.primary_site,
+              sortable: true
+          }, {
+              name: "Gender",
+              id: "demographic.gender",
+              td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.gender) || '--',
+              sortable: true
+          }, {
+              name: "Files",
+              id: "files",
+              td: (row, $scope) => {
+                  var fs = [{field: 'cases.case_id', value: row.case_id}]
+                  var sum = _.sum(_.pluck(row.summary ? row.summary.data_categories : [], 'file_count'))
+                  return this.withFilter(sum, fs, $scope.$filter);
+              },
+              thClassName: 'text-right',
+              tdClassName: 'text-right'
+          }, {
+              name: "Available Files per Data Category",
+              id: "summary.data_categories",
+              thClassName:'text-center',
+              children: Object.keys(this.DATA_CATEGORIES).map(key => ({
+                name: this.DATA_CATEGORIES[key].abbr,
+                th: '<abbr data-uib-tooltip="' + this.DATA_CATEGORIES[key].full + '">'
+                  + this.DATA_CATEGORIES[key].abbr + '</abbr>',
+                id: this.DATA_CATEGORIES[key].abbr,
+                td: (row, $scope) => this.dataCategoryWithFilters(this.DATA_CATEGORIES[key].full, row, $scope.$filter),
+                thClassName: 'text-right',
+                tdClassName: 'text-right'
+              }))
+          }, {
+            name: "Annotations",
+            id: "annotations.annotation_id",
             td: (row, $scope) => {
-              // Use diagnosis with minimum age
-              const age = (row.diagnoses || []).reduce((p, c) => c.age_at_diagnosis < p ? c.age_at_diagnosis : p, Infinity);
-              return age !== Infinity && row.diagnoses ? $scope.$filter("ageDisplay")(age) : "--";
+              function getAnnotations(row, $filter) {
+                return row.annotations.length == 1 ?
+                       '<a href="annotations/' + row.annotations[0].annotation_id + '">' + 1 + '</a>' :
+                       this.withAnnotationFilter(
+                         row.annotations.length,
+                         [{field: "annotation_id", value: _.pluck(row.annotations, 'annotation_id')}],
+                         $filter);
+              }
+
+              return row.annotations && row.annotations.length ? getAnnotations(row, $scope.$filter) : 0;
             },
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Days to death',
-            id: 'diagnoses.days_to_death',
-            td: (row, $scope) => {
-              const primaryDiagnosis = (row.diagnoses || [])
-                .reduce(youngestDiagnosis, { age_at_diagnosis: Infinity });
-              return (row.diagnoses && $scope.$filter("number")(primaryDiagnosis.days_to_death, 0)) || "--"
-            },
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Vital Status',
-            id: 'diagnoses.vital_status',
-            td: (row, $scope) => {
-              const primaryDiagnosis = (row.diagnoses || [])
-                .reduce(youngestDiagnosis, { age_at_diagnosis: Infinity });
-              return row.diagnoses && $scope.$filter("humanify")(primaryDiagnosis.vital_status)
-            },
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Year of diagnosis',
-            id: 'diagnoses.year_of_diagnosis',
-            td: (row, $scope) => {
-              const primaryDiagnosis = (row.diagnoses || [])
-                .reduce(youngestDiagnosis, { age_at_diagnosis: Infinity });
-              return (row.diagnoses && primaryDiagnosis.year_of_diagnosis) || "--"
-            },
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'ICD-10',
-            id: 'icd_10',
-            td: (row, $scope) => (row.clinical && row.clinical.icd_10) || "--",
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Ethnicity',
-            id: 'demographic.ethnicity',
-            td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.ethnicity),
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Race',
-            id: 'demographic.race',
-            td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.race),
-            sortable: false,
-            hidden: true
-        }, {
-            name: 'Submitter ID',
-            id: 'submitter_id',
-            td: (row, $scope) => row.submitter_id,
-            sortable: false,
-            hidden: true
-        }],
-        fields: [
-          "case_id",
-          "annotations.annotation_id",
-          "project.project_id",
-          "project.name",
-          "project.primary_site",
-          "project.program.name",
-          "project.disease_type",
-          "submitter_id",
-          "clinical.icd_10",
-          "demographic.gender",
-          "demographic.race",
-          "demographic.ethnicity",
-          "diagnoses.year_of_diagnosis",
-          "diagnoses.vital_status",
-          "diagnoses.days_to_death",
-          "diagnoses.age_at_diagnosis"
-        ],
-        expand: [
-          "summary.data_categories",
-        ],
-        facets: [
-            {name: "case_id", title: "Case", collapsed: false, facetType: "free-text", placeholder: "UUID, Submitter ID"},
-            {name: "project.primary_site", title: "Primary Site", collapsed: false, facetType: "terms"},
-            {name: "project.program.name", title: "Cancer Program", collapsed: false, facetType: "terms"},
-            {name: "project.project_id", title: "Project", collapsed: false, facetType: "terms"},
-            {name: "project.disease_type", title: "Disease Type", collapsed: false, facetType: "terms"},
-            {name: "demographic.gender", title: "Gender", collapsed: false, facetType: "terms"},
-            {name: "diagnoses.age_at_diagnosis", title: "Age at diagnosis", collapsed: false, facetType: "range", unitsMap: [
-                            {
-                              "label": "years",
-                              "conversionDivisor": 365.25,
-                            },
-                            {
-                              "label": "days",
-                              "conversionDivisor": 1,
-                            }
-                            ]},
-            {name: "diagnoses.vital_status", title: "Vital Status", collapsed: false, facetType: "terms"},
-            {name: "diagnoses.days_to_death", title: "Days to Death", collapsed: false, facetType: "range", hasGraph: true},
-            {name: "demographic.race", title: "Race", collapsed: false, facetType: "terms"},
-            {name: "demographic.ethnicity", title: "Ethnicity", collapsed: false, facetType: "terms"}
-        ]
-    };
+            thClassName: 'text-right',
+            tdClassName: 'text-right'
+          }, {
+              name: 'Program',
+              id: 'project.program.name',
+              td: (row, $scope) => row.project && $scope.$filter("humanify")(row.project.program.name),
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Disease Type',
+              id: 'project.disease_type',
+              td: (row, $scope) => row.project && $scope.$filter("humanify")(row.project.disease_type),
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Age at diagnosis',
+              id: 'diagnoses.age_at_diagnosis',
+              td: (row, $scope) => {
+                // Use diagnosis with minimum age
+                const age = (row.diagnoses || []).reduce((p, c) => c.age_at_diagnosis < p ? c.age_at_diagnosis : p, Infinity);
+                return age !== Infinity && row.diagnoses ? $scope.$filter("ageDisplay")(age) : "--";
+              },
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Days to death',
+              id: 'diagnoses.days_to_death',
+              td: (row, $scope) => {
+                const primaryDiagnosis = (row.diagnoses || [])
+                  .reduce(this.youngestDiagnosis, { age_at_diagnosis: Infinity });
+                return (row.diagnoses && $scope.$filter("number")(primaryDiagnosis.days_to_death, 0)) || "--"
+              },
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Vital Status',
+              id: 'diagnoses.vital_status',
+              td: (row, $scope) => {
+                const primaryDiagnosis = (row.diagnoses || [])
+                  .reduce(this.youngestDiagnosis, { age_at_diagnosis: Infinity });
+                return row.diagnoses && $scope.$filter("humanify")(primaryDiagnosis.vital_status)
+              },
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Year of diagnosis',
+              id: 'diagnoses.year_of_diagnosis',
+              td: (row, $scope) => {
+                const primaryDiagnosis = (row.diagnoses || [])
+                  .reduce(this.youngestDiagnosis, { age_at_diagnosis: Infinity });
+                return (row.diagnoses && primaryDiagnosis.year_of_diagnosis) || "--"
+              },
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'ICD-10',
+              id: 'icd_10',
+              td: (row, $scope) => (row.clinical && row.clinical.icd_10) || "--",
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Ethnicity',
+              id: 'demographic.ethnicity',
+              td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.ethnicity),
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Race',
+              id: 'demographic.race',
+              td: (row, $scope) => row.demographic && $scope.$filter("humanify")(row.demographic.race),
+              sortable: false,
+              hidden: true
+          }, {
+              name: 'Submitter ID',
+              id: 'submitter_id',
+              td: (row, $scope) => row.submitter_id,
+              sortable: false,
+              hidden: true
+          }],
+          fields: [
+            "case_id",
+            "annotations.annotation_id",
+            "project.project_id",
+            "project.name",
+            "project.primary_site",
+            "project.program.name",
+            "project.disease_type",
+            "submitter_id",
+            "clinical.icd_10",
+            "demographic.gender",
+            "demographic.race",
+            "demographic.ethnicity",
+            "diagnoses.year_of_diagnosis",
+            "diagnoses.vital_status",
+            "diagnoses.days_to_death",
+            "diagnoses.age_at_diagnosis"
+          ],
+          expand: [
+            "summary.data_categories",
+          ],
+          facets: [
+              {name: "case_id", title: "Case", collapsed: false, facetType: "free-text", placeholder: "UUID, Submitter ID"},
+              {name: "project.primary_site", title: "Primary Site", collapsed: false, facetType: "terms"},
+              {name: "project.program.name", title: "Cancer Program", collapsed: false, facetType: "terms"},
+              {name: "project.project_id", title: "Project", collapsed: false, facetType: "terms"},
+              {name: "project.disease_type", title: "Disease Type", collapsed: false, facetType: "terms"},
+              {name: "demographic.gender", title: "Gender", collapsed: false, facetType: "terms"},
+              {name: "diagnoses.age_at_diagnosis", title: "Age at diagnosis", collapsed: false, facetType: "range", unitsMap: [
+                              {
+                                "label": "years",
+                                "conversionDivisor": 365.25,
+                              },
+                                {
+                                "label": "days",
+                                "conversionDivisor": 1,
+                              }
+                              ]},
+              {name: "diagnoses.vital_status", title: "Vital Status", collapsed: false, facetType: "terms"},
+              {name: "diagnoses.days_to_death", title: "Days to Death", collapsed: false, facetType: "range", hasGraph: true},
+              {name: "demographic.race", title: "Race", collapsed: false, facetType: "terms"},
+              {name: "demographic.ethnicity", title: "Ethnicity", collapsed: false, facetType: "terms"}
+          ]
+        };
+      }
+    }
     angular.module("search.table.participants.model", [])
-        .value("SearchTableParticipantsModel", searchParticipantsModel);
+        .service("SearchTableParticipantsModel", SearchParticipantsModelService);
 }

--- a/app/scripts/search/templates/search.html
+++ b/app/scripts/search/templates/search.html
@@ -9,7 +9,7 @@
                  aggregations="sc.participants.aggregations"
                  data-doc-type="cases">
               </add-custom-facets-panel>
-              <facets-section facets-config="sc.SearchTableParticipantsModel.facets"
+              <facets-section facets-config="sc.SearchTableParticipantsModel.model().facets"
                               doctype="cases"
                               aggregations="sc.participants.aggregations">
               </facets-section>


### PR DESCRIPTION
**Motivation**

I needed to update the table models data category fields to match 'Title Case' as opposed to 'Sentence case' and realized this was going to be rather tedious due to the models being registered as `angular.value`. In order to share data I have turned project and case table models into services that return the model object. This way I can pass in `angular.constant` so that less busy work needs to be done to update.

As per @phuongmy this is not meant to be merged in yet until it has been thoroughly tested.

I think this will need some discussion, especially around naming. Types have also not been added to the services.
