### PR TITLE
fix(app): 2307 scroll top unless has tabs

### DIFF
--- a/app/scripts/core/core.controller.ts
+++ b/app/scripts/core/core.controller.ts
@@ -34,7 +34,13 @@ module ngApp.core.controllers {
         this.$rootScope.$emit('ShowLoadingScreen');
       });
 
-      this.$rootScope.$on('$stateChangeSuccess', () => this.$rootScope.$emit('ClearLoadingScreen'));
+      this.$rootScope.$on("$stateChangeSuccess", (event, toState: any, toParams: any, fromState: any) => {
+        this.$rootScope.$emit('ClearLoadingScreen');
+        if (Object.keys(toState.data || {}).indexOf('tab') === -1) {
+          document.body.scrollTop = 0;
+          document.documentElement.scrollTop = 0;
+        }
+      });
 
       this.$rootScope.$on('ShowLoadingScreen', (data, throttleMs) => {
         this.loadingTimers.push(this.$timeout(() => this.showLoadingScreen(), throttleMs || 500));


### PR DESCRIPTION
Closes #2307

Previously on the pages with tabs, scrollTop was done unless the state change was from the same page (it was a tab change). This ticket additionally scrolls top for all state changes if there are no tabs.
