### PR TITLE
🔧 generate schema on start, remove from vc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,3 @@ dist
 
 # OS
 .DS_Store
-
-# Relay Schema
-data/schema.json
-data/version.json

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ dist
 
 # OS
 .DS_Store
+
+# Relay Schema
+data/schema.json
+data/version.json

--- a/data/schema.json
+++ b/data/schema.json
@@ -11902,22 +11902,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "When paginating forwards, are there more items?",
-              "isDeprecated": false,
-              "name": "hasNextPage",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "When paginating backwards, are there more items?",
               "isDeprecated": false,
               "name": "hasPreviousPage",
@@ -11953,6 +11937,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When paginating forwards, are there more items?",
+              "isDeprecated": false,
+              "name": "hasNextPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               }
             }
           ],
@@ -12228,6 +12228,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "available_variation_data",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "observation",
               "type": {
                 "kind": "SCALAR",
@@ -12304,18 +12320,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TissueSourceSite",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "ssm_tested",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
                 "ofType": null
               }
             },

--- a/data/version.json
+++ b/data/version.json
@@ -1,5 +1,5 @@
 {
-  "commit": "e83648f704117468ea46196baaece0a86b69ddf8",
+  "commit": "9ead3e2c876a40970558a7349d356278e2747305",
   "data_release": "Data Release 3.0 - September 21, 2016",
   "status": "OK",
   "tag": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "knit": "knit",
     "build": "knit build --skip-preflight --verbose",
-    "start": "knit server",
+    "start": "rm data/schema.json&&rm data/version.json&&knit schema&&knit server",
     "test": "jest",
     "lint": "eslint --ext .js modules/node_modules || exit 0",
     "lint-fix": "eslint --ext .js modules/node_modules --fix || exit 0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "knit": "knit",
     "build": "knit build --skip-preflight --verbose",
-    "start": "rm data/schema.json&&rm data/version.json&&knit schema&&knit server",
+    "start": "knit schema&&knit server",
     "test": "jest",
     "lint": "eslint --ext .js modules/node_modules || exit 0",
     "lint-fix": "eslint --ext .js modules/node_modules --fix || exit 0",


### PR DESCRIPTION
The intention here is that anytime the API graphql schema is updated, we need to update the UI anyways. This PR makes sure a fresh relay schema is created whenever the portal is booted up.