### PR TITLE
💄 PRTL-816 reduce td height

### DIFF
--- a/modules/node_modules/@ncigdc/components/GeneTable.js
+++ b/modules/node_modules/@ncigdc/components/GeneTable.js
@@ -146,6 +146,7 @@ const GeneTable = ({
       survival_plot: (
         <Tooltip Component={`Click icon to plot ${g.symbol}`}>
           <button
+            style={{ padding: '2px 3px' }}
             onClick={() => {
               if (g.symbol !== selectedSurvivalData.id) {
                 setSurvivalLoadingId(g.symbol);

--- a/modules/node_modules/@ncigdc/components/MutationTable.js
+++ b/modules/node_modules/@ncigdc/components/MutationTable.js
@@ -193,6 +193,7 @@ const MutationTable: TMutationTable = ({
         survival_plot: (
           <Tooltip Component={`Click icon to plot ${x.genomic_dna_change}`}>
             <button
+              style={{ padding: '2px 3px' }}
               onClick={() => {
                 if (x.ssm_id !== selectedSurvivalData.id) {
                   getSurvivalCurves({

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -284,6 +284,7 @@ const FrequentMutationsTableComponent = compose(
             survival_plot: (
               <Tooltip Component={`Click icon to plot ${x.genomic_dna_change}`}>
                 <button
+                  style={{ padding: '2px 3px' }}
                   onClick={() => {
                     if (x.ssm_id !== selectedSurvivalData.id) {
                       setSurvivalLoadingId(x.ssm_id);

--- a/modules/node_modules/@ncigdc/uikit/TogglableUl.js
+++ b/modules/node_modules/@ncigdc/uikit/TogglableUl.js
@@ -11,6 +11,7 @@ const TogglableUl = ({ active, toggleActive, theme, items }) => (
     style={{
       listStyle: 'none',
       paddingLeft: 0,
+      marginBottom: 0,
     }}
   >
     <li key={items[0]} onClick={() => toggleActive()}>
@@ -19,7 +20,7 @@ const TogglableUl = ({ active, toggleActive, theme, items }) => (
         style={{
           paddingLeft: '0.5rem',
           color: theme.primaryLight1,
-          fontSize: '1.5em',
+          fontSize: '1.2em',
           transform: `rotate(${active ? '0deg' : '90deg'})`,
           transition: '0.3s ease',
         }}


### PR DESCRIPTION
ticket: 

> rows are too tick. Make all row height the same across the portal. Currently summary tables and table in repository have all thiner rows which is better.
> Talked with Shane, this is due to the Survival Analysis button. 
> We can make the button smaller in Most Frequently Mutated Genes and Most Frequent Mutations table so that row height is the same for all tables.

actually it was mostly the TogglableUI's margin bottom pushing it out