### PR TITLE
fix(manifest): API-58 remove fields parameter from manifest download

### DIFF
--- a/app/scripts/files/files.directives.ts
+++ b/app/scripts/files/files.directives.ts
@@ -271,7 +271,6 @@ module ngApp.files.directives {
             size: $scope.size,
             attachment: true,
             format: 'TSV',
-            fields: [ 'file_id' ],
             filters: $scope.projectId // on project page
               ? {
                   op: 'in',


### PR DESCRIPTION
Manifest fields are strictly defined within https://github.com/NCI-GDC/gdcapi/blob/fbad1249370c2a7eaa2fb1c5c58292be8fbda75a/gdcapi/download/utils.py

Tested in dev, doesn't seem to break anything, but...

r? @NCI-GDC/oicrdevs 