### PR TITLE
Fix/846 dl error msg if no projs

### DIFF
--- a/modules/node_modules/@ncigdc/components/BAMSlicingButton.js
+++ b/modules/node_modules/@ncigdc/components/BAMSlicingButton.js
@@ -50,7 +50,7 @@ const BAMSlicingButton = ({
           file={file}
           closeModal={() => dispatch(setModal(null))}
           setActive={setActive}
-        /> : <NoAccessModal closeModal={() => dispatch(setModal(null))} />))
+        /> : <NoAccessModal />))
     }
   >
     { active ? 'Slicing' : 'BAM Slicing' }

--- a/modules/node_modules/@ncigdc/components/Header.js
+++ b/modules/node_modules/@ncigdc/components/Header.js
@@ -48,8 +48,6 @@ const Header = compose(
       }
     },
     componentWillReceiveProps(nextProps: Object): void {
-      console.log(nextProps.error);
-      console.log('hello from Header#componentWillReceiveProps');
       if (nextProps.error !== this.props.error) {
         this.props.handleApiError({ ...nextProps.error });
       }

--- a/modules/node_modules/@ncigdc/components/Header.js
+++ b/modules/node_modules/@ncigdc/components/Header.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { compose } from 'recompose';
+import { compose, pure, lifecycle, withHandlers } from 'recompose';
 import { connect } from 'react-redux';
 
 import { dismissNotification } from '@ncigdc/dux/bannerNotification';
@@ -17,6 +17,8 @@ import QuickSearch from '@ncigdc/components/QuickSearch/QuickSearch';
 import LoginButton from '@ncigdc/components/LoginButton';
 import UserDropdown from '@ncigdc/components/UserDropdown';
 import Hidden from '@ncigdc/components/Hidden';
+import { setModal } from '@ncigdc/dux/modal';
+import SessionExpiredModal from '@ncigdc/components/Modals/SessionExpiredModal';
 
 import Banner from '@ncigdc/uikit/Banner';
 
@@ -30,7 +32,30 @@ const Header = compose(
   connect(state => ({
     notifications: state.bannerNotification,
     user: state.auth.user,
-  }))
+    error: state.error,
+  })),
+  withHandlers({
+    handleApiError: ({ dispatch }) => ({ status }) => {
+      if (status === 401 || status === 403) {
+        dispatch(setModal(<SessionExpiredModal />));
+      }
+    },
+  }),
+  lifecycle({
+    componentDidMount(): void {
+      if (this.props.error) {
+        this.props.handleApiError({ ...this.props.error });
+      }
+    },
+    componentWillReceiveProps(nextProps: Object): void {
+      console.log(nextProps.error);
+      console.log('hello from Header#componentWillReceiveProps');
+      if (nextProps.error !== this.props.error) {
+        this.props.handleApiError({ ...nextProps.error });
+      }
+    },
+  }),
+  pure
 )(({ user, notifications, dispatch }) => (
   <header
     id="header" className="navbar navbar-default navbar-static-top"

--- a/modules/node_modules/@ncigdc/components/Modals/SessionExpiredModal.js
+++ b/modules/node_modules/@ncigdc/components/Modals/SessionExpiredModal.js
@@ -1,48 +1,17 @@
 // @flow
 import React from 'react';
-import { connect } from 'react-redux';
 
-import { setModal } from '@ncigdc/dux/modal';
-import Button from '@ncigdc/uikit/Button';
-import { Column, Row } from '@ncigdc/uikit/Flex';
-import { resetError } from '@ncigdc/dux/error';
+import BaseModal from '@ncigdc/components/Modals/BaseModal';
 import LoginButton from '../LoginButton';
 
-const SessionExpired = ({
-  dispatch,
-}: {
-  dispatch: Function,
-  message: string,
-}) => (
-  <Column>
-    <h2 style={{ paddingLeft: 15 }}>Session Expired</h2>
-    <Column
-      style={{
-        borderBottom: '1px solid #e5e5e5',
-        borderTop: '1px solid #e5e5e5',
-        padding: 15,
-        marginBottom: 15,
-      }}
-    >
+const SessionExpired = () => (
+  <BaseModal
+    title="Session Expired"
+    closeText="Cancel"
+  >
       Your session has expired.
       <p>Please <LoginButton /></p>
-    </Column>
-    <Row
-      style={{
-        marginBottom: 15,
-      }}
-    >
-      <Button
-        style={{ margin: '0 10px 0 auto' }}
-        onClick={() => {
-          dispatch(resetError());
-          dispatch(setModal(null));
-        }}
-      >
-        Cancel
-      </Button>
-    </Row>
-  </Column>
+  </BaseModal>
 );
 
-export default connect()(SessionExpired);
+export default SessionExpired;

--- a/modules/node_modules/@ncigdc/components/Modals/SessionExpiredModal.js
+++ b/modules/node_modules/@ncigdc/components/Modals/SessionExpiredModal.js
@@ -1,0 +1,48 @@
+// @flow
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { setModal } from '@ncigdc/dux/modal';
+import Button from '@ncigdc/uikit/Button';
+import { Column, Row } from '@ncigdc/uikit/Flex';
+import { resetError } from '@ncigdc/dux/error';
+import LoginButton from '../LoginButton';
+
+const SessionExpired = ({
+  dispatch,
+}: {
+  dispatch: Function,
+  message: string,
+}) => (
+  <Column>
+    <h2 style={{ paddingLeft: 15 }}>Session Expired</h2>
+    <Column
+      style={{
+        borderBottom: '1px solid #e5e5e5',
+        borderTop: '1px solid #e5e5e5',
+        padding: 15,
+        marginBottom: 15,
+      }}
+    >
+      Your session has expired.
+      <p>Please <LoginButton /></p>
+    </Column>
+    <Row
+      style={{
+        marginBottom: 15,
+      }}
+    >
+      <Button
+        style={{ margin: '0 10px 0 auto' }}
+        onClick={() => {
+          dispatch(resetError());
+          dispatch(setModal(null));
+        }}
+      >
+        Cancel
+      </Button>
+    </Row>
+  </Column>
+);
+
+export default connect()(SessionExpired);

--- a/modules/node_modules/@ncigdc/components/UserDropdown.js
+++ b/modules/node_modules/@ncigdc/components/UserDropdown.js
@@ -10,6 +10,8 @@ import DropdownItem from '@ncigdc/uikit/DropdownItem';
 import styled from '@ncigdc/theme/styled';
 import DownloadIcon from '@ncigdc/theme/icons/Download';
 import { fetchToken } from '@ncigdc/dux/auth';
+import { setModal } from '@ncigdc/dux/modal';
+import { notify } from '@ncigdc/dux/notification';
 
 const NavLink = styled.a({
   padding: '15px 13px',
@@ -45,7 +47,25 @@ const UserDropdown = connect(
         </NavLink>
       }
     >
-      <DropdownItem onClick={() => dispatch(fetchToken())}>
+      <DropdownItem onClick={() => {
+        const numProjects = Object.keys(user.projects || {}).reduce((acc, k) => [...acc, ...user.projects[k]], []).length;
+        if (numProjects) {
+          dispatch(fetchToken());
+        } else {
+          dispatch(notify(
+            {
+              action: 'warning',
+              id: `${(new Date()).getTime()}`,
+              component: (
+                <span>
+                {user.username} does not have access to any protected data within the GDC. Click <a href="https://gdc.nci.nih.gov/access-data/obtaining-access-controlled-data">here</a> to learn more about obtaining access to protected data.
+                </span>
+              ),
+            }
+          ));
+        }
+      }}
+      >
         <DownloadIcon style={{ marginRight: '0.5rem', fontSize: '1.65rem' }} />
         Download Token
       </DropdownItem>

--- a/modules/node_modules/@ncigdc/dux/error.js
+++ b/modules/node_modules/@ncigdc/dux/error.js
@@ -1,0 +1,24 @@
+/* @flow */
+const RESET_ERROR = 'RESET_ERROR';
+
+export type TAction = { type: string, payload: any, error: any };
+export type TState = { error: Object };
+
+const resetError = () => ({ type: RESET_ERROR, payload: null });
+
+const initialState = {
+  error: null,
+};
+
+function errorReducer(state: TState = initialState, action: TAction): TState {
+  const { type, error } = action;
+  if (type === RESET_ERROR) {
+    return { error: null };
+  } else if (error) {
+    return action.payload;
+  }
+  return state;
+}
+
+export { resetError };
+export default errorReducer;

--- a/modules/node_modules/@ncigdc/dux/notification.js
+++ b/modules/node_modules/@ncigdc/dux/notification.js
@@ -1,4 +1,8 @@
+/* @flow */
 const NOTIFY = 'NOTIFY';
+
+export type TAction = { type: string, payload: any };
+export type TState = { id: number, component: Object, action: string };
 
 const notify = payload => ({ type: NOTIFY, payload });
 
@@ -8,7 +12,7 @@ const initialState = {
   action: null,
 };
 
-function reducer(state = initialState, action) {
+function reducer(state: TState = initialState, action: TAction): TState {
   switch (action.type) {
     case NOTIFY:
       return action.payload;

--- a/modules/node_modules/@ncigdc/dux/reducers.js
+++ b/modules/node_modules/@ncigdc/dux/reducers.js
@@ -10,6 +10,7 @@ import auth from './auth';
 import versionInfo from './versionInfo';
 import bannerNotification from './bannerNotification';
 import relayProgress from './relayProgress';
+import error from './error';
 
 /*----------------------------------------------------------------------------*/
 
@@ -23,4 +24,5 @@ export default {
   versionInfo,
   bannerNotification,
   relayProgress,
+  error,
 };

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "needle": {
       "env": {
         "API": "/api/",
-        "GDC_AUTH": "/api/",
+        "GDC_AUTH": "/auth/",
         "LEGACY": false,
         "COMMIT_HASH": "",
         "COMMIT_TAG": ""

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "needle": {
       "env": {
         "API": "/api/",
-        "GDC_AUTH": "/auth/",
+        "GDC_AUTH": "/api/",
         "LEGACY": false,
         "COMMIT_HASH": "",
         "COMMIT_TAG": ""


### PR DESCRIPTION
This PR adds an error reducer to show a SessionExpiredModal on 401 or 403 (missing functionality from prod portal), and shows a toast notification if user tries to download token but they have no projects (what the ticket wants).

To test, I did this:
1) Start yarn with
`GDC_AUTH='/api/' yarn start`
because couldn't figure out how to get knit needle to get webpack to also proxy /auth to localhost:5000 :woman_shrugging: 

2) Added
```python
@blueprint.route('/user', methods=['GET'])
def fakeness():
    return jsonify({ "username": "PIKACHU", "projects": {}}), 200


@blueprint.route('/token/refresh', methods=['GET'])
def token_fakeness():
    return jsonify({ 'lol': 'fake token' }), 200
```
to gdcapi/resources/index/v0.py

3) test that projects: {} shows the toast and projects with keys downloads the fake token.