### PR TITLE
:bug: PRTL-751 clear RangeFacet inputs when query is reset

### DIFF
--- a/modules/node_modules/@ncigdc/components/Aggregations/RangeFacet.js
+++ b/modules/node_modules/@ncigdc/components/Aggregations/RangeFacet.js
@@ -115,7 +115,7 @@ const enhance = compose(
         val !== nextProps.query[key]
       )) {
         const { field, query } = nextProps;
-        const { selectedUnit, setState, convertDays } = this.props;
+        const { state: { selectedUnit }, setState, convertDays } = this.props;
         const thisFieldCurrent = getCurrentFromAndTo({ field, query });
         const opToWord = { '>=': 'from', '<=': 'to' };
         const newState = Object.keys(thisFieldCurrent)
@@ -247,6 +247,7 @@ const RangeFacet = (props: TProps) => {
              From:
             </InputLabel>
             <StyledInput
+              style={{ borderRadius: 0 }}
               value={props.state.fromDisplayed || ''}
               onChange={props.handleFromChanged}
               id={`from-${dotField}`}


### PR DESCRIPTION
input wasn't properly resetting because selectedUnit wasn't being destructured from state