### PR TITLE
:sparkles: Pagination uikit components

### DIFF
--- a/app/react-components/.eslintrc
+++ b/app/react-components/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": ['@knit/socks-react'],
   "rules": {
+    "arrow-body-style": 0,
     "camelcase": 0,
     "flowtype/require-valid-file-annotation": 0,
     "flowtype/require-return-type": 0,

--- a/app/react-components/Project.js
+++ b/app/react-components/Project.js
@@ -335,13 +335,14 @@ const Project = ({
                   <BarChart
                     data={mutatedGenesChartData.map(g => ({
                       label: g.symbol,
-                      value: (g.num_affected_cases_project / numCasesAggByProject[project.project_id] * 100),
+                      value: ((g.num_affected_cases_project / numCasesAggByProject[project.project_id]) * 100),
                       tooltip: `<b>${g.symbol}</b><br />
                         ${g.num_affected_cases_project} Case${g.num_affected_cases_project > 1 ? 's' : ''}
                         Affected in ${project.project_id}<br />
                         ${g.num_affected_cases_project} / ${numCasesAggByProject[project.project_id]}
-                        ${(g.num_affected_cases_project / numCasesAggByProject[project.project_id] * 100).toFixed(2)}%`,
-                      href: `genes/${g.gene_id}`
+                        ${((g.num_affected_cases_project / numCasesAggByProject[project.project_id]) * 100)
+                          .toFixed(2)}%`,
+                      href: `genes/${g.gene_id}`,
                     }))}
                     title='Distribution of Most Frequently Mutated Genes'
                     yAxis={{ title: '% of Cases Affected' }}
@@ -353,8 +354,8 @@ const Project = ({
                       tooltips: {
                         fill: '#fff',
                         stroke: theme.greyScale4,
-                        textFill: theme.greyScale3
-                      }
+                        textFill: theme.greyScale3,
+                      },
                     }}
                   />
                 </Row>
@@ -384,7 +385,7 @@ const Project = ({
                 {
                   key: 'num_affected_cases_all',
                   title: <span># Affected Cases<br /> Across all Projects</span>,
-                  style: { minWidth: '210px' }
+                  style: { minWidth: '210px' },
                 },
                 {
                   key: 'num_mutations',

--- a/app/react-components/Project.js
+++ b/app/react-components/Project.js
@@ -142,7 +142,7 @@ const Project = ({
 
   const totalNumCases = Object.keys(numCasesAggByProject).reduce((sum, b) => sum + numCasesAggByProject[b], 0);
 
-  const frequentMutations = fm.map(x => {
+  const frequentMutations = fm.hits.map(g => Object.assign({}, g._source, { score: g._score })).map(x => {
     let consequence = x.consequence.find(x => x.transcript.is_canonical);
 
     return {
@@ -482,6 +482,7 @@ const Project = ({
           project={$scope.project.project_id}
           survivalData={survivalData}
           width={width}
+          total={fm.total}
         />
       </Column>
       <Column style={{...styles.card, marginTop: `2rem` }}>

--- a/app/react-components/Project.js
+++ b/app/react-components/Project.js
@@ -8,12 +8,11 @@ import _ from 'lodash';
 // Custom
 import Column from './uikit/Flex/Column';
 import Row from './uikit/Flex/Row';
-import { PaginationContainer } from './uikit/Pagination';
 import EntityPageVerticalTable from './components/EntityPageVerticalTable';
 import EntityPageHorizontalTable from './components/EntityPageHorizontalTable';
 import CountCard from './components/CountCard';
 import DownloadButton from './components/DownloadButton';
-import FrequentMutations from './components/FrequentMutations';
+import FrequentMutationsContainer from './components/FrequentMutationsContainer';
 import MostAffectedCases from './components/MostAffectedCases';
 import makeFilter from './utils/makeFilter';
 import SummaryCard from './components/SummaryCard';
@@ -73,14 +72,8 @@ const styles = {
     overflow: 'hidden',
   },
   card: {
-    backgroundColor: `white`,
+    backgroundColor: 'white',
   },
-};
-
-let impactColors = {
-  HIGH: 'rgb(185, 36, 36)',
-  MODERATE: 'rgb(193, 158, 54)',
-  LOW: 'rgb(49, 161, 60)',
 };
 
 function buildFilters(data) {
@@ -104,7 +97,6 @@ const Project = ({
   mutatedGenesProject,
   numCasesAggByProject,
   mostAffectedCases,
-  frequentMutations: fm,
   survivalData,
   setSurvivalGene,
   survivalGene,
@@ -141,39 +133,6 @@ const Project = ({
 
   const totalNumCases = Object.keys(numCasesAggByProject).reduce((sum, b) => sum + numCasesAggByProject[b], 0);
 
-  const frequentMutations = fm.hits.map(g => Object.assign({}, g._source, { score: g._score })).map(x => {
-    const consequence = x.consequence.find(c => c.transcript.is_canonical);
-
-    return {
-      ...x,
-      num_affected_cases_project: x.occurrence.filter(o =>
-        o.case.project.project_id === $scope.project.project_id
-      ).length,
-      num_affected_cases_by_project: x.occurrence.reduce((acc, o) => ({
-        ...acc,
-        [o.case.project.project_id]: acc[o.case.project.project_id] ? acc[o.case.project.project_id] + 1 : 1,
-      }), {}),
-      num_affected_cases_all: x.occurrence.length,
-      impact: consequence.transcript.annotation.impact,
-      consequence_type: (
-        <span>
-          <b>{_.startCase(consequence.transcript.consequence_type.replace('variant', ''))}</b>
-          <span style={{ marginLeft: '5px' }}>
-            <a href={`/genes/${consequence.transcript.gene.gene_id}`}>{consequence.transcript.gene_symbol}</a>
-          </span>
-          <span
-            style={{
-              marginLeft: '5px',
-              color: impactColors[consequence.transcript.annotation.impact] || 'inherit',
-            }}
-          >
-            {consequence.transcript.aa_change}
-          </span>
-        </span>
-      ),
-    };
-  });
-
   return (
     <span>
       <Row style={{ ...styles.margin, flexDirection: 'row-reverse' }}>
@@ -201,7 +160,8 @@ const Project = ({
 
         <Tooltip
           dir="down"
-          innerHTML="Download a manifest for use with the GDC Data Transfer Tool. The GDC Data Transfer Tool is recommended for transferring large volumes of data."
+          innerHTML={`Download a manifest for use with the GDC Data Transfer Tool.
+            The GDC Data Transfer Tool is recommended for transferring large volumes of data.`}
           maxWidth="250px"
         >
           <DownloadButton
@@ -255,7 +215,7 @@ const Project = ({
           <CountCard
             title="FILES"
             count={project.summary.file_count.toLocaleString()}
-            icon={<FileIcon style={styles.icon}  className="fa-3x" />}
+            icon={<FileIcon style={styles.icon} className="fa-3x" />}
             style={styles.countCard}
             onCountClick={() => {
               window.location = `/search/f?filters=${
@@ -352,26 +312,26 @@ const Project = ({
       </Row>
 
       <Column style={styles.card}>
-        <h1 style={{ ...styles.heading, padding: `1rem` }} id="mutated-genes">
-          <i className="fa fa-bar-chart-o" style={{ paddingRight: `10px` }} />
+        <h1 style={{ ...styles.heading, padding: '1rem' }} id="mutated-genes">
+          <i className="fa fa-bar-chart-o" style={{ paddingRight: '10px' }} />
           Most Frequently Mutated Genes
         </h1>
-        <Row style={{paddingBottom: '2.5rem'}}>
+        <Row style={{ paddingBottom: '2.5rem' }}>
           <span>
-            <div style={{textAlign: 'right', marginRight: 50, marginLeft: 30}}>
+            <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>
               <DownloadVisualizationButton
                 disabled={!mutatedGenesChartData.length}
                 svg="#mutated-genes-chart svg"
                 data={mutatedGenesChartData}
                 slug="bar-chart"
-                noText={true}
                 tooltipHTML="Download image or data"
+                noText
               />
             </div>
 
             {!!mutatedGenesChartData.length &&
               <div id="mutated-genes-chart">
-                <Row style={{ padding: `0 2rem` }}>
+                <Row style={{ padding: '0 2rem' }}>
                   <BarChart
                     data={mutatedGenesChartData.map(g => ({
                       label: g.symbol,
@@ -387,9 +347,9 @@ const Project = ({
                     yAxis={{ title: '% of Cases Affected' }}
                     height={240}
                     styles={{
-                      xAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
-                      yAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
-                      bars: {fill: theme.secondary},
+                      xAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+                      yAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+                      bars: { fill: theme.secondary },
                       tooltips: {
                         fill: '#fff',
                         stroke: theme.greyScale4,
@@ -419,11 +379,11 @@ const Project = ({
                 { key: 'cytoband', title: 'Cytoband' },
                 {
                   key: 'num_affected_cases_project',
-                  title: (<span># Affected Cases<br /></span>),
+                  title: <span># Affected Cases<br /></span>,
                 },
                 {
                   key: 'num_affected_cases_all',
-                  title: (<span># Affected Cases<br /> Across all Projects</span>),
+                  title: <span># Affected Cases<br /> Across all Projects</span>,
                   style: { minWidth: '210px' }
                 },
                 {
@@ -435,32 +395,39 @@ const Project = ({
                   title: <i className="fa fa-bar-chart-o"><div style={styles.hidden}>add to survival plot</div></i>,
                   key: 'survival_plot',
                   style: { textAlign: 'center', width: '55px' },
-                }
+                },
               ]}
               data={mutatedGenesChartData.map(g => ({
                 ...g,
                 symbol: <a href={`/genes/${g.gene_id}`}>{g.symbol}</a>,
                 survivalId: g.symbol,
                 cytoband: (g.cytoband || []).join(', '),
-                num_affected_cases_project: `${g.num_affected_cases_project}/${numCasesAggByProject[project.project_id]} (${(g.num_affected_cases_project/numCasesAggByProject[project.project_id]*100).toFixed(2)}%)`,
-                num_affected_cases_all:
+                num_affected_cases_project:
+                  `${g.num_affected_cases_project} / ${numCasesAggByProject[project.project_id]}
+                  (${((g.num_affected_cases_project / numCasesAggByProject[project.project_id]) * 100).toFixed(2)}%)`,
+                num_affected_cases_all: (
                   <TogglableUl
-                    items={[`${g.num_affected_cases_all}/${totalNumCases} (${(g.num_affected_cases_all/totalNumCases * 100).toFixed(2)}%)`,
+                    items={[
+                      `${g.num_affected_cases_all}/${totalNumCases}
+                      (${((g.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)`,
                       ...Object.keys(g.num_affected_cases_by_project)
-                        .map(k =>
-                          (`${k}: ${g.num_affected_cases_by_project[k]}/${numCasesAggByProject[k]} (${(g.num_affected_cases_by_project[k]/numCasesAggByProject[k]* 100).toFixed(2)}%)`))
+                        .map(k => `
+                          ${k}: ${g.num_affected_cases_by_project[k]} / ${numCasesAggByProject[k]}
+                          (${((g.num_affected_cases_by_project[k] / numCasesAggByProject[k]) * 100).toFixed(2)}%)`),
                     ]}
-                  />,
-                survival_plot:
+                  />
+                ),
+                survival_plot: (
                   <Tooltip innerHTML={`Add ${g.symbol} to surival plot`}>
-                    <span
+                    <button
                       onClick={d => setSurvivalGene(d === survivalGene ? null : d)}
                     >
                       <span className={`fa fa-bar-chart-o ${clickable}`}>
                         <div style={styles.hidden}>add to survival plot</div>
                       </span>
-                    </span>
+                    </button>
                   </Tooltip>
+                ),
               }))}
             />
           }
@@ -468,33 +435,32 @@ const Project = ({
         </Column>
       </Column>
 
-      <Column style={{...styles.card, marginTop: `2rem`, position: 'static' }}>
-        <h1 style={{...styles.heading, padding: `1rem` }} id="oncogrid">
-          <i className="fa fa-th" style={{ paddingRight: `10px` }} />
+      <Column style={{ ...styles.card, marginTop: '2rem', position: 'static' }}>
+        <h1 style={{ ...styles.heading, padding: '1rem' }} id="oncogrid">
+          <i className="fa fa-th" style={{ paddingRight: '10px' }} />
           OncoGrid
         </h1>
         <OncoGridWrapper width={width} projectId={project.project_id} esHost={esHost} esIndexVersion={esIndexVersion} />
       </Column>
 
-      <Column style={{...styles.card, marginTop: `2rem` }}>
-        <h1 style={{...styles.heading, padding: `1rem`}} id="frequent-mutations">
-          <i className="fa fa-bar-chart-o" style={{ paddingRight: `10px` }} />
+      <Column style={{ ...styles.card, marginTop: '2rem' }}>
+        <h1 style={{ ...styles.heading, padding: '1rem' }} id="frequent-mutations">
+          <i className="fa fa-bar-chart-o" style={{ paddingRight: '10px' }} />
           Most Frequent Mutations
         </h1>
-        <PaginationContainer total={fm.total}>
-          <FrequentMutations
-            frequentMutations={frequentMutations}
-            numCasesAggByProject={numCasesAggByProject}
-            totalNumCases={totalNumCases}
-            project={$scope.project.project_id}
-            survivalData={survivalData}
-            width={width}
-          />
-        </PaginationContainer>
+
+        <FrequentMutationsContainer
+          $scope={$scope}
+          numCasesAggByProject={numCasesAggByProject}
+          totalNumCases={totalNumCases}
+          survivalData={survivalData}
+          width={width}
+        />
+
       </Column>
-      <Column style={{...styles.card, marginTop: `2rem` }}>
-        <h1 style={{...styles.heading, padding: `1rem`}} id="most-affected-cases">
-          <i className="fa fa-bar-chart-o" style={{ paddingRight: `10px` }} />
+      <Column style={{ ...styles.card, marginTop: '2rem' }}>
+        <h1 style={{ ...styles.heading, padding: '1rem' }} id="most-affected-cases">
+          <i className="fa fa-bar-chart-o" style={{ paddingRight: '10px' }} />
           Most Affected Cases
         </h1>
 
@@ -507,29 +473,24 @@ const Project = ({
   );
 };
 
-Project.propTypes = {
-  $scope: React.PropTypes.object,
-  authApi: React.PropTypes.string,
-  mutatedGenesProject: React.PropTypes.array,
-  numCasesAggByProject: React.PropTypes.object,
-};
-
 const enhance = compose(
   withState('survivalGene', 'setSurvivalGene', null),
   lifecycle({
-    getInitialState: function() {
+    getInitialState() {
       return { width: window.innerWidth };
     },
 
-    componentDidMount: function() {
-      this.onResize = _.debounce(() => {this.setState({
-        width: window.innerWidth,
-      })}, 100);
+    componentDidMount() {
+      this.onResize = _.debounce(() => {
+        this.setState({
+          width: window.innerWidth,
+        });
+      }, 100);
 
       window.addEventListener('resize', this.onResize);
     },
 
-    componentWillUnmount: function() {
+    componentWillUnmount() {
       window.removeEventListener('resize', this.onResize);
     },
   })

--- a/app/react-components/components/FrequentMutations.js
+++ b/app/react-components/components/FrequentMutations.js
@@ -11,7 +11,6 @@ import EntityPageHorizontalTable from './EntityPageHorizontalTable';
 import SurvivalPlotWrapper from './SurvivalPlotWrapper';
 import TogglableUl from '../uikit/TogglableUl';
 import Tooltip from '../uikit/Tooltip';
-import { withPagination, PaginationControls, PaginationHeader } from '../uikit/Pagination';
 import DownloadVisualizationButton from '../components/DownloadVisualizationButton';
 
 const impactBubble = {
@@ -76,10 +75,6 @@ const FrequentMutations = ({
     <Column>
       {!!frequentMutations.length &&
         <div>
-          <PaginationHeader
-            {...props}
-            entityType="mutations"
-          />
           <Row style={{ paddingBottom: '2.5rem' }}>
             <span>
               <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>
@@ -204,16 +199,6 @@ const FrequentMutations = ({
               ),
             }))}
           />
-          <Row spacing="2rem" style={{ padding: '2rem', alignItems: 'center' }}>
-            <div style={{ marginLeft: 'auto' }}>
-              <PaginationControls
-                update={props.update}
-                offset={props.offset}
-                first={props.first}
-                total={props.total}
-              />
-            </div>
-          </Row>
         </div>
       }
       {!frequentMutations.length &&
@@ -225,7 +210,6 @@ const FrequentMutations = ({
 
 const enhance = compose(
   withState('survivalMutation', 'setSurvivalMutation', null),
-  withPagination()
 );
 
 export default enhance(FrequentMutations);

--- a/app/react-components/components/FrequentMutations.js
+++ b/app/react-components/components/FrequentMutations.js
@@ -69,7 +69,6 @@ const FrequentMutations = ({
   setSurvivalMutation,
   survivalData,
   width,
-  ...props
 }) => {
   return (
     <Column>
@@ -209,7 +208,7 @@ const FrequentMutations = ({
 };
 
 const enhance = compose(
-  withState('survivalMutation', 'setSurvivalMutation', null),
+  withState('survivalMutation', 'setSurvivalMutation', null)
 );
 
 export default enhance(FrequentMutations);

--- a/app/react-components/components/FrequentMutations.js
+++ b/app/react-components/components/FrequentMutations.js
@@ -10,11 +10,11 @@ import { clickable } from '../theme/mixins';
 import EntityPageHorizontalTable from './EntityPageHorizontalTable';
 import SurvivalPlotWrapper from './SurvivalPlotWrapper';
 import TogglableUl from '../uikit/TogglableUl';
-import Button from '../uikit/Button';
 import Tooltip from '../uikit/Tooltip';
+import { withPagination, PaginationControls } from '../uikit/Pagination';
 import DownloadVisualizationButton from '../components/DownloadVisualizationButton';
 
-let impactBubble = {
+const impactBubble = {
   color: 'white',
   padding: '2px 5px',
   borderRadius: '8px',
@@ -22,9 +22,9 @@ let impactBubble = {
   fontWeight: 'bold',
   display: 'inline-block',
   width: '20px',
-}
+};
 
-let impactColors = {
+const impactColors = {
   HIGH: 'rgb(185, 36, 36)',
   MODERATE: 'rgb(193, 158, 54)',
   LOW: 'rgb(49, 161, 60)',
@@ -58,10 +58,10 @@ const styles = {
       ...impactBubble,
       backgroundColor: impactColors.LOW,
     },
-  }
+  },
 };
 
-let FrequentMutations = ({
+const FrequentMutations = ({
   frequentMutations,
   numCasesAggByProject,
   project,
@@ -70,24 +70,35 @@ let FrequentMutations = ({
   setSurvivalMutation,
   survivalData,
   width,
+  ...props
 }) => {
   return (
     <Column>
       {!!frequentMutations.length &&
         <div>
-          <Row style={{paddingBottom: '2.5rem'}}>
+          <span>
+            <span>Showing </span>
+            <strong>
+              <span>{1 + (props.offset || 0)}</span>
+              <span style={{ margin: '0 0.5rem' }}>-</span>
+              <span>{props.offset + props.first}</span>
+            </strong>
+            <span> of</span>
+            <strong> {props.total.toLocaleString()}</strong>
+          </span>
+          <Row style={{ paddingBottom: '2.5rem' }}>
             <span>
-              <div style={{textAlign: 'right', marginRight: 50, marginLeft: 30}}>
+              <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>
                 <DownloadVisualizationButton
                   svg="#mutation-chart svg"
                   data={frequentMutations.map(fm => _.omit(fm, 'consequence_type'))}
                   slug="bar-chart"
-                  noText={true}
+                  noText
                   tooltipHTML="Download image or data"
                 />
               </div>
 
-              <div id="mutation-chart" style={{ padding:'10px' }}>
+              <div id="mutation-chart" style={{ padding: '10px' }}>
                 <BarChart
                   data={frequentMutations.map(x => ({
                     label: x.genomic_dna_change,
@@ -96,40 +107,43 @@ let FrequentMutations = ({
                       ? `<b>${x.genomic_dna_change}</b><br />
                         <b>${x.num_affected_cases_project} Case${x.num_affected_cases_project > 1 ? 's' : ''}
                           affected in ${project}</b><br />
-                        <b>${x.num_affected_cases_project} / ${numCasesAggByProject[project]} (${(x.num_affected_cases_project / numCasesAggByProject[project] * 100).toFixed(2)}%)</b>`
+                        <b>${x.num_affected_cases_project} / ${numCasesAggByProject[project]}
+                        (${((x.num_affected_cases_project / numCasesAggByProject[project]) * 100).toFixed(2)}%)</b>`
                       : `<b>${x.genomic_dna_change}</b><br />
                         <b>${x.num_affected_cases_all} Case${x.num_affected_cases_all > 1 ? 's' : ''}
                           affected in all projects</b><br />
                         <b>${x.num_affected_cases_all} / ${totalNumCases}
-                        (${(x.num_affected_cases_all / totalNumCases * 100).toFixed(2)}%)`,
-                    href: `mutations/${x.ssm_id}`
+                        (${((x.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)`,
+                    href: `mutations/${x.ssm_id}`,
                   }))}
                   margin={{ top: 30, right: 50, bottom: 105, left: 40 }}
                   height={250}
                   title="Distribution of Most Frequent Mutations"
                   yAxis={{ title: '# Affected Cases' }}
                   styles={{
-                    xAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
-                    yAxis: {stroke: theme.greyScale4, textFill: theme.greyScale3},
-                    bars: {fill: theme.secondary},
+                    xAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+                    yAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+                    bars: { fill: theme.secondary },
                     tooltips: {
                       fill: '#fff',
                       stroke: theme.greyScale4,
-                      textFill: theme.greyScale3
-                    }
+                      textFill: theme.greyScale3,
+                    },
                   }}
                 />
               </div>
             </span>
-            {survivalData && <span style={{flexGrow: 1, width: '50%', minWidth: 500}}>
-              <SurvivalPlotWrapper
-                rawData={survivalData}
-                gene={survivalMutation}
-                onReset={() => setSurvivalMutation(null)}
-                height={250}
-                width={width}
-              />
-            </span>}
+            {survivalData &&
+              <span style={{ flexGrow: 1, width: '50%', minWidth: 500 }}>
+                <SurvivalPlotWrapper
+                  rawData={survivalData}
+                  gene={survivalMutation}
+                  onReset={() => setSurvivalMutation(null)}
+                  height={250}
+                  width={width}
+                />
+              </span>
+            }
           </Row>
 
           <EntityPageHorizontalTable
@@ -139,7 +153,7 @@ let FrequentMutations = ({
               { key: 'consequence_type', title: 'Consequences' },
               ...(project ? [{
                 key: 'num_affected_cases_project',
-                title: <span># Affected Cases<br />in {numCasesAggByProject[project]} {project} Cases</span>
+                title: <span># Affected Cases<br />in {numCasesAggByProject[project]} {project} Cases</span>,
               }] : []),
               {
                 key: 'num_affected_cases_all',
@@ -163,48 +177,61 @@ let FrequentMutations = ({
               genomic_dna_change: <a href={`/mutations/${x.ssm_id}`}>{x.genomic_dna_change}</a>,
               ...(project ? { num_affected_cases_project:
                 `${x.num_affected_cases_project}
-                (${(x.num_affected_cases_project / numCasesAggByProject[project] * 100).toFixed(2)}%)`
+                (${((x.num_affected_cases_project / numCasesAggByProject[project]) * 100).toFixed(2)}%)`,
               } : {}),
-              num_affected_cases_all:
+              num_affected_cases_all: (
                 <TogglableUl
                   items={[
-                    `${x.num_affected_cases_all} (${(x.num_affected_cases_all / totalNumCases * 100).toFixed(2)}%)`,
+                    `${x.num_affected_cases_all} (${((x.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)`,
                     ...Object.entries(x.num_affected_cases_by_project)
-                      .map(([k, v]) => `${k}: ${v} (${(v / totalNumCases * 100).toFixed(2)}%)`)
+                      .map(([k, v]) => `${k}: ${v} (${((v / totalNumCases) * 100).toFixed(2)}%)`),
                   ]}
-                />,
-              impact: !['LOW', 'MODERATE', 'HIGH'].includes(x.impact) ? null :
+                />
+              ),
+              impact: !['LOW', 'MODERATE', 'HIGH'].includes(x.impact) ? null : (
                 <Tooltip innerHTML={x.impact}>
                   <span
                     style={styles.impact[x.impact]}
                   >
                     {x.impact.slice(0, 1)}
                   </span>
-                </Tooltip>,
-              survival_plot:
+                </Tooltip>
+              ),
+              survival_plot: (
                 <Tooltip innerHTML={`Add ${x.genomic_dna_change} to surival plot`}>
-                  <span
+                  <button
                     onClick={setSurvivalMutation}
                   >
                     <span className={`fa fa-bar-chart-o ${clickable}`}>
                       <div style={styles.hidden}>add to survival plot</div>
                     </span>
-                  </span>
+                  </button>
                 </Tooltip>
+              ),
             }))}
           />
+          <Row spacing="2rem" style={{ padding: '2rem', alignItems: 'center' }}>
+            <div style={{ marginLeft: 'auto' }}>
+              <PaginationControls
+                update={props.update}
+                offset={props.offset}
+                first={props.first}
+                total={props.total}
+              />
+            </div>
+          </Row>
         </div>
       }
       {!frequentMutations.length &&
-        <span style={{padding: `2rem`}}>No mutation data to display</span>
+        <span style={{ padding: '2rem' }}>No mutation data to display</span>
       }
     </Column>
   );
-}
-
+};
 
 const enhance = compose(
   withState('survivalMutation', 'setSurvivalMutation', null),
+  withPagination()
 );
 
 export default enhance(FrequentMutations);

--- a/app/react-components/components/FrequentMutations.js
+++ b/app/react-components/components/FrequentMutations.js
@@ -11,7 +11,7 @@ import EntityPageHorizontalTable from './EntityPageHorizontalTable';
 import SurvivalPlotWrapper from './SurvivalPlotWrapper';
 import TogglableUl from '../uikit/TogglableUl';
 import Tooltip from '../uikit/Tooltip';
-import { withPagination, PaginationControls } from '../uikit/Pagination';
+import { withPagination, PaginationControls, PaginationHeader } from '../uikit/Pagination';
 import DownloadVisualizationButton from '../components/DownloadVisualizationButton';
 
 const impactBubble = {
@@ -76,16 +76,10 @@ const FrequentMutations = ({
     <Column>
       {!!frequentMutations.length &&
         <div>
-          <span>
-            <span>Showing </span>
-            <strong>
-              <span>{1 + (props.offset || 0)}</span>
-              <span style={{ margin: '0 0.5rem' }}>-</span>
-              <span>{props.offset + props.first}</span>
-            </strong>
-            <span> of</span>
-            <strong> {props.total.toLocaleString()}</strong>
-          </span>
+          <PaginationHeader
+            {...props}
+            entityType="mutations"
+          />
           <Row style={{ paddingBottom: '2.5rem' }}>
             <span>
               <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>

--- a/app/react-components/components/FrequentMutationsContainer.js
+++ b/app/react-components/components/FrequentMutationsContainer.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import _ from 'lodash';
+import { withState, withProps, lifecycle, compose } from 'recompose';
+import FrequentMutations from './FrequentMutations';
+import { PaginationContainer } from '../uikit/Pagination';
+
+const impactColors = {
+  HIGH: 'rgb(185, 36, 36)',
+  MODERATE: 'rgb(193, 158, 54)',
+  LOW: 'rgb(49, 161, 60)',
+};
+
+export default
+compose(
+  withState('fm', 'setState', {}),
+  withProps({
+    fetchData: async props => {
+      const url =
+        `${props.$scope.config.es_host}/${props.$scope.config.es_index_version}-ssm-centric/ssm-centric/_search`;
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: props.offset || 0,
+          query: {
+            nested: {
+              path: 'occurrence',
+              score_mode: 'sum',
+              query: {
+                function_score: {
+                  query: {
+                    terms: {
+                      'occurrence.case.project.project_id': [
+                        props.$scope.project.project_id,
+                      ],
+                    },
+                  },
+                  boost_mode: 'replace',
+                  script_score: {
+                    script: "doc['occurrence.case.project.project_id'].empty ? 0 : 1",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      });
+
+      const { hits } = await res.json();
+      props.setState(() => hits);
+    },
+  }),
+  lifecycle({
+    componentDidMount() {
+      this.props.fetchData(this.props);
+    },
+  })
+)(props => {
+  if (!props.fm.hits) return null;
+
+  const frequentMutations = props.fm.hits.map(g => Object.assign({}, g._source, { score: g._score })).map(x => {
+    const consequence = x.consequence.find(c => c.transcript.is_canonical);
+
+    return {
+      ...x,
+      num_affected_cases_project: x.occurrence.filter(o =>
+        o.case.project.project_id === props.$scope.project.project_id
+      ).length,
+      num_affected_cases_by_project: x.occurrence.reduce((acc, o) => ({
+        ...acc,
+        [o.case.project.project_id]: acc[o.case.project.project_id] ? acc[o.case.project.project_id] + 1 : 1,
+      }), {}),
+      num_affected_cases_all: x.occurrence.length,
+      impact: consequence.transcript.annotation.impact,
+      consequence_type: (
+        <span>
+          <b>{_.startCase(consequence.transcript.consequence_type.replace('variant', ''))}</b>
+          <span style={{ marginLeft: '5px' }}>
+            <a href={`/genes/${consequence.transcript.gene.gene_id}`}>{consequence.transcript.gene_symbol}</a>
+          </span>
+          <span
+            style={{
+              marginLeft: '5px',
+              color: impactColors[consequence.transcript.annotation.impact] || 'inherit',
+            }}
+          >
+            {consequence.transcript.aa_change}
+          </span>
+        </span>
+      ),
+    };
+  });
+  return (
+    <PaginationContainer
+      total={props.fm.total}
+      onChange={pageInfo => props.fetchData({ ...props, ...pageInfo })}
+      entityType="Mutations"
+    >
+      <FrequentMutations
+        frequentMutations={frequentMutations}
+        numCasesAggByProject={props.numCasesAggByProject}
+        totalNumCases={props.totalNumCases}
+        project={props.$scope.project.project_id}
+        survivalData={props.survivalData}
+        width={props.width}
+      />
+    </PaginationContainer>
+  );
+});

--- a/app/react-components/oncogrid/OncoGridWrapper.js
+++ b/app/react-components/oncogrid/OncoGridWrapper.js
@@ -260,7 +260,7 @@ const enhance = compose(
               gridContainer: container,
             });
 
-            document.querySelector('.og-tooltip-oncogrid').style.transform = 'translateY(-110px)'; // TODO: fix tooltip position inside oncogrid and remove this line 
+            document.querySelector('.og-tooltip-oncogrid').style.transform = 'translateY(-110px)'; // TODO: fix tooltip position inside oncogrid and remove this line
           }
         });
     },

--- a/app/react-components/oncogrid/getQueries.js
+++ b/app/react-components/oncogrid/getQueries.js
@@ -188,7 +188,7 @@ function getQueries(projectId, esHost, esIndexVersion) {
       },
       "post_filter": {
         "terms": {
-          "project.project_id": [projectId]
+          "project.project_id.raw": [projectId]
         }
       }
     },

--- a/app/react-components/uikit/ButtonGroup.js
+++ b/app/react-components/uikit/ButtonGroup.js
@@ -1,0 +1,32 @@
+// Vendor
+import React, { Children, cloneElement } from 'react';
+import StyleBuilder from 'style-builder';
+
+// Custom
+import { Row } from './Flex';
+
+/*----------------------------------------------------------------------------*/
+
+const ButtonGroup = ({ style, children, ...props }) => (
+  <Row style={style} {...props}>
+    {Children.map(children, (child, i) =>
+      cloneElement(child, {
+        ...child.props,
+        style: StyleBuilder.build({
+          ...child.props.style,
+          borderRadius: // shouldn't have newlines
+            `${!i ? '4px' : '0px'} `
+          + `${i === children.length - 1 ? '4px' : '0px'} `
+          + `${i === children.length - 1 ? '4px' : '0px'} `
+          + `${!i ? '4px' : '0px'}`,
+          ...(i ? { borderLeft: 'none' } : {}),
+          display: 'inline',
+        }),
+      })
+    )}
+  </Row>
+);
+
+/*----------------------------------------------------------------------------*/
+
+export default ButtonGroup;

--- a/app/react-components/uikit/Pagination.js
+++ b/app/react-components/uikit/Pagination.js
@@ -11,7 +11,7 @@ const withPagination = (props = {}) => Wrapper => (
       offset: props.offset || 0,
     }
 
-    update = payload => this.setState(payload)
+    setPagination = payload => this.setState(payload)
 
     render() {
       return (
@@ -43,6 +43,20 @@ const styles = {
   }),
 };
 
+const PaginationHeader = props => (
+  <span>
+    <span>Showing </span>
+    <strong>
+      <span>{1 + (props.offset || 0)}</span>
+      <span style={{ margin: '0 0.5rem' }}>-</span>
+      <span>{props.offset + props.first}</span>
+    </strong>
+    <span> of</span>
+    <strong> {props.total.toLocaleString()}</strong>
+    <span>{props.entityType}</span>
+  </span>
+);
+
 const PaginationBtn = ({ className, children, ...props }) => (
   <button
     className={`${styles.tableActionButtons} ${styles.inactive} ${className || ''}`}
@@ -59,23 +73,23 @@ const PaginationControls = props => {
 
   return (
     <ButtonGroup>
-      <PaginationBtn onClick={() => props.update({ offset: 0 })}>{'<<'}</PaginationBtn>
-      <PaginationBtn onClick={() => props.update({ offset: props.offset - props.first })}>
+      <PaginationBtn onClick={() => props.setPagination({ offset: 0 })}>{'<<'}</PaginationBtn>
+      <PaginationBtn onClick={() => props.setPagination({ offset: props.offset - props.first })}>
         {'<'}
       </PaginationBtn>
       {_.range(1 + pageOffset, Math.min(11 + pageOffset, totalPages)).map(x =>
         <PaginationBtn
           key={x}
           className={currentPage === x ? styles.active : styles.inactive}
-          onClick={() => props.update({ offset: ((x - 1) * props.first) })}
+          onClick={() => props.setPagination({ offset: ((x - 1) * props.first) })}
         >
           {x}
         </PaginationBtn>
       )}
-      <PaginationBtn onClick={() => props.update({ offset: props.offset + props.first })}>
+      <PaginationBtn onClick={() => props.setPagination({ offset: props.offset + props.first })}>
         {'>'}
       </PaginationBtn>
-      <PaginationBtn onClick={() => props.update({ offset: (props.total - props.total) % props.size })}>
+      <PaginationBtn onClick={() => props.setPagination({ offset: (props.total - props.total) % props.size })}>
         {'>>'}
       </PaginationBtn>
     </ButtonGroup>
@@ -84,5 +98,6 @@ const PaginationControls = props => {
 
 export {
   withPagination,
+  PaginationHeader,
   PaginationControls,
 };

--- a/app/react-components/uikit/Pagination.js
+++ b/app/react-components/uikit/Pagination.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import { css } from 'glamor';
+import { lifecycle, compose } from 'recompose';
 import ButtonGroup from './ButtonGroup';
 import theme from '../theme';
 import { Row } from './Flex';
@@ -98,7 +99,16 @@ const PaginationControls = props => {
   );
 };
 
-const PaginationContainer = withPagination()(
+const PaginationContainer = compose(
+  withPagination(),
+  lifecycle({
+    componentWillReceiveProps(next) {
+      if (this.props.offset !== next.offset && this.props.onChange) {
+        this.props.onChange(next);
+      }
+    },
+  })
+)(
   props => (
     <span>
       <Row style={{ padding: '0 1rem' }}>

--- a/app/react-components/uikit/Pagination.js
+++ b/app/react-components/uikit/Pagination.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import _ from 'lodash';
+import { css } from 'glamor';
+import ButtonGroup from './ButtonGroup';
+import theme from '../theme';
+
+const withPagination = (props = {}) => Wrapper => (
+  class extends React.Component {
+    state = {
+      first: props.first || 10,
+      offset: props.offset || 0,
+    }
+
+    update = payload => this.setState(payload)
+
+    render() {
+      return (
+        <Wrapper
+          {...this.props}
+          {...this.state}
+          update={this.update}
+        />
+      );
+    }
+  }
+);
+
+const styles = {
+  tableActionButtons: css({
+    padding: '0.6rem',
+    backgroundColor: 'white',
+    color: theme.greyScale1,
+    border: `1px solid ${theme.greyScale4}`,
+  }),
+  inactive: css({
+    ':hover': {
+      backgroundColor: theme.greyScale6,
+    },
+  }),
+  active: css({
+    backgroundColor: theme.secondary,
+    color: 'white',
+  }),
+};
+
+const PaginationBtn = ({ className, children, ...props }) => (
+  <button
+    className={`${styles.tableActionButtons} ${styles.inactive} ${className || ''}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+const PaginationControls = props => {
+  const currentPage = (props.offset / props.first) + 1;
+  const totalPages = props.total / props.first;
+  const pageOffset = 10 * Math.floor((currentPage - 1) / 10);
+
+  return (
+    <ButtonGroup>
+      <PaginationBtn onClick={() => props.update({ offset: 0 })}>{'<<'}</PaginationBtn>
+      <PaginationBtn onClick={() => props.update({ offset: props.offset - props.first })}>
+        {'<'}
+      </PaginationBtn>
+      {_.range(1 + pageOffset, Math.min(11 + pageOffset, totalPages)).map(x =>
+        <PaginationBtn
+          key={x}
+          className={currentPage === x ? styles.active : styles.inactive}
+          onClick={() => props.update({ offset: ((x - 1) * props.first) })}
+        >
+          {x}
+        </PaginationBtn>
+      )}
+      <PaginationBtn onClick={() => props.update({ offset: props.offset + props.first })}>
+        {'>'}
+      </PaginationBtn>
+      <PaginationBtn onClick={() => props.update({ offset: (props.total - props.total) % props.size })}>
+        {'>>'}
+      </PaginationBtn>
+    </ButtonGroup>
+  );
+};
+
+export {
+  withPagination,
+  PaginationControls,
+};

--- a/app/react-components/uikit/Pagination.js
+++ b/app/react-components/uikit/Pagination.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { css } from 'glamor';
 import ButtonGroup from './ButtonGroup';
 import theme from '../theme';
+import { Row } from './Flex';
 
 const withPagination = (props = {}) => Wrapper => (
   class extends React.Component {
@@ -18,7 +19,7 @@ const withPagination = (props = {}) => Wrapper => (
         <Wrapper
           {...this.props}
           {...this.state}
-          update={this.update}
+          setPagination={this.setPagination}
         />
       );
     }
@@ -27,6 +28,7 @@ const withPagination = (props = {}) => Wrapper => (
 
 const styles = {
   tableActionButtons: css({
+    outline: 'none',
     padding: '0.6rem',
     backgroundColor: 'white',
     color: theme.greyScale1,
@@ -53,13 +55,13 @@ const PaginationHeader = props => (
     </strong>
     <span> of</span>
     <strong> {props.total.toLocaleString()}</strong>
-    <span>{props.entityType}</span>
+    <span style={{ marginLeft: '0.5rem' }}>{props.entityType}</span>
   </span>
 );
 
 const PaginationBtn = ({ className, children, ...props }) => (
   <button
-    className={`${styles.tableActionButtons} ${styles.inactive} ${className || ''}`}
+    className={`${styles.tableActionButtons} ${className || styles.inactive}`}
     {...props}
   >
     {children}
@@ -96,8 +98,25 @@ const PaginationControls = props => {
   );
 };
 
+const PaginationContainer = withPagination()(
+  props => (
+    <span>
+      <Row style={{ padding: '0 1rem' }}>
+        <PaginationHeader {...props} />
+      </Row>
+      {props.children}
+      <Row style={{ padding: '1rem', alignItems: 'center' }}>
+        <div style={{ marginLeft: 'auto' }}>
+          <PaginationControls {...props} />
+        </div>
+      </Row>
+    </span>
+  )
+);
+
 export {
   withPagination,
   PaginationHeader,
   PaginationControls,
+  PaginationContainer,
 };

--- a/app/scripts/projects/module.ts
+++ b/app/scripts/projects/module.ts
@@ -90,7 +90,7 @@ module ngApp.projects {
               "aggs": {
                 "projects": {
                   "terms": {
-                    "field": "project.project_id",
+                    "field": "project.project_id.raw",
                     "size": 20000
                   },
                   "aggs": {

--- a/app/scripts/projects/module.ts
+++ b/app/scripts/projects/module.ts
@@ -201,9 +201,7 @@ module ngApp.projects {
                 }
               }
             }
-          }).then(data => {
-            return data.data.hits.hits;
-          });
+          }).then(data => data.data.hits);
         },
         survivalData: (
           $stateParams: ng.ui.IStateParamsService,

--- a/app/scripts/projects/module.ts
+++ b/app/scripts/projects/module.ts
@@ -169,40 +169,6 @@ module ngApp.projects {
             return data.data.hits.hits;
           });
         },
-        frequentMutations: (
-          $stateParams: ng.ui.IStateParamsService,
-          $http: ng.IHttpService,
-          config: IGDCConfig
-        ): ng.IPromise => {
-          return $http({
-            method: 'POST',
-            url: `${config.es_host}/${config.es_index_version}-ssm-centric/ssm-centric/_search`,
-            headers: {'Content-Type' : 'application/json'},
-            data: {
-              "query": {
-                "nested": {
-                  "path": "occurrence",
-                  "score_mode": "sum",
-                  "query": {
-                    "function_score": {
-                      "query": {
-                        "terms": {
-                          "occurrence.case.project.project_id": [
-                            $stateParams["projectId"]
-                          ]
-                        }
-                      },
-                      "boost_mode": "replace",
-                      "script_score": {
-                        "script": "doc['occurrence.case.project.project_id'].empty ? 0 : 1"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }).then(data => data.data.hits);
-        },
         survivalData: (
           $stateParams: ng.ui.IStateParamsService,
           $http: ng.IHttpService,

--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -622,7 +622,7 @@ module ngApp.projects.controllers {
             authApi: this.CoreService.config.auth_api,
             esHost: this.CoreService.config.es_host,
             esIndexVersion: this.CoreService.config.es_index_version,
-            frequentMutations: this.frequentMutations.map(g => Object.assign({}, g._source, { score: g._score })),
+            frequentMutations: this.frequentMutations,
             survivalData: this.survivalData,
             mostAffectedCases: this.mostAffectedCases.map(c => c._source),
           })

--- a/app/scripts/projects/projects.controller.ts
+++ b/app/scripts/projects/projects.controller.ts
@@ -381,7 +381,6 @@ module ngApp.projects.controllers {
       public project: IProject,
       public mutatedGenesProject: Array<Object>,
       public numCasesAggByProject: Array<Object>,
-      public frequentMutations: Array<Object>,
       public mostAffectedCases: Array<Object>,
       public survivalData: Array<Object>,
       private CoreService: ICoreService,
@@ -390,7 +389,8 @@ module ngApp.projects.controllers {
       private ExperimentalStrategyNames: string[],
       private DATA_CATEGORIES,
       public $state: ng.ui.IStateService,
-      private $filter: ng.ui.IFilterService
+      private $filter: ng.ui.IFilterService,
+      private config
     ) {
       CoreService.setPageTitle("Project", project.project_id);
       this.experimentalStrategies = _.reduce(ExperimentalStrategyNames.slice(), function(result, name) {
@@ -622,7 +622,6 @@ module ngApp.projects.controllers {
             authApi: this.CoreService.config.auth_api,
             esHost: this.CoreService.config.es_host,
             esIndexVersion: this.CoreService.config.es_index_version,
-            frequentMutations: this.frequentMutations,
             survivalData: this.survivalData,
             mostAffectedCases: this.mostAffectedCases.map(c => c._source),
           })

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "redux": "^3.6.0",
     "redux-actions": "^0.12.0",
     "save-svg-as-png": "git+http://git@github.com/Jephuff/saveSvgAsPng.git#gh-pages",
+    "style-builder": "^1.0.13",
     "whatwg-fetch": "^1.0.0"
   },
   "jest": {


### PR DESCRIPTION
The purpose of this PR is to provide generic pagination UI elements that can be added to anything that needs pagination.
 
  `withPagination` is function that returns an HOC who may take an options argument to set the default `first` and `offset`.

Components wrapped with the resulting HOC can also update pagination data via `props.setPagination({ offset })`

Components will need to make api requests are a result of these props changes are recommended to do so in `componentWillReceiveProps` and make necessary comparisons there.

Update:

## This is my proposed API:

```
import { PaginationContainer } from 'uikit/pagination'

<PaginationContainer
  total={totalNumOfItems}
  entityType="Cases"
  onChange={pageInfo => /* do whatever */}
>
  <WhateverComponent />
</PaginationContainer>
```

This will wrap `WhateverComponent` with a pagination header `Showing x-offset of total Cases` and the buttons to move pages at the bottom. The container callback will trigger when someone goes to a new page.