### PR TITLE
🐛 [PRTL-824] Mutation external reference

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -35687,6 +35687,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cosmic_id",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "impact",
               "type": {
                 "kind": "SCALAR",

--- a/data/version.json
+++ b/data/version.json
@@ -1,5 +1,5 @@
 {
-  "commit": "2a58084006b2ade99e4b29fc920d204541f5e020",
+  "commit": "e83648f704117468ea46196baaece0a86b69ddf8",
   "data_release": "Data Release 3.0 - September 21, 2016",
   "status": "OK",
   "tag": "1.5.0",

--- a/modules/node_modules/@ncigdc/components/SSM.js
+++ b/modules/node_modules/@ncigdc/components/SSM.js
@@ -82,14 +82,9 @@ const Mutation = compose(
   const allCasesAggByProject = allCasesAgg.reduce((acc, bucket) =>
     ({ ...acc, [bucket.key]: bucket.doc_count }), {}
   );
-
   const consequences = mutation.consequence.hits.edges;
-  const externalDbIds = consequences.reduce((acc, c) => {
-    if (c.node.transcript.is_canonical) {
-      return c.node.transcript.gene.external_db_ids;
-    }
-    return acc;
-  }, {});
+  const dbSNP = consequences.reduce((acc, c) =>
+    c.node.transcript.annotation.dbsnp_rs ? c.node.transcript.annotation.dbsnp_rs : acc, {});
 
   const functionalImpact = (
     consequences.reduce(
@@ -210,23 +205,13 @@ const Mutation = compose(
             alignSelf: 'flex-start',
           }}
         />
-        {externalDbIds && !!Object.keys(externalDbIds).length &&
+        {dbSNP && /rs([0-9]+)$/g.test(dbSNP) &&
           <EntityPageVerticalTable
             title={<span><BookIcon style={{ marginRight: '1rem' }} /> External References</span>}
-            thToTd={
-              Object.keys(externalDbIds)
-              .filter(x => x !== '__dataID__')
-              .map(db => ({
-                th: db.replace(/_/g, ' '),
-                td: externalDbIds[db] && !!externalDbIds[db].length && (
-                  <ExternalLink
-                    href={externalReferenceLinks[db](externalDbIds[db][0])}
-                  >
-                    {externalDbIds[db]}
-                  </ExternalLink>
-                ),
-              }))
-          }
+            thToTd={[
+              { th: 'Name', td: 'dbSNP' },
+              { th: 'Value', td: dbSNP },
+            ]}
             style={{ ...styles.summary, ...styles.column, alignSelf: 'flex-start' }}
           />}
       </Row>

--- a/modules/node_modules/@ncigdc/components/SSM.js
+++ b/modules/node_modules/@ncigdc/components/SSM.js
@@ -85,7 +85,8 @@ const Mutation = compose(
   const consequences = mutation.consequence.hits.edges;
   const dbSNP = consequences.reduce((acc, c) =>
     c.node.transcript.annotation.dbsnp_rs ? c.node.transcript.annotation.dbsnp_rs : acc, '');
-
+  const cosmic = consequences.reduce((acc, c) =>
+    c.node.transcript.annotation.cosmic_id ? c.node.transcript.annotation.cosmic_id : acc, []);
   const functionalImpact = (
     consequences.reduce(
       (impact, consequence) => impact || ((consequence.node.transcript || {}).annotation || {}).impact, ''
@@ -208,8 +209,20 @@ const Mutation = compose(
         <EntityPageVerticalTable
           title={<span><BookIcon style={{ marginRight: '1rem' }} /> External References</span>}
           thToTd={[
-            { th: 'Name', td: 'dbSNP' },
-            { th: 'Value', td: (dbSNP && /rs([0-9]+)$/g.test(dbSNP)) ? dbSNP : 'None' },
+            { th: 'dbSNP', td: (dbSNP && /rs(\d+)$/g.test(dbSNP)) ? dbSNP : '--' },
+            { th: 'COSMIC', td: (cosmic.length ? <ul style={{ listStyle: 'none', paddingLeft: 0, marginBottom: 0 }}>
+              {cosmic.map(
+                (c, i) => (
+                  <li key={i}>
+                    <ExternalLink
+                      href={externalReferenceLinks.cosmic(c.match(/(\d+)$/g))}
+                    >
+                      {c}
+                    </ExternalLink>
+                  </li>
+                ))
+              }
+            </ul> : '--') },
           ]}
           style={{ ...styles.summary, ...styles.column, alignSelf: 'flex-start' }}
         />

--- a/modules/node_modules/@ncigdc/components/SSM.js
+++ b/modules/node_modules/@ncigdc/components/SSM.js
@@ -84,7 +84,7 @@ const Mutation = compose(
   );
   const consequences = mutation.consequence.hits.edges;
   const dbSNP = consequences.reduce((acc, c) =>
-    c.node.transcript.annotation.dbsnp_rs ? c.node.transcript.annotation.dbsnp_rs : acc, {});
+    c.node.transcript.annotation.dbsnp_rs ? c.node.transcript.annotation.dbsnp_rs : acc, '');
 
   const functionalImpact = (
     consequences.reduce(
@@ -205,15 +205,14 @@ const Mutation = compose(
             alignSelf: 'flex-start',
           }}
         />
-        {dbSNP && /rs([0-9]+)$/g.test(dbSNP) &&
-          <EntityPageVerticalTable
-            title={<span><BookIcon style={{ marginRight: '1rem' }} /> External References</span>}
-            thToTd={[
-              { th: 'Name', td: 'dbSNP' },
-              { th: 'Value', td: dbSNP },
-            ]}
-            style={{ ...styles.summary, ...styles.column, alignSelf: 'flex-start' }}
-          />}
+        <EntityPageVerticalTable
+          title={<span><BookIcon style={{ marginRight: '1rem' }} /> External References</span>}
+          thToTd={[
+            { th: 'Name', td: 'dbSNP' },
+            { th: 'Value', td: (dbSNP && /rs([0-9]+)$/g.test(dbSNP)) ? dbSNP : 'None' },
+          ]}
+          style={{ ...styles.summary, ...styles.column, alignSelf: 'flex-start' }}
+        />
       </Row>
       <Column style={styles.card}>
         <h1 id="consequences" style={{ ...styles.heading, padding: '1rem' }}>

--- a/modules/node_modules/@ncigdc/containers/SSMPage.js
+++ b/modules/node_modules/@ncigdc/containers/SSMPage.js
@@ -94,6 +94,7 @@ export const SSMPageQuery = {
                   annotation {
                     impact
                     hgvsc
+                    dbsnp_rs
                   }
                   gene {
                     external_db_ids {

--- a/modules/node_modules/@ncigdc/containers/SSMPage.js
+++ b/modules/node_modules/@ncigdc/containers/SSMPage.js
@@ -94,7 +94,8 @@ export const SSMPageQuery = {
                   annotation {
                     impact
                     hgvsc
-                    dbsnp_rs
+                  dbsnp_rs
+                  cosmic_id
                   }
                   gene {
                     external_db_ids {

--- a/modules/node_modules/@ncigdc/utils/externalReferenceLinks.js
+++ b/modules/node_modules/@ncigdc/utils/externalReferenceLinks.js
@@ -7,4 +7,5 @@ export default {
   omim_gene: id => `http://omim.org/entry/${id}`,
   uniprotkb_swissprot: id => `http://www.uniprot.org/uniprot/${id}`,
   transcript: id => `http://feb2014.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=${id}`,
+  cosmic: id => `http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=${id}`,
 };


### PR DESCRIPTION
reading `dbSNP` and `COSMIC` ids as external reference for mutation. 