### PR TITLE
Defer loading d3tip script

### DIFF
--- a/modules/node_modules/webpack_entry/index.html
+++ b/modules/node_modules/webpack_entry/index.html
@@ -29,8 +29,8 @@
 
 <script src="https://unpkg.com/lodash-aliases@1.2.0/dist/lodash-aliases.min.js"></script>
 
-<!-- githut -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
+<!-- githut defer so it loads after bundle.js -->
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
 <!-- END githut -->
 </body>
 </html>


### PR DESCRIPTION
d3tip needs d3, which is in bundle, which is placed at end of document in production build