### PR TITLE
fix(cart): 2113 dont clobber project ids

### DIFF
--- a/app/scripts/cart/cart.services.ts
+++ b/app/scripts/cart/cart.services.ts
@@ -340,7 +340,7 @@ module ngApp.cart.services {
           access: f.access,
           file_id: f.file_id,
           file_size: f.file_size,
-          projects: _.map(f.cases, c => c.project.project_id)
+          projects: f.projects || _.map(f.cases, c => c.project.project_id)
         }
       });
 


### PR DESCRIPTION
Closes #2113

sometimes the project_ids got clobbered in localstorage so the authorization chart became wrong, didn't have anything to do with the login.
