### PR TITLE
:bug: PRTL-763 fix overlap of facet reset/value search/remove buttons

### DIFF
--- a/modules/node_modules/@ncigdc/components/Aggregations/DateFacet.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/DateFacet.js
@@ -15,12 +15,8 @@ import { Row, Column } from '@ncigdc/uikit/Flex';
 import Link from '../Links/Link';
 import FacetResetButton from './FacetResetButton';
 
+import { Container } from './';
 import './style.css';
-
-const Container = styled(Column, ({
-  padding: '1rem 1.2rem',
-  backgroundColor: 'white',
-}));
 
 const Header = styled(Row, ({
   color: ({ theme }) => theme.primary,
@@ -51,12 +47,10 @@ const GoLink = styled(Link, ({
 
 const enhance = compose(
   withState('state', 'setState', {
-    collapsed: false,
     date: moment(),
     focused: false,
   }),
   mapProps(({ setState, ...rest }) => ({
-    toggleCollapsed: () => setState(state => ({ collapsed: !state.collapsed })),
     handleDatePicked: (date) => setState(s => ({ ...s, date })),
     setState,
     ...rest,
@@ -70,14 +64,13 @@ type TProps = {
   field: string,
   query: Object,
   title: string,
+  collapsed: boolean,
   state: {
-    collapsed: boolean,
     date: any,
     focused: boolean,
   },
   setState: Function,
   style: Object,
-  toggleCollapsed: Function,
   handleToChanged: Function,
   handleFromChanged: Function,
 };
@@ -97,51 +90,39 @@ const DateFacet = (props: TProps) => {
       }],
     },
   };
+
   return (
-    <LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => {
-    const currentFilters = ctx.query && parseFilterParam((ctx.query || {}).filters, {}).content || [];
-    return (
     <Container style={{ ...props.style }}>
-      <Header>
-        <span style={{ cursor: 'pointer' }} onClick={() => props.toggleCollapsed()}>
-          <AngleIcon style={{ transform: `rotate(${props.state.collapsed ? 270 : 0}deg)` }} />
-          {props.title}
-        </span>
-        <FacetResetButton field={dotField} currentFilters={currentFilters} />
-      </Header>
-      {!props.state.collapsed &&
-      (<Row>
-        <Label
-          style={{
-            borderRight: 0,
-            borderRadius: '4px 0 0 4px',
-          }}
-          htmlFor={`since-${dotField}`}
-        >
-          since
-        </Label>
-        <SingleDatePicker
-          id="date_input"
-          date={props.state.date}
-          displayFormat="YYYY-MM-DD"
-          isOutsideRange={() => false}
-          focused={props.state.focused}
-          onDateChange={(date) => props.setState(s => ({ ...s, date }))}
-          onFocusChange={({ focused }) => { props.setState(s => ({ ...s, focused })); }}
-          enableOutsideDays
-        />
-        <GoLink
-          merge="merge"
-          query={query}
-        >
-          Go!
-        </GoLink>
-      </Row>
+      {!props.collapsed &&
+        (<Row>
+          <Label
+            style={{
+              borderRight: 0,
+              borderRadius: '4px 0 0 4px',
+            }}
+            htmlFor={`since-${dotField}`}
+          >
+            since
+          </Label>
+          <SingleDatePicker
+            id="date_input"
+            date={props.state.date}
+            displayFormat="YYYY-MM-DD"
+            isOutsideRange={() => false}
+            focused={props.state.focused}
+            onDateChange={(date) => props.setState(s => ({ ...s, date }))}
+            onFocusChange={({ focused }) => { props.setState(s => ({ ...s, focused })); }}
+            enableOutsideDays
+          />
+          <GoLink
+            merge="merge"
+            query={query}
+          >
+            Go!
+          </GoLink>
+        </Row>
       )}
     </Container>
-    );
-    }}
-    </LocationSubscriber>
   );
 };
 

--- a/modules/node_modules/@ncigdc/components/Aggregations/FacetHeader.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/FacetHeader.js
@@ -1,0 +1,87 @@
+/* @flow */
+
+import React from 'react';
+import { compose, lifecycle, defaultProps, renameProps, withState } from 'recompose';
+
+import { parseFilterParam } from '@ncigdc/utils/uri';
+import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
+import styled from '@ncigdc/theme/styled';
+import FacetResetButton from '@ncigdc/components/Aggregations/FacetResetButton';
+import CloseIcon from '@ncigdc/theme/icons/CloseIcon';
+import SearchIcon from '@ncigdc/theme/icons/SearchIcon';
+import AngleIcon from '@ncigdc/theme/icons/AngleIcon';
+import { Row } from '@ncigdc/uikit/Flex';
+
+const Header = styled(Row, ({
+  color: ({ theme }) => theme.primary,
+  fontSize: '1.7rem',
+  cursor: 'pointer',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '1rem 1.2rem 0.5rem 1.2rem',
+  backgroundColor: 'white',
+}));
+
+const IconsRow = styled(Row, {
+  color: ({ theme }) => theme.primaryLight1,
+  lineHeight: '1.48px',
+  fontSize: '1.2em',
+});
+
+const RemoveIcon = styled(CloseIcon, {
+  ':hover::before': {
+    textShadow: ({ theme }) => theme.textShadow,
+  },
+  paddingLeft: '2px',
+});
+
+const MagnifyingGlass = styled(SearchIcon, {
+  ':hover::before': {
+    textShadow: ({ theme }) => theme.textShadow,
+  },
+});
+
+const FacetHeader = compose(
+  defaultProps({
+    handleRequestRemove: () => {},
+    isRemovable: false,
+    hasValueSearch: false,
+    setShowingValueSearch: () => {},
+  })
+)(({
+  field,
+  title,
+  isRemovable,
+  handleRequestRemove,
+  collapsed,
+  setCollapsed,
+  showingValueSearch,
+  setShowingValueSearch,
+  hasValueSearch,
+}) => (
+  <LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => {
+    const currentFilters = ctx.query && parseFilterParam((ctx.query || {}).filters, {}).content || [];
+    return (
+      <Header>
+        <span style={{ cursor: 'pointer' }} onClick={() => setCollapsed(!collapsed)}>
+          <AngleIcon style={{ paddingRight: '0.25rem', transform: `rotate(${collapsed ? 270 : 0}deg)` }} />
+          {title}
+        </span>
+        <IconsRow>
+          {hasValueSearch && <MagnifyingGlass onClick={() => setShowingValueSearch(!showingValueSearch)} />}
+          <FacetResetButton field={field} currentFilters={currentFilters} />
+          {
+            isRemovable &&
+              <RemoveIcon
+                onClick={handleRequestRemove}
+                onKeyPress={(event) => event.key === 'Enter' && handleRequestRemove()}
+                role="button"
+                tabIndex="0"
+              />
+          }
+        </IconsRow>
+      </Header>);
+  }}
+  </LocationSubscriber>
+));
+export default FacetHeader;

--- a/modules/node_modules/@ncigdc/components/Aggregations/FacetResetButton.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/FacetResetButton.js
@@ -1,22 +1,38 @@
 // @flow
 
 import React from 'react';
-import UndoIcon from 'react-icons/lib/md/undo';
 
 import Link from '@ncigdc/components/Links/Link';
+import UndoIcon from '@ncigdc/theme/icons/UndoIcon';
 import { getFilterValue } from '@ncigdc/utils/filters';
 import Hidden from '@ncigdc/components/Hidden';
+import styled from '@ncigdc/theme/styled';
 
-const FacetResetButton = ({ field, currentFilters }) => {
+const ShadowedUndoIcon = styled(UndoIcon, {
+  ':hover::before': {
+    textShadow: ({ theme }) => theme.textShadow,
+  },
+});
+
+const StyledLink = styled(Link, {
+  ':link': {
+    color: ({ theme }) => theme.primaryLight1,
+  },
+  ':visited': {
+    color: ({ theme }) => theme.primaryLight1,
+  },
+});
+
+const FacetResetButton = ({ field, currentFilters, style, ...props }) => {
   const currentValues = getFilterValue({
-      currentFilters,
-      dotField: field,
+    currentFilters,
+    dotField: field,
   }) || { content: { value: [] } };
   const display = !!currentValues.content.value.length;
   return (
-  <Link
+  <StyledLink
     merge="toggle"
-    style={{ display: display ? 'inline' : 'none' }}
+    style={{ display: display ? 'inline' : 'none', ...style }}
     query={!!currentValues.content.value.length && {
       offset: 0,
       filters: {
@@ -31,8 +47,8 @@ const FacetResetButton = ({ field, currentFilters }) => {
       },
     }}
   >
-    <UndoIcon /><Hidden>reset</Hidden>
-  </Link>
+    <ShadowedUndoIcon /><Hidden>reset</Hidden>
+  </StyledLink>
   );
 };
 

--- a/modules/node_modules/@ncigdc/components/Aggregations/PrefixFacet.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/PrefixFacet.js
@@ -11,28 +11,14 @@ import SearchIcon from 'react-icons/lib/fa/search';
 import { makeFilter } from '@ncigdc/utils/filters';
 import { parseFilterParam } from '@ncigdc/utils/uri';
 import { Row, Column } from '@ncigdc/uikit/Flex';
-import Input from '@ncigdc/uikit/Form/Input';
 import withDropdown from '@ncigdc/uikit/withDropdown';
 import { withTheme } from '@ncigdc/theme';
 import { dropdown } from '@ncigdc/theme/mixins';
 import styled from '@ncigdc/theme/styled';
 import Link from '@ncigdc/components/Links/Link';
 import Hidden from '@ncigdc/components/Hidden';
-import FacetResetButton from './FacetResetButton';
 
-const Container = styled(Column, {
-  padding: '1rem 1.2rem',
-  backgroundColor: 'white',
-});
-
-const Header = styled(Row, {
-  color: ({ theme }) => theme.primary,
-  fontSize: '1.7rem',
-  marginBottom: '0.5rem',
-  cursor: 'pointer',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-});
+import { Container, StyledInput } from './';
 
 const MagnifyingGlass = styled(SearchIcon, {
   backgroundColor: ({ theme }) => theme.greyScale5,
@@ -61,85 +47,66 @@ const StyledDropdownLink = styled(Link, ({
 }));
 
 let input;
-
 const PrefixFacet = compose(
   withDropdown,
-  withState('state', 'setState', { collapsed: false }),
-  mapProps(({ setState, ...rest }) => ({
-    toggleCollapsed: () => setState(state => ({ collapsed: !state.collapsed })),
-    ...rest,
-  })),
   pure,
-  withTheme
+  withState('value', 'setValue', '')
 )(({
-  title,
-  state,
   doctype,
   fieldNoDoctype,
-  toggleCollapsed,
   placeholder,
-  setAutocomplete,
   setActive,
   active,
   mouseDownHandler,
   mouseUpHandler,
-}) => {
-  return (
-    <LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => {
-      const currentFilters = ctx.query && parseFilterParam((ctx.query || {}).filters, {}).content || [];
-      return (
-        <Container>
-          <Header>
-            <span style={{ cursor: 'pointer' }} onClick={() => toggleCollapsed()}>
-              <AngleIcon style={{ transform: `rotate(${state.collapsed ? 270 : 0}deg)` }} />
-              {title}
-            </span>
-            <FacetResetButton field={`${doctype}.${fieldNoDoctype}`} currentFilters={currentFilters} />
-          </Header>
-          {!state.collapsed &&
-            <Row>
-              <label htmlFor={fieldNoDoctype}><MagnifyingGlass /><Hidden>title</Hidden></label>
-              <Input
-                id={fieldNoDoctype}
-                name={fieldNoDoctype}
-                getNode={node => { input = node; }}
-                onChange={() => {
-                  setActive(!!input.value);
-                }}
-                placeholder={placeholder}
-              />
-              {active &&
-                <Column
-                  style={{ ...dropdown, marginTop: 0, top: '35px', minWidth: '290px' }}
-                  onMouseUp={mouseUpHandler}
-                  onMouseDown={mouseDownHandler}
-                >
-                  <StyledDropdownLink
-                    merge="toggle"
-                    query={{
-                      filters: makeFilter([
-                        {
-                          field: `${doctype}.${fieldNoDoctype}`,
-                          value: [`${input.value}*`],
-                        },
-                      ], false),
-                    }}
-                    id='prefix-search-link'
-                    onClick={() => {
-                      setActive(false);
-                      input.value = '';
-                    }}
-                  >
-                    {input.value}* <br />
-                    Prefix Search
-                  </StyledDropdownLink>
-                </Column>
-            }
-            </Row>
-        }
-        </Container>);
-    }}
-    </LocationSubscriber>
-  );
-});
+  value,
+  setValue,
+  collapsed,
+}) => (
+  <Container>
+    {!collapsed &&
+      <Row>
+        <label htmlFor={fieldNoDoctype}><MagnifyingGlass /><Hidden>title</Hidden></label>
+        <StyledInput
+          id={fieldNoDoctype}
+          name={fieldNoDoctype}
+          onChange={(e) => {
+            const v = e.target.value;
+            setValue(v);
+            setActive(!!v);
+          }}
+          placeholder={placeholder}
+          value={value}
+        />
+        {active &&
+          <Column
+            style={{ ...dropdown, marginTop: 0, top: '35px', minWidth: '290px' }}
+            onMouseUp={mouseUpHandler}
+            onMouseDown={mouseDownHandler}
+          >
+            <StyledDropdownLink
+              merge="toggle"
+              query={{
+                filters: makeFilter([
+                  {
+                    field: `${doctype}.${fieldNoDoctype}`,
+                    value: [`${value}*`],
+                  },
+                ], false),
+              }}
+              id='prefix-search-link'
+              onClick={() => {
+                setActive(false);
+                setValue('');
+              }}
+            >
+              {value}* <br />
+              Prefix Search
+            </StyledDropdownLink>
+          </Column>
+      }
+      </Row>
+  }
+  </Container>
+));
 export default PrefixFacet;

--- a/modules/node_modules/@ncigdc/components/Aggregations/RangeFacet.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/RangeFacet.js
@@ -2,16 +2,15 @@
 
 import React from 'react';
 import { compose, withState, mapProps, pure, lifecycle } from 'recompose';
-import AngleIcon from 'react-icons/lib/fa/angle-down';
 
 import styled from '@ncigdc/theme/styled';
 import withRouter from '@ncigdc/utils/withRouter';
-import Input from '@ncigdc/uikit/Form/Input';
 import { parseFilterParam } from '@ncigdc/utils/uri';
+import Input from '@ncigdc/uikit/Form/Input';
 import { Row, Column } from '@ncigdc/uikit/Flex';
 import ExclamationTriangle from '@ncigdc/theme/icons/ExclamationTriangle';
 
-import Link from '../Links/Link';
+import { Container, InputLabel, StyledInput, GoLink } from './';
 
 const getCurrentFromAndTo = ({ field, query }) => {
   const dotField = field.replace(/__/g, '.');
@@ -76,32 +75,6 @@ const convertInputs = ({ from, to, selectedUnit, setState }) => {
   }
 };
 
-const Container = styled(Column, ({
-  padding: '1rem 1.2rem',
-  backgroundColor: 'white',
-}));
-
-const HeaderRow = styled(Row, ({
-  color: ({ theme }) => theme.primary,
-  fontSize: '1.7rem',
-  marginBottom: '0.5rem',
-  cursor: 'pointer',
-  alignItems: 'center',
-}));
-
-const InputLabel = styled.label({
-  backgroundColor: ({ theme }) => theme.greyScale5,
-  color: ({ theme }) => theme.greyScale2,
-  padding: '0.8rem',
-  height: '3.4rem',
-  border: ({ theme }) => `1px solid ${theme.greyScale4}`,
-});
-
-const StyledInput = styled(Input, ({
-  height: '3.4rem',
-  borderRadius: 0,
-}));
-
 const WarningRow = styled(Row, ({
   backgroundColor: '#fcf8e3',
   borderColor: '#faebcc',
@@ -111,19 +84,8 @@ const WarningRow = styled(Row, ({
   borderRadius: '4px',
 }));
 
-const GoLink = styled(Link, ({
-  color: ({ theme, dark }) => (dark ? theme.greyScale2 : theme.greyScale4),
-  textDecoration: 'none',
-  border: ({ theme }) => `1px solid ${theme.greyScale4}`,
-  borderLeft: 0,
-  padding: '6px 4px 2px 4px',
-  height: '3.4rem',
-  borderRadius: '0 4px 4px 0',
-}));
-
 const enhance = compose(
   withState('state', 'setState', {
-    collapsed: false,
     from: undefined,
     to: undefined,
     fromDisplayed: '',
@@ -168,7 +130,6 @@ const enhance = compose(
     },
   }),
   mapProps(({ setState, max, min, convertDays, ...rest }) => ({
-    toggleCollapsed: () => setState(state => ({ ...state, collapsed: !state.collapsed })),
     handleFromChanged: (e) => {
       const v = e.target.value;
       const { state: { toDisplayed, selectedUnit } } = rest;
@@ -201,7 +162,6 @@ type TProps = {
   query: Object,
   title: string,
   state: {
-    collapsed: boolean,
     to: number,
     from: number,
     selectedUnit: string,
@@ -216,6 +176,7 @@ type TProps = {
   min: Number,
   max: Number,
   convertDays: boolean,
+  collapsed: boolean,
 };
 
 const RangeFacet = (props: TProps) => {
@@ -242,11 +203,7 @@ const RangeFacet = (props: TProps) => {
 
   return (
     <Container style={{ ...props.style }}>
-      <HeaderRow onClick={() => props.toggleCollapsed()}>
-        <AngleIcon style={{ transform: `rotate(${props.state.collapsed ? 270 : 0}deg)` }} />
-        {props.title}
-      </HeaderRow>
-      {!props.state.collapsed && props.convertDays && (
+      {!props.collapsed && props.convertDays && (
         <Row>
           <form name={`${dotField}-radio`}>
             <label htmlFor={`${dotField}-years-radio`} style={{ paddingRight: '10px' }}>
@@ -277,7 +234,7 @@ const RangeFacet = (props: TProps) => {
           </form>
         </Row>
       )}
-      {!props.state.collapsed &&
+      {!props.collapsed &&
         (<Column>
           <Row>
             <InputLabel

--- a/modules/node_modules/@ncigdc/components/Aggregations/SuggestionFacet.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/SuggestionFacet.js
@@ -2,8 +2,7 @@
 
 // Vendor
 import React from 'react';
-import { compose, withState, mapProps, pure } from 'recompose';
-import AngleIcon from 'react-icons/lib/fa/angle-down';
+import { compose, pure } from 'recompose';
 import SearchIcon from 'react-icons/lib/fa/search';
 import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
 
@@ -11,31 +10,14 @@ import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
 import { parseFilterParam } from '@ncigdc/utils/uri';
 import { getFilterValue } from '@ncigdc/utils/filters';
 import { Row, Column } from '@ncigdc/uikit/Flex';
-import Input from '@ncigdc/uikit/Form/Input';
 import withDropdown from '@ncigdc/uikit/withDropdown';
 import styled from '@ncigdc/theme/styled';
 import { dropdown } from '@ncigdc/theme/mixins';
 import Link from '@ncigdc/components/Links/Link';
 import CheckCircleOIcon from '@ncigdc/theme/icons/CheckCircleOIcon';
 import type { TRawQuery } from '@ncigdc/utils/uri/types';
-import FacetResetButton from './FacetResetButton';
 import Hidden from '../Hidden';
-
-/*----------------------------------------------------------------------------*/
-
-const Container = styled(Column, {
-  padding: '1rem 1.2rem',
-  backgroundColor: 'white',
-});
-
-const Header = styled(Row, {
-  color: ({ theme }) => theme.primary,
-  fontSize: '1.7rem',
-  marginBottom: '0.5rem',
-  cursor: 'pointer',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-});
+import { Container, StyledInput } from './';
 
 const MagnifyingGlass = styled(SearchIcon, {
   backgroundColor: ({ theme }) => theme.greyScale5,
@@ -60,6 +42,11 @@ const StyledDropdownLink = styled(Link, ({
   padding: '1rem',
   ':link': {
     textDecoration: 'none',
+    color: ({ theme }) => theme.primary,
+  },
+  ':visited': {
+    textDecoration: 'none',
+    color: ({ theme }) => theme.primary,
   },
   ':hover': {
     backgroundColor: 'rgb(31, 72, 108)',
@@ -84,37 +71,15 @@ const CheckedLink = styled(Link, ({
   },
 }));
 
-const GoLink = styled(Link, ({
-  color: ({ theme, dark }) => (dark ? theme.greyScale2 : theme.greyScale4),
-  textDecoration: 'none',
-  border: ({ theme }) => `1px solid ${theme.greyScale4}`,
-  borderLeft: 0,
-  padding: '6px 4px 2px 4px',
-  height: '3.4rem',
-  borderRadius: '0 4px 4px 0',
-  ':link': {
-    textDecoration: 'none',
-  },
-}));
-
 let input;
 const SuggestionFacet = compose(
   withDropdown,
-  withState('state', 'setState', { collapsed: false, inputValue: '' }),
-  mapProps(({ setState, ...rest }) => ({
-    toggleCollapsed: () => setState(state => ({ ...state, collapsed: !state.collapsed })),
-    setInputValue: v => setState(state => ({ ...state, inputValue: v })),
-    ...rest,
-  })),
   pure
 )(({
   dropdownItem,
   title,
   doctype,
   fieldNoDoctype,
-  state,
-  toggleCollapsed,
-  setInputValue,
   placeholder,
   hits,
   setAutocomplete,
@@ -122,6 +87,8 @@ const SuggestionFacet = compose(
   active,
   mouseDownHandler,
   mouseUpHandler,
+  collapsed,
+  style,
 }) => {
   const query = v => ({
     offset: 0,
@@ -146,15 +113,8 @@ const SuggestionFacet = compose(
         dotField: `${doctype}.${fieldNoDoctype}`,
       }) || { content: { value: [] } };
       return (
-        <Container>
-          <Header>
-            <span style={{ cursor: 'pointer' }} onClick={() => toggleCollapsed()}>
-              <AngleIcon style={{ transform: `rotate(${state.collapsed ? 270 : 0}deg)` }} />
-              {title}
-            </span>
-            <FacetResetButton field={`${doctype}.${fieldNoDoctype}`} currentFilters={currentFilters} />
-          </Header>
-          {!state.collapsed &&
+        <Container style={style}>
+          {!collapsed &&
             <Column>
               {currentValues.content.value.map(v => (
                 <CheckedRow key={v}>
@@ -181,12 +141,11 @@ const SuggestionFacet = compose(
               ))}
               <Row>
                 <label htmlFor={fieldNoDoctype}><MagnifyingGlass /><Hidden>{title}</Hidden></label>
-                <Input
+                <StyledInput
                   id={fieldNoDoctype}
                   name={fieldNoDoctype}
                   getNode={node => { input = node; }}
                   onChange={() => {
-                    setInputValue(input.value);
                     setActive(!!input.value);
                     if (!!input.value) {
                       setAutocomplete(input.value);
@@ -208,7 +167,7 @@ const SuggestionFacet = compose(
                 >
                   {(hits || []).map(x => (
                     <Row
-                    key={x.id}
+                      key={x.id}
                       style={{ alignItems: 'center' }}
                     >
                       <StyledDropdownLink
@@ -231,13 +190,6 @@ const SuggestionFacet = compose(
                   }
                 </Column>
                 }
-                <GoLink
-                  dark={!!state.inputValue}
-                  merge="toggle"
-                  query={state.inputValue !== '' && query(state.inputValue)}
-                >
-                  Go!
-                </GoLink>
               </Row>
             </Column>
           }

--- a/modules/node_modules/@ncigdc/components/Aggregations/TermAggregation.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/TermAggregation.js
@@ -2,10 +2,8 @@
 
 import React from 'react';
 import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
-import { compose, withState, mapProps, withPropsOnChange, pure } from 'recompose';
-import AngleIcon from 'react-icons/lib/fa/angle-down';
+import { compose, withState, withPropsOnChange, pure } from 'recompose';
 
-import SearchIcon from '@ncigdc/theme/icons/SearchIcon';
 import CloseIcon from '@ncigdc/theme/icons/CloseIcon';
 import type { TRawQuery } from '@ncigdc/utils/uri/types';
 import { parseFilterParam } from '@ncigdc/utils/uri';
@@ -18,7 +16,7 @@ import styled from '@ncigdc/theme/styled';
 import Input from '@ncigdc/uikit/Form/Input';
 
 import Link from '../Links/Link';
-import FacetResetButton from './FacetResetButton';
+import { Container } from './';
 
 import type { TBucket } from './types';
 
@@ -26,22 +24,13 @@ type TProps = {
   buckets: [TBucket],
   field: string,
   filteredBuckets: Array<Object>,
-  state: {
-    collapsed: boolean,
-    showingMore: boolean,
-    showingValueSearch: boolean,
-  },
   style: Object,
   title: string,
-  toggleCollapsed: Function,
-  toggleShowMore: Function,
-  toggleValueSearch: Function,
+  showingValueSearch: boolean,
+  collapsed: boolean,
+  setShowingMore: Function,
+  showingMore: boolean,
 };
-
-const Container = styled(Column, ({
-  padding: '1rem 1.2rem',
-  backgroundColor: 'white',
-}));
 
 const BucketLink = styled(Link, ({
   color: '#3a3a3a',
@@ -61,15 +50,6 @@ const ToggleMoreLink = styled(A, ({
   },
 }));
 
-const HeaderRow = styled(Row, ({
-  color: ({ theme }) => theme.primary,
-  fontSize: '1.7rem',
-  marginBottom: '0.5rem',
-  cursor: 'pointer',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-}));
-
 const BucketRow = styled(Row, ({
   padding: '0.3rem 0',
 }));
@@ -83,24 +63,12 @@ const TermAggregation = (props: TProps) => {
   const dotField = props.field.replace(/__/g, '.');
   const { filteredBuckets } = props;
 
-  const hasValueSearch = filteredBuckets.length >= 20;
   return (
     <LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => {
       const currentFilters = ctx.query && parseFilterParam((ctx.query || {}).filters, {}).content || [];
       return (
         <Container style={props.style}>
-          <HeaderRow>
-            <span style={{ cursor: 'pointer' }} onClick={() => props.toggleCollapsed()}>
-              <AngleIcon style={{ transform: `rotate(${props.state.collapsed ? 270 : 0}deg)` }} />
-              {props.title}
-            </span>
-            <span>
-              { (hasValueSearch || props.state.showingValueSearch) &&
-                <SearchIcon onClick={() => props.toggleValueSearch()} style={{ paddingRight: '5px' }}/>}
-              <FacetResetButton field={dotField} currentFilters={currentFilters} />
-            </span>
-          </HeaderRow>
-          {!props.state.collapsed && props.state.showingValueSearch &&
+          {!props.collapsed && props.showingValueSearch &&
             <Row>
               <Input
                 getNode={node => { input = node; }}
@@ -125,10 +93,10 @@ const TermAggregation = (props: TProps) => {
               }
             </Row>
           }
-          {!props.state.collapsed &&
+          {!props.collapsed &&
             <Column>
               {filteredBuckets
-                .slice(0, props.state.showingMore ? Infinity : 5)
+                .slice(0, props.showingMore ? Infinity : 5)
                 .map(b => ({ ...b, name: b.key === '1' ? 'Cancer Gene Sensus' : b.key })) // TODO: this needs to change in the data
                 .map(bucket => (
                   <BucketRow key={bucket.key}>
@@ -156,7 +124,9 @@ const TermAggregation = (props: TProps) => {
                         id={`input-${bucket.name.replace(/\s/g, '-')}`}
                         name={`input-${bucket.name.replace(/\s/g, '-')}`}
                       />
-                      <label htmlFor={`input-${bucket.name.replace(/\s/g, '-')}`} style={{ marginLeft: '0.3rem' }}>{bucket.name}</label>
+                      <label htmlFor={`input-${bucket.name.replace(/\s/g, '-')}`} style={{ marginLeft: '0.3rem' }}>
+                        {bucket.name}
+                      </label>
                     </BucketLink>
                     <CountBubble>{bucket.doc_count.toLocaleString()}</CountBubble>
                   </BucketRow>
@@ -164,8 +134,8 @@ const TermAggregation = (props: TProps) => {
             }
               {filteredBuckets.length > 5 &&
                 <BottomRow>
-                  <ToggleMoreLink onClick={() => props.toggleShowMore()}>
-                    {props.state.showingMore
+                  <ToggleMoreLink onClick={() => props.setShowingMore(!props.showingMore)}>
+                    {props.showingMore
                       ? 'Less...'
                       : filteredBuckets.length - 5 && 'More...'
                     }
@@ -189,19 +159,8 @@ const TermAggregation = (props: TProps) => {
 };
 
 const enhance = compose(
-  withState('state', 'setState', {
-    collapsed: false,
-    showingMore: false,
-    showingValueSearch: false,
-  }),
+  withState('showingMore', 'setShowingMore', false),
   withState('filter', 'setFilter', ''),
-  mapProps(({ setState, ...rest }) => ({
-    toggleCollapsed: () => setState(s => ({ ...s, collapsed: !s.collapsed})),
-    toggleShowMore: () => setState(s => ({ ...s, showingMore: !s.showingMore })),
-    toggleValueSearch: () => setState(s => ({ ...s, showingValueSearch: !s.showingValueSearch})),
-    setState,
-    ...rest,
-  })),
   withPropsOnChange(['buckets', 'filter'], ({ buckets, filter }) => ({
     filteredBuckets: buckets.filter(b => b.key !== '_missing' && b.key.toLowerCase().includes(filter.toLowerCase())),
   })),

--- a/modules/node_modules/@ncigdc/components/Aggregations/index.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/index.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import { Column } from '@ncigdc/uikit/Flex';
+import styled from '@ncigdc/theme/styled';
+import Input from '@ncigdc/uikit/Form/Input';
+
+import Link from '@ncigdc/components/Links/Link';
+
+export const Container = styled(Column, ({
+  padding: '0 1.2rem 1rem 1.2rem',
+  backgroundColor: 'white',
+}));
+
+export const InputLabel = styled.label({
+  backgroundColor: ({ theme }) => theme.greyScale5,
+  color: ({ theme }) => theme.greyScale2,
+  padding: '0.8rem',
+  height: '3.4rem',
+  border: ({ theme }) => `1px solid ${theme.greyScale4}`,
+});
+
+export const StyledInput = styled(Input, ({
+  height: '3.4rem',
+  borderRadius: '0 4px 4px 0',
+}));
+
+export const GoLink = styled(Link, ({
+  color: ({ theme, dark }) => (dark ? theme.greyScale2 : theme.greyScale4),
+  textDecoration: 'none',
+  border: ({ theme }) => `1px solid ${theme.greyScale4}`,
+  borderLeft: 0,
+  padding: '6px 4px 2px 4px',
+  height: '3.4rem',
+  borderRadius: '0 4px 4px 0',
+  ':link': {
+    textDecoration: 'none',
+  },
+}));

--- a/modules/node_modules/@ncigdc/components/FacetWrapper.js
+++ b/modules/node_modules/@ncigdc/components/FacetWrapper.js
@@ -4,14 +4,15 @@
 import React from 'react';
 import _ from 'lodash';
 
-import { css } from 'glamor';
-import { compose, lifecycle, defaultProps, renameProps } from 'recompose';
-import { withTheme } from '@ncigdc/theme';
+import { compose, lifecycle, defaultProps, renameProps, withState } from 'recompose';
 
 import TermAggregation from '@ncigdc/components/Aggregations/TermAggregation';
 import DateFacet from '@ncigdc/components/Aggregations/DateFacet';
 import PrefixFacet from '@ncigdc/components/Aggregations/PrefixFacet';
 import RangeFacet from '@ncigdc/components/Aggregations/RangeFacet';
+import styled from '@ncigdc/theme/styled';
+import { Row } from '@ncigdc/uikit/Flex';
+import FacetHeader from '@ncigdc/components/Aggregations/FacetHeader';
 
 import escapeForRelay from '@ncigdc/utils/escapeForRelay';
 
@@ -26,6 +27,10 @@ const fieldNameToTitle = (fieldName) => fieldName.replace(/_|\./g, ' ')
 const getFacetType = facet => {
   if (_.includes(facet.field, 'datetime')) {
     return 'datetime';
+  } else if (facet.type === 'terms') {
+    // on Annotations & Repo pages project_id is a terms facet
+    // need a way to force an *_id field to return terms
+    return 'terms';
   } else if (_.some(['_id', '_uuid', 'md5sum', 'file_name'], idSuffix => _.includes(facet.field, idSuffix))) {
     return 'id';
   } else if (facet.type === 'long') {
@@ -35,25 +40,11 @@ const getFacetType = facet => {
   }
 };
 
-const styles = {
-  FacetWrapper: {
-    position: 'relative',
-  },
-  removeIcon: {
-    color: '#bb0e3d',
-    position: 'absolute',
-    zIndex: 1,
-    fontSize: '1.4em',
-    top: 15,
-    right: 15,
-    ':hover::before': {
-      textShadow: '0 0 7px rgba(255, 127, 71, 0.62)',
-    },
-  },
-};
+const FacetWrapperDiv = styled.div({
+  position: 'relative',
+});
 
 const FacetWrapper = compose(
-  withTheme,
   defaultProps({
     onRequestRemove: _.noop,
     isRemovable: false,
@@ -76,19 +67,33 @@ const FacetWrapper = compose(
         });
       }
     },
-  })
-)(({ facet, title, aggregation = {}, handleRequestRemove, style, isRemovable, additionalProps }) => {
+  }),
+  withState('showingValueSearch', 'setShowingValueSearch', false),
+  withState('collapsed', 'setCollapsed', false)
+)(({
+  setShowingValueSearch,
+  showingValueSearch,
+  collapsed,
+  setCollapsed,
+  facet,
+  title,
+  aggregation = {},
+  handleRequestRemove,
+  style,
+  isRemovable,
+  additionalProps,
+}) => {
   const facetType = getFacetType(facet);
   const displayTitle = title || fieldNameToTitle(facet.field);
   const commonProps = {
     style,
     title: displayTitle,
+    collapsed,
   };
 
   const facetComponent = ({
     id: () => (
       <PrefixFacet
-        field={facet.full}
         hits={{}}
         {...commonProps}
         fieldNoDoctype={facet.field}
@@ -118,25 +123,28 @@ const FacetWrapper = compose(
         field={facet.full}
         {...commonProps}
         buckets={aggregation.buckets || []}
+        showingValueSearch={showingValueSearch}
         {...additionalProps}
       />
     ),
   }[facetType])();
+  const hasValueSearch = facetType === 'terms' && (aggregation.buckets || []).filter(b => b.key !== '_missing').length >= 20;
 
   return (
-    <div {...css(styles.FacetWrapper)} style={style}>
-      {
-        isRemovable && <i
-          className="fa fa-times"
-          onClick={handleRequestRemove}
-          onKeyPress={(event) => event.key === 'Enter' && handleRequestRemove()}
-          role="button"
-          tabIndex="0"
-          {...css(styles.removeIcon)}
-        />
-      }
+    <FacetWrapperDiv style={style}>
+      <FacetHeader
+        title={displayTitle}
+        field={facet.full}
+        handleRequestRemove={handleRequestRemove}
+        isRemovable={isRemovable}
+        hasValueSearch={hasValueSearch}
+        collapsed={collapsed}
+        setCollapsed={setCollapsed}
+        showingValueSearch={showingValueSearch}
+        setShowingValueSearch={setShowingValueSearch}
+      />
       {facetComponent}
-    </div>
+    </FacetWrapperDiv>
   );
 });
 

--- a/modules/node_modules/@ncigdc/containers/AnnotationAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/AnnotationAggregations.js
@@ -2,18 +2,22 @@
 
 import React from 'react';
 import Relay from 'react-relay';
+import { compose, withState } from 'recompose';
 
-import TermAggregation from '@ncigdc/components/Aggregations/TermAggregation';
 import SuggestionFacet from '@ncigdc/components/Aggregations/SuggestionFacet';
-import DateFacet from '@ncigdc/components/Aggregations/DateFacet';
-import { Row } from '@ncigdc/uikit/Flex';
+import FacetHeader from '@ncigdc/components/Aggregations/FacetHeader';
+import FacetWrapper from '@ncigdc/components/FacetWrapper';
+import escapeForRelay from '@ncigdc/utils/escapeForRelay';
 
 import type { TBucket } from '@ncigdc/components/Aggregations/types';
 
+import { Row } from '@ncigdc/uikit/Flex';
 import { withTheme } from '@ncigdc/theme';
 import AnnotationIcon from '@ncigdc/theme/icons/AnnotationIcon';
 
 export type TProps = {
+  annotationIdCollapsed: boolean,
+  setAnnotationIdCollapsed: Function,
   aggregations: {
     category: { buckets: [TBucket] },
     classification: { buckets: [TBucket] },
@@ -28,58 +32,54 @@ export type TProps = {
   theme: Object,
 };
 
-export const AnnotationAggregationsComponent = (props: TProps) => (
+const annotationFacets = [
+  { title: 'Primary Site', field: 'project.primary_site', full: 'annotations.project.primary_site', doc_type: 'annotation', type: 'keyword' },
+  { title: 'Project', field: 'project.project_id', full: 'annotations.project.project_id', doc_type: 'annotation', type: 'terms' },
+  { title: 'Entity Type', field: 'entity_type', full: 'annotations.entity_type', doc_type: 'annotation', type: 'keyword' },
+  { title: 'Annotation Category', field: 'category', full: 'annotations.category', doc_type: 'annotation', type: 'keyword' },
+  { title: 'Annotation Created', field: 'created_datetime', full: 'annotations.created_datetime', doc_type: 'annotation', type: 'date' },
+  { title: 'Annotation Classification', field: 'classification', full: 'annotations.classification', doc_type: 'annotation', type: 'keyword' },
+];
+
+export const AnnotationAggregationsComponent = compose(
+  withState('annotationIdCollapsed', 'setAnnotationIdCollapsed', false)
+)((props: TProps) => (
   <div>
-    <SuggestionFacet
+    <FacetHeader
       title="Annotation ID"
+      field="annotations.annotation_id"
+      collapsed={props.annotationIdCollapsed}
+      setCollapsed={props.setAnnotationIdCollapsed}
+    />
+    <SuggestionFacet
+      collapsed={props.annotationIdCollapsed}
       placeholder="Search for Annotation ID"
       hits={props.suggestions}
       setAutocomplete={props.setAutocomplete}
       doctype='annotations'
       fieldNoDoctype='annotation_id'
+      style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
       dropdownItem={(x) => (
         <Row>
           <AnnotationIcon style={{ paddingRight: '1rem' }} />
           {x.annotation_id}
         </Row>)}
     />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.project__primary_site'}
-      title="Primary Site"
-      buckets={props.aggregations.project__primary_site.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.project__project_id'}
-      title="Project"
-      buckets={props.aggregations.project__project_id.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.entity_type'}
-      title="Entity Type"
-      buckets={props.aggregations.entity_type.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.category'}
-      title="Annotation Category"
-      buckets={props.aggregations.category.buckets}
-    />
-    <DateFacet
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.created_datetime'}
-      title="Annotation Created"
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'annotations.classification'}
-      title="Annotation Classification"
-      buckets={props.aggregations.classification.buckets}
-    />
+    {
+      annotationFacets.map((facet) => (
+        <FacetWrapper
+          key={facet.full}
+          facet={facet}
+          title={facet.title}
+          aggregation={props.aggregations[escapeForRelay(facet.field)]}
+          relay={props.relay}
+          additionalProps={facet.additionalProps}
+          style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
+        />
+      ))
+    }
   </div>
-);
+));
 
 export const AnnotationAggregationsQuery = {
   fragments: {

--- a/modules/node_modules/@ncigdc/containers/CaseAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/CaseAggregations.js
@@ -5,7 +5,7 @@ import React from 'react';
 import Relay from 'react-relay';
 
 import _ from 'lodash';
-import { compose } from 'recompose';
+import { compose, withState } from 'recompose';
 
 import Modal from '@ncigdc/uikit/Modal';
 import SuggestionFacet from '@ncigdc/components/Aggregations/SuggestionFacet';
@@ -21,8 +21,12 @@ import { initialCaseAggregationsVariables, repositoryCaseAggregationsFragment } 
 import withFacetSelection from '@ncigdc/utils/withFacetSelection';
 import escapeForRelay from '@ncigdc/utils/escapeForRelay';
 import tryParseJSON from '@ncigdc/utils/tryParseJSON';
+import FacetHeader from '@ncigdc/components/Aggregations/FacetHeader';
 
 export type TProps = {
+  caseIdCollapsed: boolean,
+  setCaseIdCollapsed: Function,
+  relay: Object,
   aggregations: {
     demographic__ethnicity: { buckets: [TBucket] },
     demographic__gender: { buckets: [TBucket] },
@@ -67,7 +71,7 @@ const presetFacets = [
   { title: 'Case Submitter ID', field: 'submitter_id', full: 'cases.submitter_id', doc_type: 'cases', type: 'id' },
   { title: 'Primary Site', field: 'primary_site', full: 'cases.primary_site', doc_type: 'cases', type: 'keyword' },
   { title: 'Cancer Program', field: 'project.program.name', full: 'cases.project.program.name', doc_type: 'cases', type: 'keyword' },
-  { title: 'Project', field: 'project.project_id', full: 'cases.project.project_id', doc_type: 'cases', type: 'keyword' },
+  { title: 'Project', field: 'project.project_id', full: 'cases.project.project_id', doc_type: 'cases', type: 'terms' },
   { title: 'Days to Death', field: 'diagnoses.days_to_death', full: 'cases.diagnoses.days_to_death', doc_type: 'cases', type: 'long' },
   { title: 'Disease Type', field: 'project.disease_type', full: 'cases.project.disease_type', doc_type: 'cases', type: 'keyword' },
   { title: 'Age at Diagnosis', field: 'diagnoses.age_at_diagnosis', full: 'cases.diagnoses.age_at_diagnosis', doc_type: 'cases', type: 'long', additionalProps: { convertDays: true } },
@@ -84,7 +88,8 @@ const enhance = compose(
     storageKey,
     presetFacetFields,
     validFacetDocTypes: ['cases'],
-  })
+  }),
+  withState('caseIdCollapsed', 'setCaseIdCollapsed', false)
 );
 
 const styles = {
@@ -137,8 +142,14 @@ export const CaseAggregationsComponent = (props: TProps) => (
       ))
     }
 
-    <SuggestionFacet
+    <FacetHeader
       title="Case"
+      field="cases.case_id"
+      collapsed={props.caseIdCollapsed}
+      setCollapsed={props.setCaseIdCollapsed}
+    />
+    <SuggestionFacet
+      collapsed={props.caseIdCollapsed}
       doctype="cases"
       fieldNoDoctype="case_id"
       placeholder="Search for Case ID or Case Submitter ID"
@@ -160,6 +171,7 @@ export const CaseAggregationsComponent = (props: TProps) => (
           </Column>
         </span>
       )}
+      style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
     />
 
     {
@@ -170,8 +182,8 @@ export const CaseAggregationsComponent = (props: TProps) => (
           title={facet.title}
           aggregation={props.aggregations[escapeForRelay(facet.field)]}
           relay={props.relay}
-          style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
           additionalProps={facet.additionalProps}
+          style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         />
       ))
     }

--- a/modules/node_modules/@ncigdc/containers/FileAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/FileAggregations.js
@@ -5,13 +5,13 @@ import React from 'react';
 import Relay from 'react-relay';
 
 import _ from 'lodash';
-import { compose, defaultProps } from 'recompose';
+import { compose, withState } from 'recompose';
 
 import Modal from '@ncigdc/uikit/Modal';
-import TermAggregation from '@ncigdc/components/Aggregations/TermAggregation';
 import SuggestionFacet from '@ncigdc/components/Aggregations/SuggestionFacet';
 import FacetSelection from '@ncigdc/components/FacetSelection';
 import FacetWrapper from '@ncigdc/components/FacetWrapper';
+import FacetHeader from '@ncigdc/components/Aggregations/FacetHeader';
 
 import { initialFileAggregationsVariables, repositoryFileAggregationsFragment } from '@ncigdc/utils/generated-relay-query-parts';
 import withFacetSelection from '@ncigdc/utils/withFacetSelection';
@@ -22,7 +22,7 @@ import type { TBucket } from '@ncigdc/components/Aggregations/types';
 
 import { withTheme } from '@ncigdc/theme';
 import FileIcon from '@ncigdc/theme/icons/File';
-import { Row, Column } from '@ncigdc/uikit/Flex';
+import { Column } from '@ncigdc/uikit/Flex';
 
 const storageKey = 'RepositoryFileAggregations.userSelectedFacets';
 
@@ -44,7 +44,8 @@ const enhance = compose(
     storageKey,
     presetFacetFields,
     validFacetDocTypes: ['files'],
-  })
+  }),
+  withState('fileIdCollapsed', 'setFileIdCollapsed', false)
 );
 
 const styles = {
@@ -55,6 +56,9 @@ const styles = {
 };
 
 export type TProps = {
+  relay: Object,
+  fileIdCollapsed: boolean,
+  setFileIdCollapsed: Function,
   aggregations: {
     access: { buckets: [TBucket] },
     data_category: { buckets: [TBucket] },
@@ -126,13 +130,20 @@ export const FileAggregationsComponent = (props: TProps) => (
           />
         ))
       }
-      <SuggestionFacet
+      <FacetHeader
         title="File"
+        field="files.file_id"
+        collapsed={props.fileIdCollapsed}
+        setCollapsed={props.setFileIdCollapsed}
+      />
+      <SuggestionFacet
+        collapsed={props.fileIdCollapsed}
         doctype="files"
         fieldNoDoctype="file_id"
         placeholder="Search for File ID or File Submitter ID"
         hits={props.suggestions}
         setAutocomplete={props.setAutocomplete}
+        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         dropdownItem={x => (
           <span style={{ display: 'flex' }}>
             <Column>
@@ -150,7 +161,6 @@ export const FileAggregationsComponent = (props: TProps) => (
           </span>
         )}
       />
-
       {
         _.reject(presetFacets, { full: 'files.file_id' }).map((facet) => (
           <FacetWrapper
@@ -159,7 +169,7 @@ export const FileAggregationsComponent = (props: TProps) => (
             title={facet.title}
             aggregation={props.aggregations[escapeForRelay(facet.field)]}
             relay={props.relay}
-            style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
+            style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
             additionalProps={facet.additionalProps}
           />
         ))

--- a/modules/node_modules/@ncigdc/containers/ProjectAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/ProjectAggregations.js
@@ -2,9 +2,12 @@
 
 import React from 'react';
 import Relay from 'react-relay';
+import { compose, withState } from 'recompose';
 
-import TermAggregation from '@ncigdc/components/Aggregations/TermAggregation';
 import SuggestionFacet from '@ncigdc/components/Aggregations/SuggestionFacet';
+import FacetHeader from '@ncigdc/components/Aggregations/FacetHeader';
+import FacetWrapper from '@ncigdc/components/FacetWrapper';
+import escapeForRelay from '@ncigdc/utils/escapeForRelay';
 
 import type { TBucket } from '@ncigdc/components/Aggregations/types';
 
@@ -26,10 +29,26 @@ export type TProps = {
   theme: Object,
 };
 
-export const ProjectAggregationsComponent = (props: TProps) => (
+const projectFacets = [
+  { title: 'Primary Site', field: 'primary_site', full: 'projects.primary_site', doc_type: 'project', type: 'keyword' },
+  { title: 'Cancer Program', field: 'program.name', full: 'projects.program.name', doc_type: 'project', type: 'keyword' },
+  { title: 'Disease Type', field: 'disease_type', full: 'projects.disease_type', doc_type: 'project', type: 'keyword' },
+  { title: 'Data Category', field: 'summary.data_categories.data_category', full: 'projects.summary.data_categories.data_category', doc_type: 'project', type: 'keyword' },
+  { title: 'Experimental Strategies', field: 'summary.experimental_strategies.experimental_strategy', full: 'projects.summary.experimental_strategies.experimental_strategy', doc_type: 'project', type: 'keyword' },
+];
+
+export const ProjectAggregationsComponent = compose(
+  withState('projectIdCollapsed', 'setProjectIdCollapsed', false)
+)((props: TProps) => (
   <div>
-    <SuggestionFacet
+    <FacetHeader
       title="Project"
+      field="projects.project_id"
+      collapsed={props.projectIdCollapsed}
+      setCollapsed={props.setProjectIdCollapsed}
+    />
+    <SuggestionFacet
+      collapsed={props.projectIdCollapsed}
       placeholder="Search for Project ID"
       hits={props.suggestions}
       setAutocomplete={props.setAutocomplete}
@@ -54,38 +73,21 @@ export const ProjectAggregationsComponent = (props: TProps) => (
         </Row>
       )}
     />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'projects.primary_site'}
-      title="Primary Site"
-      buckets={props.aggregations.primary_site.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'projects.program__name'}
-      title="Cancer Program"
-      buckets={props.aggregations.program__name.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'projects.disease_type'}
-      title="Disease Type"
-      buckets={props.aggregations.disease_type.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'projects.summary__data_categories__data_category'}
-      title="Data Category"
-      buckets={props.aggregations.summary__data_categories__data_category.buckets}
-    />
-    <TermAggregation
-      style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'projects.summary__experimental_strategies__experimental_strategy'}
-      title="Experimental Strategies"
-      buckets={props.aggregations.summary__experimental_strategies__experimental_strategy.buckets}
-    />
+    {
+      projectFacets.map((facet) => (
+        <FacetWrapper
+          key={facet.full}
+          facet={facet}
+          title={facet.title}
+          aggregation={props.aggregations[escapeForRelay(facet.field)]}
+          relay={props.relay}
+          additionalProps={facet.additionalProps}
+          style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
+        />
+      ))
+    }
   </div>
-);
+));
 
 export const ProjectAggregationsQuery = {
   fragments: {

--- a/modules/node_modules/@ncigdc/theme/icons/AngleIcon.js
+++ b/modules/node_modules/@ncigdc/theme/icons/AngleIcon.js
@@ -1,0 +1,4 @@
+// @flow
+import React from 'react';
+
+export default ({ className = '', ...props }) => <i className={`${className} fa fa-angle-down`} {...props} />;

--- a/modules/node_modules/@ncigdc/theme/icons/UndoIcon.js
+++ b/modules/node_modules/@ncigdc/theme/icons/UndoIcon.js
@@ -1,0 +1,4 @@
+// @flow
+import React from 'react';
+
+export default ({ className = '', ...props }) => <i className={`${className} fa fa-undo`} {...props} />;

--- a/modules/node_modules/@ncigdc/theme/versions/active.js
+++ b/modules/node_modules/@ncigdc/theme/versions/active.js
@@ -13,6 +13,8 @@ const theme = {
 
   secondary: 'rgb(23, 132, 172)',
 
+  textShadow: '0 0 7px rgba(255, 127, 71, 0.62)',
+
   // greyscale
 
   greyScale7: 'rgb(107,98,98)',


### PR DESCRIPTION
<img width="376" alt="screen shot 2017-03-02 at 5 14 36 pm" src="https://cloud.githubusercontent.com/assets/1314446/23529470/c20507b0-ff6b-11e6-92e4-69cf80940555.png">
got all three right hand side buttons to play nice. Had to move TermAggregation's showingValueSearch state (for the mag glass) to FacetWrapper.