### PR TITLE
[API-216] use release date from api

### DIFF
--- a/app/scripts/app.ts
+++ b/app/scripts/app.ts
@@ -148,6 +148,7 @@ function appRun(gettextCatalog: any,
 
   Restangular.all('status').get('').then(function(data){
 
+    config.data_release = data.data_release;
     config.apiVersion = data['tag'];
     config.apiCommitHash = data['commit'];
     config.apiTag = "https://github.com/NCI-GDC/gdcapi/releases/tag/" + config.apiVersion;

--- a/app/scripts/home/home.controllers.ts
+++ b/app/scripts/home/home.controllers.ts
@@ -30,7 +30,9 @@ module ngApp.home.controllers {
                 private FilesService: IFilesService,
                 private ProjectsService: IProjectsService,
                 private DATA_TYPES,
-                private DATA_CATEGORIES) {
+                private DATA_CATEGORIES,
+                private config: IGDCConfig
+                ) {
 
       CoreService.setPageTitle("Welcome to The Genomic Data Commons Data Portal");
 

--- a/app/scripts/home/templates/home.html
+++ b/app/scripts/home/templates/home.html
@@ -74,8 +74,7 @@
           <h3 style="margin:0 0 1rem 0; color: #333 !important">Data Portal Summary</h3>
           <a href="https://docs.gdc.cancer.gov/Data/Release_Notes/Data_Release_Notes/" target="_blank">
             <em style="font-size:1.3rem;text-transform: none">
-              Data Release <span data-ng-bind-placholder="">4.0</span> -
-              <span style="margin-right: 1rem">October 31, 2016</span>
+              {{::config.data_release}}
             </em>
           </a>
         </div>


### PR DESCRIPTION
Looks like https://github.com/NCI-GDC/portal-ui/commit/1204596d31422df214fe7a1f6632627d9d61dbe5 to get the date release date from api didn't make it into `release/1.5.0` making this PR to do that.