### PR TITLE
✨ [PRTL-420] update download permission check for files with no projects

### DIFF
--- a/modules/node_modules/@ncigdc/containers/FilePage.js
+++ b/modules/node_modules/@ncigdc/containers/FilePage.js
@@ -48,6 +48,8 @@ export const FilePageQuery = {
         experimental_strategy
         md5sum
         state
+        file_state
+        acl
         analysis {
           analysis_id
           workflow_type

--- a/modules/node_modules/@ncigdc/containers/FileTable.js
+++ b/modules/node_modules/@ncigdc/containers/FileTable.js
@@ -146,6 +146,9 @@ export const FileTableQuery = {
             file_name
             file_size
             access
+            file_state
+            state
+            acl
             data_category
             data_format
             cases {

--- a/modules/node_modules/@ncigdc/dux/cart.js
+++ b/modules/node_modules/@ncigdc/dux/cart.js
@@ -216,7 +216,7 @@ function fetchFilesAndAdd(currentFilters: ?Object, total: number): Function {
       const search = stringify({
         filters: currentFilters && JSON.stringify(currentFilters),
         size: total,
-        fields: 'access,file_id,file_size,cases.project.project_id',
+        fields: 'acl,state,file_state,access,file_id,file_size,cases.project.project_id',
       });
       const { data } = await fetchApi(`files?${search}`);
       dispatch(addAllFilesInCart(data.hits));
@@ -311,6 +311,9 @@ export function reducer(state: Object = initialState, action: Object): Object {
     case ADD_TO_CART:
       return {
         files: state.files.concat(action.payload.map(file => ({
+          acl: file.acl,
+          state: file.state,
+          file_state: file.file_state,
           access: file.access,
           file_id: file.file_id,
           file_size: file.file_size,
@@ -328,6 +331,9 @@ export function reducer(state: Object = initialState, action: Object): Object {
       return {
         ...state,
         files: action.payload.map(file => ({
+          acl: file.acl,
+          state: file.state,
+          file_state: file.file_state,
           access: file.access,
           file_id: file.file_id,
           file_size: file.file_size,

--- a/modules/node_modules/@ncigdc/utils/auth/__tests__/auth.test.js
+++ b/modules/node_modules/@ncigdc/utils/auth/__tests__/auth.test.js
@@ -1,0 +1,230 @@
+/* @flow */
+
+import {
+  isUserProject,
+  userCanDownloadFile,
+  userCanDownloadFiles,
+  fileInCorrectState,
+  intersectsWithFileAcl,
+ } from '..';
+
+const user = {
+  username: 'TEST_USER',
+  projects: {
+    phs_ids: {
+      TEST: ['read', 'create', 'update', 'download', 'release', '_member_', 'read_report', 'delete'],
+    },
+    gdc_ids: {
+      'TCGA-TEST': ['read', 'create', 'update', 'release', 'download', '_member_', 'read_report', 'delete'],
+      'TCGA-LUAD': ['read', 'create', 'update', 'release', 'download', '_member_', 'read_report', 'delete'],
+      'TCGA-LAML': ['read', 'create', 'update', 'release', 'download', '_member_', 'read_report', 'delete'],
+    },
+  },
+};
+
+const TESTCase = { node: { project: { project_id: 'TCGA-TEST' } } };
+const LUADCase = { node: { project: { project_id: 'TCGA-LUAD' } } };
+const LAMLCase = { node: { project: { project_id: 'TCGA-LAML' } } };
+const KIRPCase = { node: { project: { project_id: 'TCGA-KIRP' } } };
+const KIRCCase = { node: { project: { project_id: 'TCGA-KIRC' } } };
+
+const TESTFile = { cases: { hits: { edges: [TESTCase] } } };
+const LUADFile = { cases: { hits: { edges: [LUADCase] } } };
+const KIRPFile = { cases: { hits: { edges: [KIRPCase] } } };
+describe('isUserProject', () => {
+  it('should detect projects directly under file', () => {
+    it('with only one project', () => {
+      expect(isUserProject({ user, file: { projects: [{ project_id: 'TCGA-TEST' }] } })).toBe(true);
+      expect(isUserProject({ user, file: { projects: [{ project_id: 'TCGA-KIRC' }] } })).toBe(false);
+    });
+    it('with more than one project, only one of them needs to be in gdc_ids', () => {
+      expect(isUserProject({ user, file: { projects: [
+        { project_id: 'TCGA-TEST' },
+        { project_id: 'TCGA-LUAD' },
+      ] } })).toBe(true);
+      expect(isUserProject({ user, file: { projects: [
+        { project_id: 'TCGA-TEST' },
+        { project_id: 'TCGA-KIRC' },
+      ] } })).toBe(true);
+      expect(isUserProject({ user, file: { projects: [
+        { project_id: 'TCGA-KIRP' },
+        { project_id: 'TCGA-TEST' },
+        { project_id: 'TCGA-KIRC' },
+      ] } })).toBe(true);
+    });
+  });
+  it('should detect projects directly under file.cases', () => {
+    it('with only one project', () => {
+      expect(isUserProject({ user, file: TESTFile })).toBe(true);
+      expect(isUserProject({ user, file: LUADFile })).toBe(true);
+      expect(isUserProject({ user, file: KIRPFile })).toBe(false);
+    });
+    it('with more than one project, only one of them needs to be in gdc_ids', () => {
+      expect(isUserProject({ user, file: {
+        cases: { hits: { edges: [
+          TESTCase,
+          LUADCase,
+        ],
+        } } } })).toBe(true);
+      expect(isUserProject({ user, file: {
+        cases: { hits: { edges: [
+          TESTCase,
+          KIRPCase,
+        ],
+        } } } })).toBe(true);
+      expect(isUserProject({ user, file: {
+        cases: { hits: { edges: [
+          KIRCCase,
+          KIRPCase,
+        ],
+        } } } })).toBe(false);
+    });
+  });
+});
+
+describe('fileInCorrectState', () => {
+  it('should be correct for active files when file.state is submitted and file.file_state is in ["submitted", "processing", "processed"]', () => {
+    expect(fileInCorrectState({ state: 'submitted', file_state: 'submitted' })).toBe(true);
+    expect(fileInCorrectState({ state: 'submitted', file_state: 'processing' })).toBe(true);
+    expect(fileInCorrectState({ state: 'submitted', file_state: 'processed' })).toBe(true);
+
+    expect(fileInCorrectState({ state: 'submitted', file_state: 'registered' })).toBe(false);
+    expect(fileInCorrectState({ state: 'uploaded', file_state: 'submitted' })).toBe(false);
+  });
+});
+
+describe('intersectsWithFileAcl', () => {
+  it('should detect _member_ role phsids_ has intersection with file.acl', () => {
+    expect(intersectsWithFileAcl({ user, file: { acl: ['TEST'] } })).toBe(true);
+    expect(intersectsWithFileAcl({ user, file: { acl: ['TEST', 'NOT IN'] } })).toBe(true);
+    expect(intersectsWithFileAcl({ user, file: { acl: ['NOT IN'] } })).toBe(false);
+  });
+});
+
+describe('userCanDownloadFiles', () => {
+  it('should work on files with projects', () => {
+    expect(userCanDownloadFiles({ user, files: [{ access: 'open' }] })).toBe(true);
+    expect(userCanDownloadFiles({ user, files: [{ access: 'controlled', projects: ['TCGA-TEST'] }] })).toBe(true);
+    expect(userCanDownloadFiles({ user, files: [{ access: 'controlled', projects: ['TCGA-KIRC'] }] })).toBe(false);
+    expect(userCanDownloadFiles({ user, files: [{ access: 'controlled', projects: ['TCGA-KIRC', 'TCGA-TEST'] }] })).toBe(true);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        { access: 'controlled', projects: ['TCGA-KIRC', 'TCGA-TEST'] },
+        { access: 'controlled', projects: ['TCGA-KIRC'] },
+      ],
+    })).toBe(false);
+    expect(userCanDownloadFiles({
+      user,
+      files: [TESTFile],
+    })).toBe(true);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        TESTFile,
+        LUADFile,
+      ],
+    })).toBe(true);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        { access: 'open', ...TESTFile },
+        { access: 'open', ...KIRPFile },
+      ],
+    })).toBe(true);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        { access: 'controlled', ...TESTFile },
+        { access: 'controlled', ...KIRPFile },
+      ],
+    })).toBe(false);
+  });
+  it('should work on files with no projects', () => {
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        {
+          state: 'submitted',
+          file_state: 'submitted',
+          acl: ['TEST'],
+        },
+      ],
+    })).toBe(true);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        {
+          state: 'submitted',
+          file_state: 'submitted',
+          acl: ['TEST'],
+        },
+        {
+          state: 'submitted',
+          file_state: 'submitted',
+          acl: ['NOT-IN'],
+        },
+      ],
+    })).toBe(false);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        {
+          state: 'uploaded',
+          file_state: 'registered',
+          acl: ['TEST'],
+        },
+      ],
+    })).toBe(false);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        {
+          state: 'submitted',
+          file_state: 'submitted',
+          acl: [],
+        },
+      ],
+    })).toBe(false);
+    expect(userCanDownloadFiles({
+      user,
+      files: [
+        {
+          state: 'submitted',
+          file_state: 'submitted',
+          acl: ['NOT-IN'],
+        },
+      ],
+    })).toBe(false);
+  });
+});
+describe('userCanDownloadFile', () => {
+  it('works on a single file', () => {
+    expect(userCanDownloadFile({
+      user,
+      file: {
+        state: 'submitted',
+        file_state: 'submitted',
+        acl: ['TEST'],
+      },
+    })).toBe(true);
+    expect(userCanDownloadFile({
+      user,
+      file: {
+        state: 'submitted',
+        file_state: 'submitted',
+        acl: ['NOT-IN'],
+      },
+    })).toBe(false);
+  });
+  it('should not throw when user has no projects', () => {
+    expect(userCanDownloadFile({
+      user: { username: 'TEST_USER' },
+      file: TESTFile,
+    })).toBe(false);
+    expect(userCanDownloadFile({
+      user: { username: 'TEST_USER' },
+      file: { access: 'open', ...TESTFile},
+    })).toBe(true);
+  });
+});

