### PR TITLE
:bug: [PRTL-579] Fix cart notification not showing up

### DIFF
--- a/modules/node_modules/@ncigdc/uikit/Notification.js
+++ b/modules/node_modules/@ncigdc/uikit/Notification.js
@@ -82,7 +82,7 @@ Notification.propTypes = {
 };
 
 let timeoutId;
-let pageload = true;
+let pageload = false;
 
 const enhance = compose(
   withState('visible', 'setState', false),


### PR DESCRIPTION
- Initialized `pageload` to be `false` so first time cart action of adding/removing file shows the notification