### PR TITLE
🐛 PRTL-742 make primary site show up in facet sidebar

### DIFF
--- a/modules/node_modules/@ncigdc/utils/generated-relay-query-parts/generate-script.js
+++ b/modules/node_modules/@ncigdc/utils/generated-relay-query-parts/generate-script.js
@@ -61,9 +61,23 @@ import Relay from 'react-relay';
 ${contents}
 `
 
+const mungeMapping = (mapping) => {
+  const migrations = {
+    'cases.project.primary_site': 'cases.primary_site',
+  };
+  const newKeys = Object.keys(mapping).map(key => migrations[key] || key);
+  const newValues = Object.values(mapping).map(value => ({
+    ...value,
+    full: migrations[value.full] || value.full,
+    field: (migrations[value.full] || value.full).replace(new RegExp(`^${value.doc_type}.`), ''),
+  }));
+  return _.zipObject(newKeys, newValues);
+};
+
 let generateFragments = async () => {
   const mapping = await fetch('http://localhost:5000/v0/gql/_mapping').then(x => x.json());
-  const groupedFacets = _.groupBy(_.values(mapping), facet => facet.doc_type);
+  const mungedMapping = mungeMapping(mapping);
+  const groupedFacets = _.groupBy(_.values(mungedMapping), facet => facet.doc_type);
 
   const repositoryCaseAggregations = exportTemplate(groupedFacets.cases, 'repositoryCaseAggregationsFragment', 'CaseAggregations');
   const repositoryFileAggregations = exportTemplate(groupedFacets.files, 'repositoryFileAggregationsFragment', 'FileAggregations');

--- a/modules/node_modules/@ncigdc/utils/generated-relay-query-parts/repositoryCaseAggregations.js
+++ b/modules/node_modules/@ncigdc/utils/generated-relay-query-parts/repositoryCaseAggregations.js
@@ -63,7 +63,7 @@ export const initialCaseAggregationsVariables = {
   shouldShow_project__dbgap_accession_number: false,
   shouldShow_project__disease_type: false,
   shouldShow_project__name: false,
-  shouldShow_project__primary_site: false,
+  shouldShow_primary_site: false,
   shouldShow_project__program__dbgap_accession_number: false,
   shouldShow_project__program__name: false,
   shouldShow_project__program__program_id: false,
@@ -601,7 +601,7 @@ project__name @include(if: $shouldShow_project__name) {
       
 }
 
-project__primary_site @include(if: $shouldShow_project__primary_site) {
+primary_site @include(if: $shouldShow_primary_site) {
   
       buckets {
         doc_count


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/23558299/0c755d46-0001-11e7-8527-644c89557cc2.png)

cases.project.primary_site -> cases.primary_site

Allow future field migrations to be specified without having to manually modify the generated files

@NCI-GDC/oicrdevs ready for review