### PR TITLE
Feat/1222 id fields in custom facets

### DIFF
--- a/app/scripts/components/facets/facets.directives.ts
+++ b/app/scripts/components/facets/facets.directives.ts
@@ -54,7 +54,9 @@ module ngApp.components.facets.directives {
         field: "@",
         entity: "@",
         template: "@",
-        autocomplete: "@"
+        autocomplete: "@",
+        removeFunction: "&",
+        removable: "@",
       },
       replace: true,
       templateUrl: "components/facets/templates/facets-free-text.html",

--- a/app/scripts/components/facets/facets.services.ts
+++ b/app/scripts/components/facets/facets.services.ts
@@ -242,7 +242,6 @@ module ngApp.components.facets.services {
       return _.map(_.filter(data, (datum) => {
         return datum.doc_type === docType &&
                datum.field !== 'archive.revision' &&
-               !_.includes(datum.field, "_id") &&
                !_.includes(current, datum.field) &&
                !_.includes(docType === 'files'
                 ? _.pluck(this.SearchTableFilesModel.facets, "name")
@@ -316,11 +315,19 @@ module ngApp.components.facets.services {
     }
 
     addField(docType: string, fieldName: string, fieldType: string): void {
+      var facetType = 'terms';
+      if (_.includes(fieldName, 'datetime')) {
+        facetType = 'datetime';
+      } else if (_.some(['_id', '_uuid', 'md5sum'], a => _.includes(fieldName, a))) {
+        facetType = 'id';
+      } else if (fieldType === 'long') {
+        facetType = 'range';
+      }
       this.fieldsMap[docType].unshift({
           name: fieldName,
           title: fieldName,
           collapsed: false,
-          facetType: fieldType === 'long' ? 'range' : _.includes(fieldName, 'datetime') ? 'datetime' : 'terms',
+          facetType: facetType,
           removable: true
       });
       this.save();

--- a/app/scripts/components/facets/templates/facets-free-text.html
+++ b/app/scripts/components/facets/templates/facets-free-text.html
@@ -8,7 +8,7 @@
       role="button"
       for="{{ 'autocomplete-' + title }}"
     >
-      <i class="fa" data-ng-class="{ 'fa-angle-down': !ftc.collapsed, 'fa-angle-right': ftc.collapsed }"></i>
+    <i class="fa" data-ng-class="{ 'fa-angle-down': !ftc.collapsed, 'fa-angle-right': ftc.collapsed }"></i>
       {{ title | translate }}
     </label>
     <span class="pull-right">
@@ -16,9 +16,12 @@
         data-ng-if="ftc.actives.length"
         data-ng-click="ftc.clear()"
       ></i>
+      <i class="fa fa-times"
+        data-ng-if="removable === 'true'"
+        data-ng-click="removeFunction()"
+      ></i>
     </span>
   </h4>
-
   <p class="text-success facet-title" data-ng-repeat="active in ftc.actives">
     <span data-ng-click="ftc.remove(active)"
           data-ng-keypress="ftc.remove(active)">
@@ -30,7 +33,7 @@
   <div>
   </div>
   <div class="input-group" data-ng-if="!ftc.collapsed">
-    <span class="input-group-addon">
+    <span data-ng-if="ftc.autocomplete" class="input-group-addon">
       <span class="fa fa-search"></span>
     </span>
     <input data-ng-if="ftc.autocomplete"
@@ -47,15 +50,12 @@
            style="border-radius: 0px;">
     <input data-ng-if="!ftc.autocomplete"
            type="text" data-ng-model="ftc.searchTerm"
-           placeholder="{{ 'Search for' | translate }} {{ placeholder | translate }}"
-           data-uib-typeahead="id for id in ['autocomplete not supported']"
-           data-typeahead-on-select="ftc.termSelected(false)"
-           data-typeahead-template-url="components/facets/templates/typeahead-not-supported.html"
+           placeholder="{{ 'Enter' | translate }} {{ placeholder | translate }}"
            data-ng-change="ftc.saveInput()"
            maxlength="100"
-           id="{{ 'autocomplete-' + title }}"
+           id="{{ 'input-' + title }}"
            class="form-control"
-           style="border-radius: 0px;">
+           style="">
     <span class="input-group-btn" data-ng-if="!ftc.autocomplete">
       <button class="btn btn-default" type="button" data-ng-click="ftc.setTerm()" data-ng-class="{'disabled' : ftc.searchTerm === ''}">Go!</button>
     </span>

--- a/app/scripts/components/facets/templates/facets-section.html
+++ b/app/scripts/components/facets/templates/facets-section.html
@@ -1,15 +1,28 @@
 <div data-ng-repeat="f in facetsConfig track by f.title">
   <facets-free-text data-ng-if="f.facetType === 'free-text'"
-                  data-title="{{f.title}}" placeholder="{{ f.placeholder | translate }}"
+                  data-title="{{ f.title | facetTitlefy }}"
+                  placeholder="{{ f.name | facetTitlefy }}"
                   data-field="{{doctype}}.{{f.name}}"
                   data-entity="{{doctype}}"
+                  data-removable="{{ f.removable }}"
+                  data-remove-function="removeFacet(f.name)"
                   data-template="components/facets/templates/typeahead-{{doctype}}.html"></facets-free-text>
 
-  <facets-prefix data-ng-if="f.facetType === 'free-text' && doctype === 'cases'"
-                  data-title="Case Submitter ID Prefix" placeholder="e.g. TCGA-DD*"
-                  data-field="cases.submitter_id"
-                  data-entity="cases"
-                  data-template="components/facets/templates/typeahead-prefix.html"></facets-prefix>
+  <facets-free-text data-ng-if="f.facetType === 'id'"
+                  data-title="{{ f.title | facetTitlefy }}"
+                  placeholder="{{ f.name | humanify }}"
+                  data-field="{{doctype}}.{{f.name}}"
+                  data-entity="{{doctype}}"
+                  data-removable="{{ f.removable }}"
+                  data-autocomplete="{{false}}"
+                  data-remove-function="removeFacet(f.name)"></facets-free-text>
+
+  <facets-prefix data-ng-if="f.facetType === 'prefix'"
+                 data-title="{{ f.title | facetTitlefy }}"
+                 placeholder="{{ f.name | facetTitlefy }}"
+                 data-field="{{doctype}}.{{f.name}}"
+                 data-entity="{{doctype}}"
+                 data-template="components/facets/templates/typeahead-prefix.html"></facets-prefix>
 
   <terms data-ng-if="f.facetType === 'terms'"
          data-name="{{doctype}}.{{f.name}}"

--- a/app/scripts/search/search.cases.table.service.ts
+++ b/app/scripts/search/search.cases.table.service.ts
@@ -214,6 +214,7 @@ module ngApp.search.cases.table.service {
           ],
           facets: [
             {name: "case_id", title: "Case", collapsed: false, facetType: "free-text", placeholder: "UUID, Submitter ID"},
+            {name: "submitter_id", title: "Case Submitter ID Prefix", collapsed: false, facetType: "prefix", placeholder: "e.g. TCGA-DD*"},
             {name: "project.primary_site", title: "Primary Site", collapsed: false, facetType: "terms"},
             {name: "project.program.name", title: "Cancer Program", collapsed: false, facetType: "terms"},
             {name: "project.project_id", title: "Project", collapsed: false, facetType: "terms"},


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1314446/15832813/e4aebf8e-2bf1-11e6-9e9c-8234699593ab.png)
forgot about facet-free-text already having a autocomplete false option, reusing that. 

todo:
- [x] remove autocomplete not supported
- [x] remove 🔍
- ~~don't disallow *~~ nvm, * breaks OR
- ~~time travel btn~~ part of new ticket 2578