### PR TITLE
🐛 handle error parsing user

### DIFF
--- a/modules/node_modules/@ncigdc/dux/auth.js
+++ b/modules/node_modules/@ncigdc/dux/auth.js
@@ -90,8 +90,8 @@ export default handleActions({
   [USER_SUCCESS]: (state, action) => ({
     ...state,
     isFetching: false,
-    user: action.payload,
-    error: {},
+    user: action.error ? null : action.payload,
+    error: action.error ? action.payload : {},
     firstLoad: false,
   }),
   [USER_FAILURE]: (state, action) => ({


### PR DESCRIPTION
alternative to https://github.com/NCI-GDC/portal-ui/pull/1261 if we can't remove the custom payload. We can handling the error produced. 

Needs to be deployed to Dev2 to test