### PR TITLE
:sparkles: reload projects charts on query update

### DIFF
--- a/modules/node_modules/@ncigdc/components/ProgressContainer.js
+++ b/modules/node_modules/@ncigdc/components/ProgressContainer.js
@@ -12,7 +12,7 @@ const ProgressBar = styled(Progress, {
 });
 
 const ProgressContainer = compose(
-  connect(state => ({ percent: state.relayProgress })),
+  connect(state => ({ percent: state.relayProgress.percent })),
   withTheme
 )(({ percent, theme }) => (
   <ProgressBar

--- a/modules/node_modules/@ncigdc/components/ProjectsCharts.js
+++ b/modules/node_modules/@ncigdc/components/ProjectsCharts.js
@@ -3,10 +3,10 @@
 import React from 'react';
 import Measure from 'react-measure';
 import Relay from 'react-relay';
+import { connect } from 'react-redux';
 import * as d3 from 'd3';
-import { compose, withState, lifecycle } from 'recompose';
+import { compose, withState, withProps, lifecycle } from 'recompose';
 import JSURL from 'jsurl';
-import { stringify } from 'query-string';
 
 // Custom
 import Column from '@ncigdc/uikit/Flex/Column';
@@ -21,7 +21,16 @@ import { removeEmptyKeys } from '@ncigdc/utils/uri';
 import DoubleRingChart from '@ncigdc/components/Charts/DoubleRingChart';
 import StackedBarChart from '@ncigdc/components/Charts/StackedBarChart';
 
+import styled from '@ncigdc/theme/styled';
 import { withTheme } from '@ncigdc/theme';
+
+const Container = styled(Row, {
+  marginBottom: '2rem',
+  backgroundColor: 'white',
+  border: '1px solid #ddd',
+  borderRadius: '4px',
+  height: '300px',
+});
 
 const initialState = {
   topGenesWithCasesPerProject: {},
@@ -33,9 +42,10 @@ const initialState = {
 const ProjectsChartsComponent = compose(
   withState('state', 'setState', initialState),
   withRouter,
-  lifecycle({
-    async componentDidMount(): Promise<*> {
-      const projectIds = this.props.hits.edges.map(x => x.node.project_id);
+  connect(state => ({ relayProgress: state.relayProgress })),
+  withProps({
+    async fetchData(props): Promise<*> {
+      const projectIds = props.hits.edges.map(x => x.node.project_id);
 
       const { data } = await fetchApi(
         `analysis/top_mutated_genes_by_project?fields=gene_id,symbol&filters=${
@@ -103,13 +113,30 @@ const ProjectsChartsComponent = compose(
         return acc;
       }, {});
 
-      this.props.setState(state => ({
+      props.setState(state => ({
         ...state,
         numUniqueCases,
         topGenesWithCasesPerProject,
         projectsIsFetching: false,
         genesIsFetching: false,
       }));
+    },
+  }),
+  lifecycle({
+    componentDidMount(): void {
+      this.props.fetchData(this.props);
+    },
+    componentWillReceiveProps(nextProps: Object): void {
+      if (this.props.relayProgress.event !== nextProps.relayProgress.event &&
+        ['NETWORK_QUERY_RECEIVED_ALL', 'STORE_FOUND_ALL'].includes(nextProps.relayProgress.event)
+      ) {
+        this.props.setState(s => ({ ...s,
+          projectsIsFetching: true,
+          genesIsFetching: true,
+        }));
+
+        this.props.fetchData(nextProps);
+      }
     },
   }),
   withTheme
@@ -249,7 +276,7 @@ const ProjectsChartsComponent = compose(
   }), {});
 
   return (
-    <Row style={{ marginBottom: '2rem', backgroundColor: 'white', border: '1px solid #ddd', borderRadius: '4px' }}>
+    <Container>
       <Column flex={3} style={{ paddingRight: '10px', minWidth: '450px' }}>
         <div style={{ alignSelf: 'center', color: '#6b6262', padding: '1.5rem 0 0.5rem', fontWeight: 'bold' }}>
           Top Mutated Genes in Selected Projects
@@ -315,7 +342,7 @@ const ProjectsChartsComponent = compose(
         </Row>
         }
       </Column>
-    </Row>
+    </Container>
   );
 });
 

--- a/modules/node_modules/@ncigdc/containers/ProjectsPage.js
+++ b/modules/node_modules/@ncigdc/containers/ProjectsPage.js
@@ -2,16 +2,12 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
 
 import SearchPage from '@ncigdc/components/SearchPage';
 import ProjectsCharts from '@ncigdc/components/ProjectsCharts';
 
-import type { TRawQuery } from '@ncigdc/utils/uri/types';
-
 import ProjectTable from './ProjectTable';
 import ProjectAggregations from './ProjectAggregations';
-
 
 export type TProps = {
   relay: Object,
@@ -36,13 +32,7 @@ export const ProjectsPageComponent = (props: TProps) => (
       />
     }
     Results={<ProjectTable hits={props.viewer.projects.hits} />}
-    charts={<LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => (
-      <ProjectsCharts
-        hits={props.viewer.projects.hits}
-        query={ctx.query}
-        pathname={ctx.pathname}
-      />
-    )}</LocationSubscriber>}
+    charts={<ProjectsCharts hits={props.viewer.projects.hits} />}
   />
 );
 

--- a/modules/node_modules/@ncigdc/dux/relayProgress.js
+++ b/modules/node_modules/@ncigdc/dux/relayProgress.js
@@ -2,12 +2,17 @@
 
 const UPDATE_RELAY_PROGRESS = 'UPDATE_RELAY_PROGRESS';
 
-const updateProgress = (percent: number): Object => ({
+const updateProgress = (payload: Object): Object => ({
   type: UPDATE_RELAY_PROGRESS,
-  payload: percent,
+  payload,
 });
 
-const reducer = (state: number = 0, action: Object) => {
+const initialState = {
+  percent: 0,
+  event: null,
+};
+
+const reducer = (state = initialState, action: Object) => {
   switch (action.type) {
     case 'UPDATE_RELAY_PROGRESS':
       return action.payload;
@@ -21,10 +26,16 @@ const reducer = (state: number = 0, action: Object) => {
 type TProps = { dispatch: Function };
 type THandleStateChange = (props: TProps) => (readyState: Object) => void;
 const handleStateChange: THandleStateChange = props => ({ events }) => {
-  props.dispatch(updateProgress(events.length * 30));
+  props.dispatch(updateProgress({
+    percent: events.length * 30,
+    event: events[events.length - 1].type,
+  }));
 
   if (events.some(x => x.type === 'NETWORK_QUERY_RECEIVED_ALL' || x.type === 'STORE_FOUND_ALL')) {
-    props.dispatch(updateProgress(0));
+    props.dispatch(updateProgress({
+      percent: 0,
+      event: events[events.length - 1].type,
+    }));
   }
 };
 


### PR DESCRIPTION
Kind of an odd fix. Because the url is changing, the projects charts are re-firing, but we need to wait for the relay container to finish loading to get the returned projects.