### PR TITLE
[PRTL-683] Exploration page link disable

### DIFF
--- a/modules/node_modules/@ncigdc/components/GeneTable.js
+++ b/modules/node_modules/@ncigdc/components/GeneTable.js
@@ -89,6 +89,8 @@ const GeneTable = ({
       num_affected_cases_all: (
         <TogglableUl
           items={[
+            /*  TODO: Commented out as part of PRTL-683
+                Should be revert back once Exploration page is ready
             <CohortLink
               query={{
                 searchTableTab: 'cases',
@@ -97,7 +99,11 @@ const GeneTable = ({
             >
               {g.num_affected_cases_all.toLocaleString()} / {totalNumCases.toLocaleString()}
               &nbsp;({((g.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)
-            </CohortLink>,
+            </CohortLink>, */
+            <span>
+              {g.num_affected_cases_all.toLocaleString()} / {totalNumCases.toLocaleString()}
+              &nbsp;({((g.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)
+            </span>,
             ...Object.keys(g.num_affected_cases_by_project)
               .map(k => `
                 ${k}: ${g.num_affected_cases_by_project[k]} / ${numCasesAggByProject[k]}
@@ -106,6 +112,8 @@ const GeneTable = ({
         />
       ),
       num_mutations: (
+        /*  TODO: Commented out as part of PRTL-683
+            Should be revert back once Exploration page is ready
         <CohortLink
           query={{
             searchTableTab: 'mutations',
@@ -113,7 +121,10 @@ const GeneTable = ({
           }}
         >
           {g.case.reduce((acc, c) => acc + (c.ssm || []).length, 0).toLocaleString()}
-        </CohortLink>
+        </CohortLink>*/
+        <span>
+          {g.case.reduce((acc, c) => acc + (c.ssm || []).length, 0).toLocaleString()}
+        </span>
       ),
       survival_plot: (
         <Tooltip Component={`Click icon to plot ${g.symbol}`}>

--- a/modules/node_modules/@ncigdc/components/MutationTable.js
+++ b/modules/node_modules/@ncigdc/components/MutationTable.js
@@ -149,6 +149,8 @@ const MutationTable: TMutationTable = ({
       num_affected_cases_all: (
         <TogglableUl
           items={[
+            /*  TODO: Commented out as part of PRTL-683
+                Should be revert back once Exploration page is ready
             <CohortLink
               query={{
                 searchTableTab: 'cases',
@@ -156,7 +158,10 @@ const MutationTable: TMutationTable = ({
               }}
             >
               {x.num_affected_cases_all} ({((x.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)
-           </CohortLink>,
+            </CohortLink>,*/
+            <span>
+              {x.num_affected_cases_all} ({((x.num_affected_cases_all / totalNumCases) * 100).toFixed(2)}%)
+            </span>,
             ...Object.entries(x.num_affected_cases_by_project)
               .map(([k, v]) => `${k}: ${v} (${((v / totalNumCases) * 100).toFixed(2)}%)`),
           ]}


### PR DESCRIPTION
Commented out links for following tables:
- Gene table: # Affected Cases across all project + # mutations
- Mutation table: # Affected Cases
