### PR TITLE
🐛 PRTL-746 Populate advanced/smart search from jsurl filters

### DIFF
--- a/modules/node_modules/@ncigdc/containers/SmartSearchPage.js
+++ b/modules/node_modules/@ncigdc/containers/SmartSearchPage.js
@@ -61,9 +61,11 @@ class SmartSearchComponent extends React.Component {
         };
       })
       .directive('smartSearchWrapper', () => ({
-        controller() {
+        controller(LocationService) {
           this.setQuery = () => {
-            const currentQuery = queryString.parse(window.location.search).query;
+            const { query, filters } = queryString.parse(window.location.search);
+            const currentQuery = query || (filters && LocationService.filter2query(JSURL.parse(filters)));
+
             if (typeof currentQuery === 'string') {
               this.query = currentQuery;
             }


### PR DESCRIPTION
test instructions: 
Go to `/repository`, select a filter, click on "Advanced Search"
![image](https://cloud.githubusercontent.com/assets/743976/23908788/56b7079e-08ab-11e7-88fe-99c13356ff51.png) Verify that query is populated from filters
![image](https://cloud.githubusercontent.com/assets/743976/23908814/6607ae2e-08ab-11e7-8ee4-cc2e0067f899.png)

