### PR TITLE
Feat/418 most affected cases

### DIFF
--- a/app/react-components/Gene.js
+++ b/app/react-components/Gene.js
@@ -13,6 +13,7 @@ import CountCard from './components/CountCard';
 import ProteinLolliplotComponent from './components/ProteinLolliplot';
 import FrequentMutations from './components/FrequentMutations';
 import { ExternalLink } from './uikit/Links';
+import Tooltip from './uikit/Tooltip';
 import BarChart from './charts/BarChart';
 import theme from './theme';
 import externalReferenceLinks from './utils/externalReferenceLinks';
@@ -288,8 +289,12 @@ let Gene = (() => {
                   { key: 'project_id', title: 'Project ID' },
                   { key: 'disease_type', title: 'Disease Type' },
                   { key: 'site', title: 'Site' },
-                  { key: 'num_affected_cases', title: '# Affected Cases', tooltip: `Number of Cases where ${gene.symbol} contains SSM`},
-                  { key: 'num_mutations', title: '# Mutations', tooltip: `Number of SSM observed in ${gene.symbol}`},
+                  { key: 'num_affected_cases',
+                    title: <Tooltip innerHTML={`Number of Cases where ${gene.symbol} contains SSM`}># Affected Cases</Tooltip>
+                  },
+                  { key: 'num_mutations',
+                    title: <Tooltip innerHTML={`Number of SSM observed in ${gene.symbol}`}># Mutations</Tooltip>
+                  }
                 ]}
                 data={sortedCancerDistData.map(
                   d => ({

--- a/app/react-components/Project.js
+++ b/app/react-components/Project.js
@@ -11,6 +11,7 @@ import EntityPageHorizontalTable from './components/EntityPageHorizontalTable';
 import CountCard from './components/CountCard';
 import DownloadButton from './components/DownloadButton';
 import FrequentMutations from './components/FrequentMutations';
+import MostAffectedCases from './components/MostAffectedCases';
 import makeFilter from './utils/makeFilter';
 import SummaryCard from './components/SummaryCard';
 import BarChart from './charts/BarChart';
@@ -93,6 +94,7 @@ const Project = ({
   esHost,
   mutatedGenesProject,
   numCasesAggByProject,
+  mostAffectedCases,
   frequentMutations: fm,
   survivalData,
   setSurvivalGene,
@@ -403,7 +405,7 @@ const Project = ({
                 ...g,
                 symbol: <a href={`/genes/${g.gene_id}`}>{g.symbol}</a>,
                 survivalId: g.symbol,
-                geneSymbol: g.symbol,
+                cytoband: g.cytoband.join(', '),
                 num_affected_cases_project: `${g.num_affected_cases_project} (${(g.num_affected_cases_project/numCasesAggByProject[project.project_id]*100).toFixed(2)}%)`,
                 num_affected_cases_all:
                   <TogglableUl
@@ -440,6 +442,17 @@ const Project = ({
           project={$scope.project.project_id}
           survivalData={survivalData}
           width={width}
+        />
+      </Column>
+      <Column style={{...styles.card, marginTop: `2rem` }}>
+        <h1 style={{...styles.heading, padding: `1rem`}} id="most-affected-cases">
+          <i className="fa fa-bar-chart-o" style={{ paddingRight: `10px` }} />
+          Most Affected Cases
+        </h1>
+
+        <MostAffectedCases
+          mostAffectedCases={_.sortBy(mostAffectedCases, c => c.gene.length).reverse()}
+          project={$scope.project.project_id}
         />
       </Column>
     </span>

--- a/app/react-components/components/EntityPageHorizontalTable.js
+++ b/app/react-components/components/EntityPageHorizontalTable.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import _ from 'lodash';
 
 import { Row, Column } from '../uikit/Flex';
 import theme from '../theme';
@@ -55,19 +56,15 @@ const EntityPageHorizontalTable = ({ style, title, titleStyle, rightComponent, h
         <Table
           style={styles.table}
           headings={headings.map(h => (
-            <Th key={h.key || h.value}>
-              {h.tooltip && 
-                <Tooltip innerHTML={h.tooltip}>
-                  {h.title}
-                </Tooltip>
-              }
-              {!h.tooltip &&
-                <span>
-                  {h.title}
-                </span>
-              }
+            <Th
+              rowSpan={h.subheadings ? 1 : 2}
+              colSpan={h.subheadings ? h.subheadings.length : 1}
+              key={h.key || h.value}
+            >
+              {h.title}
             </Th>
           ))}
+          subheadings={headings.map(h => h.subheadings && h.subheadings.map((s, i) => <Th key={`subheading-${i}`}>{s}</Th>))}
           body={
             <tbody>
               {data.map((d, i) => {
@@ -82,12 +79,12 @@ const EntityPageHorizontalTable = ({ style, title, titleStyle, rightComponent, h
                   {headings.map(h => {
                     const value = typeof d[h.key] !== 'undefined' ? d[h.key] : h.value;
 
-                    return (
-                      <Td key={h.key || h.value} style={h.style || {}}>
-                        {h.color && <div className="item-color" style={{ backgroundColor: colors(i) }} />}
-                        {h.onClick && value ? <a onClick={() => h.onClick(d)}>{value}</a> : (value || '--')}
-                      </Td>
-                    );
+                    const makeTd = (v, i) => (<Td key={`${h.key}-${i}`} style={h.style || {}}>
+                        {h.color && <div className="h-color" style={{ backgroundColor: colors(i) }} />}
+                        {h.onClick && v? <a onClick={() => h.onClick(d)}>{v}</a> : (v|| '--')}
+                      </Td>);
+
+                    return _.isArray(value) ? value.map((v, i) => makeTd(v, i)) : makeTd(value);
                   })}
                   </Tr>);
               })}

--- a/app/react-components/components/MostAffectedCases.js
+++ b/app/react-components/components/MostAffectedCases.js
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import Column from '../uikit/Flex/Column';
+import Row from '../uikit/Flex/Row';
+import BarChart from '../charts/BarChart';
+import theme from '../theme';
+import EntityPageHorizontalTable from './EntityPageHorizontalTable';
+import ageDisplay from '../utils/ageDisplay';
+import { DATA_CATEGORIES } from '../utils/constants';
+import Tooltip from '../uikit/Tooltip';
+import makeFilter from '../utils/makeFilter';
+
+let MostAffectedCases = ({
+  mostAffectedCases,
+  project
+}) => (
+  <Column>
+    {!!mostAffectedCases.length &&
+      <div>
+        <div style={{ padding: `0 2rem` }}>
+          <BarChart
+            data={mostAffectedCases.map(c => ({
+              label: `${c.case_id.substring(0, 14)}\u2026`,
+              value: c.gene.length,
+              tooltip: `${c.case_id}<br />${c.gene.length} Genes Affected`,
+              href: `cases/${c.case_id}`
+            }))}
+            margin={{ top: 30, right: 50, bottom: 105, left: 30 }}
+            height={250}
+            yAxis={{ title: '# Genes Affected' }}
+            styles={{
+              xAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
+              yAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
+              bars: {fill: theme.secondary},
+              tooltips: {
+                fill: '#fff',
+                stroke: theme.greyScale4,
+                textFill: theme.greyScale3
+              }
+            }}
+          />
+        </div>
+
+        <EntityPageHorizontalTable
+          headings={[
+            { key: 'id', title: 'UUID' },
+            { key: 'primary_site', title: 'Site' },
+            { key: 'gender', title: 'Gender' },
+            { key: 'age_at_diagnosis', title: 'Age at Diagnosis'},
+            { key: 'tumor_stage', title: 'Stage'},
+            { key: 'days_to_death',
+              title: <Tooltip innerHTML='Survival (days)'>Survival</Tooltip>
+            },
+            { key: 'days_to_last_follow_up',
+              title: <Tooltip innerHTML='Days to Last Follow Up'>Last Follow<br />Up</Tooltip>},
+            { key: 'data_types',
+              title: 'Available Files per Data Category',
+              subheadings: Object.keys(DATA_CATEGORIES).map(
+                k => (
+                  <abbr key={DATA_CATEGORIES[k].abbr}>
+                    <Tooltip innerHTML={DATA_CATEGORIES[k].full}>
+                      {DATA_CATEGORIES[k].abbr}
+                    </Tooltip>
+                  </abbr>)
+              )
+            },
+            { key: 'num_mutations', title: '#Mutations'},
+            { key: 'num_genes', title: '#Genes'},
+          ]}
+          data={mostAffectedCases.map(c => {
+            const dataCategorySummary = c.summary.data_categories.reduce((acc, c) => ({ ...acc, [c.data_category]: c.file_count }), {});
+            return {
+              id: <a href={`/cases/${c.case_id}`}>{c.case_id}</a>,
+              primary_site: c.project.primary_site,
+              gender: c.demographic.gender,
+              age_at_diagnosis: ageDisplay(c.diagnoses[0].age_at_diagnosis),
+              tumor_stage: c.diagnoses[0].tumor_stage,
+              days_to_last_follow_up: c.diagnoses[0].days_to_last_follow_up,
+              num_mutations: c.gene.reduce((sum, g) => sum + g.ssm.length, 0),
+              num_genes: c.gene.length,
+              data_types: Object.keys(DATA_CATEGORIES).map(k => (
+                dataCategorySummary[DATA_CATEGORIES[k].full] ?
+                  <a href={
+                    `/search/f?filters=${ makeFilter([
+                      { field: 'cases.case_id', value: c.case_id},
+                      { field: 'files.data_category', value: DATA_CATEGORIES[k].full},
+                    ]) }`
+                  }>{dataCategorySummary[DATA_CATEGORIES[k].full]}</a> :
+                  '--'
+              )
+            )};
+          })}
+        />
+      </div>
+    }
+    {!mostAffectedCases.length &&
+      <span style={{padding: `2rem`}}>No most affected case data to display</span>
+    }
+  </Column>
+);
+
+export default MostAffectedCases;

--- a/app/react-components/uikit/Table/Table.js
+++ b/app/react-components/uikit/Table/Table.js
@@ -14,12 +14,15 @@ const styles = {
   },
 };
 
-const Table = ({ style, body, headings, ...props }) => (
+const Table = ({ style, body, headings, subheadings, ...props }) => (
   <table style={{ ...styles.table, ...style }} {...props}>
     <thead>
       <Tr>
         {headings}
       </Tr>
+      {subheadings && <Tr>
+        {subheadings}
+      </Tr>}
     </thead>
     {body}
   </table>

--- a/app/react-components/utils/ageDisplay.js
+++ b/app/react-components/utils/ageDisplay.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+
+export default (ageInDays: number, yearsOnly: boolean = false, defaultValue: string = '--'): string => {
+  const oneYear = 365.25;
+  const leapThenPair = (years: number, days: number): number[] => (days === 365) ? [years + 1, 0] : [years, days];
+  const timeString = (number: number, singular: string, plural: string): string => {
+    const pluralChecked = plural ? plural : `${singular}s`;
+    return `${number} ${number === 1 ? singular : pluralChecked}`;
+  };
+  const _timeString = _.spread(timeString);
+
+  if (!ageInDays) {
+    return defaultValue;
+  }
+  return _.zip(leapThenPair(Math.floor(ageInDays / oneYear), Math.ceil(ageInDays % oneYear)), ['year', 'day'])
+  .filter(p => yearsOnly ? p[1] === 'year' : p[0] > 0)
+  .map(p => !yearsOnly ? _timeString(p) : p[0])
+  .join(' ')
+  .trim();
+};

--- a/app/react-components/utils/constants.js
+++ b/app/react-components/utils/constants.js
@@ -1,0 +1,8 @@
+export const DATA_CATEGORIES = {
+  SEQ: { full: "Raw Sequencing Data", abbr: "Seq" },
+  EXP: { full: "Transcriptome Profiling", abbr: "Exp" },
+  SNV: { full: "Simple Nucleotide Variation", abbr: "SNV" },
+  CNV: { full: "Copy Number Variation", abbr: "CNV" },
+  CLINICAL: { full: "Clinical", abbr: "Clinical" },
+  BIOSPECIMEN: { full: "Biospecimen", abbr: "Bio" },
+};

--- a/app/scripts/projects/module.ts
+++ b/app/scripts/projects/module.ts
@@ -99,6 +99,43 @@ module ngApp.projects {
           });
 
         },
+        mostAffectedCases: (
+          $stateParams: ng.ui.IStateParamsService,
+          $http: ng.IHttpService,
+          config: IGDCConfig
+        ): ng.IPromise => {
+          return $http({
+            method: 'POST',
+            url: `${config.es_host}/${config.es_index_version}-case-centric/case-centric/_search`,
+            headers: {'Content-Type' : 'application/json'},
+            data: {
+              "post_filter": {
+                "terms": {
+                  "project.project_id": [$stateParams["projectId"]]
+                }
+              },
+              "query": {
+                "nested": {
+                  "path": "gene",
+                  "score_mode": "sum",
+                  "query": {
+                    "function_score": {
+                      "query": {
+                        "match_all": {}
+                      },
+                      "boost_mode": "replace",
+                      "script_score": {
+                        "script": "doc['gene.ssm.ssm_id'].empty ? 0 : 1"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }).then(data => {
+            return data.data.hits.hits;
+          });
+        },
         frequentMutations: (
           $stateParams: ng.ui.IStateParamsService,
           $http: ng.IHttpService,

--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -205,6 +205,7 @@ module ngApp.projects.controllers {
       public mutatedGenesProject: Array<Object>,
       public numCasesAggByProject: Array<Object>,
       public frequentMutations: Array<Object>,
+      public mostAffectedCases: Array<Object>,
       public survivalData: Array<Object>,
       private CoreService: ICoreService,
       private AnnotationsService: IAnnotationsService,
@@ -432,6 +433,7 @@ module ngApp.projects.controllers {
               { icon: 'bar-chart-o', title: 'Mutated Genes', id: 'mutated-genes' },
               { icon: 'th', title: 'OncoGrid', id: 'oncogrid' },
               { icon: 'bar-chart-o', title: 'Frequent Mutations', id: 'frequent-mutations' },
+              { icon: 'bar-chart-o', title: 'Most Affected Cases', id: 'most-affected-cases' },
             ],
             title: this.project.project_id,
             entityType: 'PR',
@@ -444,6 +446,7 @@ module ngApp.projects.controllers {
             esHost: this.CoreService.config.es_host,
             frequentMutations: this.frequentMutations.map(g => Object.assign({}, g._source, { score: g._score })),
             survivalData: this.survivalData,
+            mostAffectedCases: this.mostAffectedCases.map(c => c._source),
           })
         ),
         document.getElementById('react-root')


### PR DESCRIPTION
<img width="1098" alt="screen shot 2016-11-22 at 2 35 38 pm" src="https://cloud.githubusercontent.com/assets/1314446/20538883/0f02c75e-b0c1-11e6-81f9-4bd937ffd407.png">

- move over ageDisplay and DATA_CATEGORIES from angular code
- add subheadings capability to Table

based off https://github.com/NCI-GDC/portal-ui/pull/1144

todos
- [x] link available data types
- [x] ellipsis on y-axis
- [x] survival/days to death cols match spec