### PR TITLE
:bug: improve loading of project list viz

### DIFF
--- a/app/react-components/Projects.js
+++ b/app/react-components/Projects.js
@@ -27,7 +27,7 @@ let Projects = (() => {
     },
   };
 
-  return ({ projects = [], genes = [], FacetService, isFetching }) => {
+  return ({ projects = [], genes = [], FacetService, isFetching, projectsIsFetching, genesIsFetching }) => {
     const actives = FacetService.getActiveIDs('project_id');
     const projectIds = projects.map(p => p.project_id);
     const stackedBarData = genes.map(g => ({
@@ -44,7 +44,7 @@ let Projects = (() => {
       <Row>
         <Column style={{width: '70%', paddingRight: '10px', minWidth: '450px'}}>
           <h4 style={{alignSelf: 'center'}}>Top Mutated Genes in Selected Projects</h4>
-          { !isFetching ?
+          { !genesIsFetching ?
             (<Measure>
               {({width}) => (
               <StackedBarChart
@@ -66,7 +66,7 @@ let Projects = (() => {
         </Column>
         <Column style={{width: '30%', minWidth: '200px'}}>
           <h4 style={{alignSelf: 'center'}}>Case Distribution per Project</h4>
-          { !isFetching ?
+          { !projectsIsFetching ?
             (<PieChart
               key='chart'
               data={projects.map(p => ({

--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -65,23 +65,24 @@ module ngApp.projects.controllers {
       $scope.tableConfig = this.ProjectsTableService.model();
 
       this.refresh();
-      this.renderReact({ projects: [], genes: [], isFetching: true });
     }
 
-    renderReact({ projects, genes, isFetching }: { projects: Array<Object>, genes: Array<Object>, isFetching: boolean }) {
+    renderReact({ projects, genes, projectsIsFetching, genesIsFetching }: { projects: Array<Object>, genes: Array<Object>, projectsIsFetching: boolean, genesIsFetching: boolean  }) {
       ReactDOM.render(
       React.createElement(ReactComponents.Projects, {
         projects: projects || [],
         genes: genes || [],
         FacetService: this.FacetService,
-        isFetching: isFetching,
-      }), document.getElementById('react-root')
+        projectsIsFetching: projectsIsFetching,
+        genesIsFetching: genesIsFetching,
+      }), document.getElementById('react-projects-root')
       );
     };
 
     refresh() {
       this.loading = true;
       this.$rootScope.$emit('ShowLoadingScreen');
+      this.renderReact({ projects: [], genes: [], projectsIsFetching: true, genesIsFetching: true });
       var projectsTableModel = this.ProjectsTableService.model();
       if (!this.tabSwitch) {
         this.ProjectsService.getProjects({
@@ -92,6 +93,7 @@ module ngApp.projects.controllers {
           this.loading = false;
           this.$rootScope.$emit('ClearLoadingScreen');
           this.projects = data;
+          this.renderReact({ projects: this.projects.hits, genes: [], projectsIsFetching: false, genesIsFetching: true });
           if (this.ProjectsState.tabs.graph.active) {
             this.drawGraph(this.projects);
           } else if(this.ProjectsState.tabs.summary.active || this.numPrimarySites === 0) {
@@ -129,7 +131,7 @@ module ngApp.projects.controllers {
              }
            }).then(data => {
             const genes = (data.data.hits.hits || []).map(g => g._source);
-            this.renderReact({ projects: this.projects.hits, genes: genes, isFetching: false });
+            this.renderReact({ projects: this.projects.hits, genes: genes, projectsIsFetching: false, genesIsFetching: false });
           });
         });
       } else {

--- a/app/scripts/projects/templates/projects.html
+++ b/app/scripts/projects/templates/projects.html
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div id="react-root">
+      <div id="react-projects-root">
       </div>
 
       <h3 class="col-lg-9 col-md-8" data-ng-if="!prsc.projects.hits.length && !prsc.loading" data-translate>


### PR DESCRIPTION
- 2nd fetch: reshows spinner
- seperate isFetching state for each chart
- change id of react root so if user navigates away to another page in the middle of a
  fetch, the current react root isn't replaced by the charts.

noticed these things when testing on the vm. r?