### PR TITLE
fix(search): fix pagination not updating

### DIFF
--- a/app/scripts/query/query.controllers.ts
+++ b/app/scripts/query/query.controllers.ts
@@ -111,9 +111,10 @@ module ngApp.query.controllers {
         this.filesLoading = false;
         this.files = this.files || {};
         this.files.aggregations = data.aggregations;
+        this.files.pagination = data.pagination;
 
         if (!_.isEqual(this.files.hits, data.hits)) {
-          this.files = data;
+          this.files.hits = data.hits;
           this.tabSwitch = false;
           if (this.QState.tabs.files.active) {
             this.QState.setActive("files", "hasLoadedOnce");
@@ -129,9 +130,10 @@ module ngApp.query.controllers {
         this.participantsLoading = false;
         this.participants = this.participants || {};
         this.participants.aggregations = data.aggregations;
-
+        this.participants.pagination = data.pagination
+        
         if (!_.isEqual(this.participants.hits, data.hits)) {
-          this.participants = data;
+          this.participants.hits = data.hits;
           this.tabSwitch = false;
           if (this.QState.tabs.participants.active) {
             this.QState.setActive("participants", "hasLoadedOnce");

--- a/app/scripts/search/search.controllers.ts
+++ b/app/scripts/search/search.controllers.ts
@@ -143,9 +143,10 @@ module ngApp.search.controllers {
         this.filesLoading = false;
         this.files = this.files || {};
         this.files.aggregations = data.aggregations;
+        this.files.pagination = data.pagination;
 
         if (!_.isEqual(this.files.hits, data.hits)) {
-          this.files = data;
+          this.files.hits = data.hits;
           this.tabSwitch = false;
           if (this.SearchState.tabs.files.active) {
             this.SearchState.setActive("tabs", "files", "hasLoadedOnce");
@@ -161,9 +162,10 @@ module ngApp.search.controllers {
         this.participantsLoading = false;
         this.participants = this.participants || {};
         this.participants.aggregations = data.aggregations;
-
+        this.participants.pagination = data.pagination;
+        
         if (!_.isEqual(this.participants.hits, data.hits)) {
-          this.participants = data;
+          this.participants.hits = data.hits;
           this.tabSwitch = false;
           if (this.SearchState.tabs.participants.active) {
             this.SearchState.setActive("tabs", "participants", "hasLoadedOnce");


### PR DESCRIPTION
- We had an optimization that only updated the hits when they actually
  changed to reduce extra ajax request/processing but forgot exclude the
  pagination data. So anytime the first page of results didnt change the
  pagination data would update either.

Closes #2185
