### PR TITLE
💄 widen quicksearch box wider so ‘h’ in "Quick Search" isn’t cut off

### DIFF
--- a/modules/node_modules/@ncigdc/components/QuickSearch/QuickSearch.js
+++ b/modules/node_modules/@ncigdc/components/QuickSearch/QuickSearch.js
@@ -20,13 +20,15 @@ const styles = {
 
 const SearchInput = styled.input({
   fontSize: '14px',
-  height: '2rem',
+  height: '2.7rem',
   padding: '0.7rem 1rem',
   border: ({ theme }) => `1px solid ${theme.greyScale5}`,
-  width: '10rem',
+  width: '12rem',
   borderRadius: '4px',
   outline: 'none',
   transition: 'all 0.2s ease',
+  marginTop: -10,
+  marginBottom: -10,
   ':focus': {
     borderColor: 'rgb(18, 141, 219) !important',
     boxShadow: '0px 0px 22px 0px rgba(18, 147, 219, 0.75)',


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/22836025/dc6d0e74-ef88-11e6-946b-6ec90f8977ed.png)
