### PR TITLE
:bug: PRTL-795 MostFrequentMutationsContainer display none message

### DIFF
--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
@@ -34,6 +34,7 @@ const FrequentMutationsChartComponent = compose(
     width,
   },
   cohort: { ssms, cases },
+  push,
 }) => {
   if (!ssms) {
     return (
@@ -51,58 +52,64 @@ const FrequentMutationsChartComponent = compose(
   ) * 0.7;
 
   return (
-    <span style={{ flex: 1 }}>
-      <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>
-        <DownloadVisualizationButton
-          svg="#mutation-chart svg"
-          data={ssms.hits.edges.map(x => x.node)}
-          slug="bar-chart"
-          noText
-          tooltipHTML="Download image or data"
-        />
-      </div>
-      <div style={graphTitle()}>Distribution of Most Frequent Mutations</div>
-      <Row id="mutation-chart" style={{ padding: '10px', justifyContent: 'center' }}>
-        <BarChart
-          bandwidth={bandWidth}
-          data={ssms.hits.edges.map(x => ({
-            label: `${x.node.ssm_id.substr(0, 8)}...`,
-            value: projectId ? x.node.filteredOccurrences.hits.total : x.node.score,
-            tooltip: projectId
-            ? (
-              <span>
-                <b>{x.node.ssm_id}</b><br />
-                <div>{x.node.filteredOccurrences.hits.total} Case{x.node.filteredOccurrences.hits.total > 1 ? 's' : ''}
-                &nbsp;affected in {projectId}</div>
-                <div>{x.node.filteredOccurrences.hits.total.toLocaleString()} / {numCasesAggByProject[projectId].toLocaleString()}
-                &nbsp;({((x.node.filteredOccurrences.hits.total / numCasesAggByProject[projectId]) * 100).toFixed(2)}%)</div>
-              </span>
-            )
-            : (
-              <span><b>{x.node.ssm_id}</b><br />
-                <div>{x.node.score} Case{x.node.score > 1 ? 's ' : ' '}
-                  &nbsp;affected in all projects</div>
-                <div>{x.node.score.toLocaleString()} / {cases.hits.total.toLocaleString()}
-                &nbsp;({((x.node.allOccurrences.hits.total / cases.hits.total) * 100).toFixed(2)}%)</div>
-              </span>
-            ),
-            href: `ssms/${x.node.ssm_id}`,
-          }))}
-          margin={chartMargin}
-          height={250}
-          yAxis={{ title: '# Affected Cases' }}
-          styles={{
-            xAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
-            yAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
-            bars: { fill: theme.secondary },
-            tooltips: {
-              fill: '#fff',
-              stroke: theme.greyScale4,
-              textFill: theme.greyScale3,
-            },
-          }}
-        />
-      </Row>
+    <span>
+      {!!ssms.hits.edges.length && <span style={{ flex: 1 }}>
+        <div style={{ textAlign: 'right', marginRight: 50, marginLeft: 30 }}>
+          <DownloadVisualizationButton
+            svg="#mutation-chart svg"
+            data={ssms.hits.edges.map(x => x.node)}
+            slug="bar-chart"
+            noText
+            tooltipHTML="Download image or data"
+          />
+        </div>
+        <div style={graphTitle()}>Distribution of Most Frequent Mutations</div>
+        <Row id="mutation-chart" style={{ padding: '10px', justifyContent: 'center' }}>
+          <BarChart
+            bandwidth={bandWidth}
+            data={ssms.hits.edges.map(x => ({
+              label: `${x.node.ssm_id.substr(0, 8)}...`,
+              value: projectId ? x.node.filteredOccurrences.hits.total : x.node.score,
+              tooltip: projectId
+                ? (
+                  <span>
+                    <b>{x.node.ssm_id}</b><br />
+                    <div>{x.node.filteredOccurrences.hits.total} Case{x.node.filteredOccurrences.hits.total > 1 ?
+                      's' : ''}
+                    &nbsp;affected in {projectId}</div>
+                    <div>
+                      {x.node.filteredOccurrences.hits.total.toLocaleString()} / {numCasesAggByProject[projectId].toLocaleString()}
+                      &nbsp;({((x.node.filteredOccurrences.hits.total / numCasesAggByProject[projectId]) * 100).toFixed(2)}%)
+                    </div>
+                  </span>
+                )
+                  : (
+                    <span><b>{x.node.ssm_id}</b><br />
+                      <div>{x.node.score} Case{x.node.score > 1 ? 's ' : ' '}
+                      &nbsp;affected in all projects</div>
+                      <div>{x.node.score.toLocaleString()} / {cases.hits.total.toLocaleString()}
+                      &nbsp;({((x.node.allOccurrences.hits.total / cases.hits.total) * 100).toFixed(2)}%)</div>
+                    </span>
+                  ),
+                  onClick: () => push(`/ssms/${x.node.ssm_id}`),
+            }))}
+            margin={chartMargin}
+            height={250}
+            yAxis={{ title: '# Affected Cases' }}
+            styles={{
+              xAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+              yAxis: { stroke: theme.greyScale4, textFill: theme.greyScale3 },
+              bars: { fill: theme.secondary },
+              tooltips: {
+                fill: '#fff',
+                stroke: theme.greyScale4,
+                textFill: theme.greyScale3,
+              },
+            }}
+          />
+        </Row>
+      </span>
+    }
     </span>
   );
 });


### PR DESCRIPTION
~move the 'No mutations data found' message from `FrequentMutations` to `FrequentMutationsContainer` because it was never being reached if there were none.~
now hiding the chart when no hits. also updated the barchart herfs to onClicks