--- a/modules/node_modules/@ncigdc/utils/auth/index.js
+++ b/modules/node_modules/@ncigdc/utils/auth/index.js
@@ -1,25 +1,29 @@
 // @flow
+/* global LEGACY:false */
 
 import _ from 'lodash';
-
-/*----------------------------------------------------------------------------*/
 
 const isUserProject = ({ user, file }) => {
   if (!user) {
     return false;
   }
+  const projectIds = Array.from(new Set([
+    ...(file.projects || []).map(p => p.project_id || p),
+    ...(file.cases || { hits: { edges: [] } }).hits.edges.map(e => e.node.project.project_id),
+  ]));
 
-  let projectIds;
-
-  // Support multiple use cases
-  if (file.projects) {
-    projectIds = _.uniq(file.projects.map(p => p.project_id || p));
-  } else {
-    projectIds = _.uniq(file.cases.map(p => p.project.project_id));
-  }
-
-  return !!_.intersection(projectIds, Object.keys(user.projects.gdc_ids)).length;
+  const gdcIds = Object.keys((user.projects || { gdc_ids: {} }).gdc_ids);
+  return _.intersection(projectIds, gdcIds).length !== 0;
 };
+
+const fileInCorrectState = (file): boolean => LEGACY ?
+  file.state === 'live' :
+    file.state === 'submitted' && ['submitted', 'processing', 'processed'].indexOf(file.file_state) !== -1;
+
+const intersectsWithFileAcl = ({user, file}): boolean => _.intersection(
+    Object.keys((user.projects || { phs_ids: {} }).phs_ids)
+      .filter(p => user.projects.phs_ids[p].indexOf('_member_') !== -1) || [],
+    file.acl).length !== 0;
 
 const userCanDownloadFiles = ({ user, files }) => (
   files.every(file => {
@@ -31,7 +35,7 @@ const userCanDownloadFiles = ({ user, files }) => (
       return false;
     }
 
-    if (isUserProject({ user, file })) {
+    if (isUserProject({ user, file }) || intersectsWithFileAcl({ user, file}) && fileInCorrectState(file)) {
       return true;
     }
 
@@ -43,4 +47,10 @@ const userCanDownloadFile = ({ user, file }) => userCanDownloadFiles({ user, fil
 
 /*----------------------------------------------------------------------------*/
 
-export { isUserProject, userCanDownloadFiles, userCanDownloadFile };
+export {
+  isUserProject,
+  userCanDownloadFiles,
+  userCanDownloadFile,
+  intersectsWithFileAcl,
+  fileInCorrectState,
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
+    },
+    "globals": {
+      "LEGACY": false
     }
   },
   "author": {
@@ -64,6 +67,7 @@
     "@knit/eslint-config-socks-react": "^0.2.0",
     "@knit/jest-config-socks": "^0.1.6",
     "@knit/knit": "0.1.6",
+    "babel-jest": "18.0.0",
     "eslint": "^3.13.1",
     "flow-bin": "^0.37.4",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
ticket says all `Data Type = Copy Number QA Metrics` files will have no projects associated, check file state and file acl instead. There doesn't seem to be any files of that type indexed currently, so wrote some tests.