### PR TITLE
🐛  null check in auth reducer for local dev

### DIFF
--- a/modules/node_modules/@ncigdc/dux/auth.js
+++ b/modules/node_modules/@ncigdc/dux/auth.js
@@ -92,7 +92,7 @@ export default handleActions({
   [USER_SUCCESS]: (state, action) => ({
     ...state,
     isFetching: false,
-    isAuthorized: Object.keys(action.payload.projects.gdc_ids || {}).length > 0,
+    isAuthorized: Object.keys((action.payload || { projects: { gdc_ids: {} } }).projects.gdc_ids).length > 0,
     user: action.payload,
     error: {},
     firstLoad: false,


### PR DESCRIPTION
my bad, didn't check that auth reducer works locally after dispatching on initial load. @alex-wilmer 