### PR TITLE
[PRTL-304] move primary site and disease type to case entity

### DIFF
--- a/modules/node_modules/@ncigdc/components/Case.js
+++ b/modules/node_modules/@ncigdc/components/Case.js
@@ -210,9 +210,9 @@ const Case = compose(
               td: <Link pathname={`/projects/${p.project.project_id}`}>{p.project.project_id}</Link>,
             },
             { th: 'Project Name', td: p.project.name },
-            { th: 'Disease Type', td: p.project.disease_type },
+            { th: 'Disease Type', td: p.disease_type },
             { th: 'Program', td: p.project.program.name },
-            { th: 'Primary Site', td: p.project.primary_site },
+            { th: 'Primary Site', td: p.primary_site },
           ]}
           style={{ flex: 1 }}
         />

--- a/modules/node_modules/@ncigdc/components/Home.js
+++ b/modules/node_modules/@ncigdc/components/Home.js
@@ -167,13 +167,13 @@ const Home = compose(
                 const query = {
                   filters: JSURL.stringify(makeFilter([
                     {
-                      field: 'projects.primary_site',
+                      field: 'cases.primary_site',
                       value: [key],
                     }],
                     false
                   )),
                 };
-                push({ pathname: '/projects', query });
+                push({ pathname: '/repository', query });
               }
               dispatch(setTooltip(null));
             },

--- a/modules/node_modules/@ncigdc/components/Project.js
+++ b/modules/node_modules/@ncigdc/components/Project.js
@@ -10,6 +10,7 @@ import { makeFilter, mergeQuery } from '@ncigdc/utils/filters';
 
 import { Row, Column } from '@ncigdc/uikit/Flex';
 import { Tooltip } from '@ncigdc/uikit/Tooltip';
+import CollapsibleList from '@ncigdc/uikit/CollapsibleList';
 
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
 import CountCard from '@ncigdc/components/CountCard';
@@ -168,8 +169,8 @@ const Project = ({
             thToTd={[
               { th: 'Project ID', td: projectId },
               { th: 'Project Name', td: projectName },
-              { th: 'Disease Type', td: diseaseType.map(p => <div key={p}>{p}</div>) },
-              { th: 'Primary Site', td: primarySite.map(p => <div key={p}>{p}</div>) },
+              { th: 'Disease Type', td: (<CollapsibleList data={diseaseType} />) },
+              { th: 'Primary Site', td: (<CollapsibleList data={primarySite} />) },
               { th: 'Program', td: programName },
             ]}
           />

--- a/modules/node_modules/@ncigdc/containers/CaseAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/CaseAggregations.js
@@ -72,7 +72,7 @@ const presetFacets = [
   { title: 'Primary Site', field: 'primary_site', full: 'cases.primary_site', doc_type: 'cases', type: 'keyword' },
   { title: 'Cancer Program', field: 'project.program.name', full: 'cases.project.program.name', doc_type: 'cases', type: 'keyword' },
   { title: 'Project', field: 'project.project_id', full: 'cases.project.project_id', doc_type: 'cases', type: 'terms' },
-  { title: 'Disease Type', field: 'project.disease_type', full: 'cases.project.disease_type', doc_type: 'cases', type: 'keyword' },
+  { title: 'Disease Type', field: 'disease_type', full: 'cases.disease_type', doc_type: 'cases', type: 'keyword' },
   { title: 'Gender', field: 'demographic.gender', full: 'cases.demographic.gender', doc_type: 'cases', type: 'keyword' },
   { title: 'Age at Diagnosis', field: 'diagnoses.age_at_diagnosis', full: 'cases.diagnoses.age_at_diagnosis', doc_type: 'cases', type: 'long', additionalProps: { convertDays: true } },
   { title: 'Vital Status', field: 'diagnoses.vital_status', full: 'cases.diagnoses.vital_status', doc_type: 'cases', type: 'keyword' },

--- a/modules/node_modules/@ncigdc/containers/CasePage.js
+++ b/modules/node_modules/@ncigdc/containers/CasePage.js
@@ -112,6 +112,8 @@ export const CasePageQuery = {
       fragment on Case {
         case_id
         submitter_id
+        primary_site
+        disease_type
         annotations {
           hits(first: 20) {
             total
@@ -207,11 +209,9 @@ export const CasePageQuery = {
         project {
           project_id
           name
-          disease_type
           program {
             name
           }
-          primary_site
         }
         samples {
           hits(first: 99) {

--- a/modules/node_modules/@ncigdc/containers/CaseTable.js
+++ b/modules/node_modules/@ncigdc/containers/CaseTable.js
@@ -40,8 +40,8 @@ export const CaseTableComponent = (props: TTableProps) => {
           endpoint="cases"
           downloadFields={[
             'case_id',
+            'primary_site',
             'project.project_id',
-            'project.primary_site',
             'demographic.gender',
             'summary.data_categories.file_count',
             'summary.data_categories.data_category',
@@ -52,7 +52,7 @@ export const CaseTableComponent = (props: TTableProps) => {
               name: 'Project',
             },
             {
-              id: 'project.primary_site',
+              id: 'cases.primary_site',
               name: 'Primary Site',
             },
             {

--- a/modules/node_modules/@ncigdc/containers/CaseTr.js
+++ b/modules/node_modules/@ncigdc/containers/CaseTr.js
@@ -105,7 +105,7 @@ export const CaseTrComponent = ({ node, index, theme, relay, total }: TProps) =>
       </Td>
       <Td><CaseLink id={node.case_id} merge whitelist={['filters']} /></Td>
       <Td><ProjectLink id={node.project.project_id}>{node.project.project_id}</ProjectLink></Td>
-      <Td>{node.project.primary_site}</Td>
+      <Td>{node.primary_site}</Td>
       <Td>{node.demographic.gender}</Td>
       <Td>
         <FilesLink>{node.summary.file_count}</FilesLink>
@@ -167,9 +167,9 @@ export const CaseTrQuery = {
     node: () => Relay.QL`
       fragment on Case {
         case_id
+        primary_site
         project {
           project_id
-          primary_site
         }
         annotations {
           hits(first:20) {

--- a/modules/node_modules/@ncigdc/containers/ProjectTr.js
+++ b/modules/node_modules/@ncigdc/containers/ProjectTr.js
@@ -10,6 +10,7 @@ import { makeFilter } from '@ncigdc/utils/filters';
 import type { TCategory } from '@ncigdc/utils/data/types';
 
 import { Tr, Td } from '@ncigdc/uikit/Table';
+import CollapsibleList from '@ncigdc/uikit/CollapsibleList';
 
 import { withTheme } from '@ncigdc/theme';
 
@@ -68,8 +69,12 @@ export const ProjectTrComponent = ({ node, index, theme }: TProps) => {
       <Td>
         <ProjectLink id={node.project_id} />
       </Td>
-      <Td style={{ whiteSpace: 'normal' }}>{node.disease_type}</Td>
-      <Td>{node.primary_site}</Td>
+      <Td style={{ whiteSpace: 'normal' }}>
+        <CollapsibleList data={node.disease_type} />
+      </Td>
+      <Td>
+        <CollapsibleList data={node.primary_site} />
+      </Td>
       <Td>{node.program.name}</Td>
       <Td>
         <CasesLink>{node.summary.case_count.toLocaleString()}</CasesLink>

--- a/modules/node_modules/@ncigdc/containers/SmartSearchPage.js
+++ b/modules/node_modules/@ncigdc/containers/SmartSearchPage.js
@@ -45,8 +45,9 @@ class SmartSearchComponent extends React.Component {
     const router = this.context.router;
     angular
       .module('legacyAngularWrapper', ['ngApp'])
-      .config(($locationProvider) => {
+      .config(($locationProvider, RestangularProvider) => {
         $locationProvider.html5Mode(false);
+        RestangularProvider.setBaseUrl(API);
       })
       .run(($browser) => {
         // angular dirty checks the browser url and messes with routing in other pages

--- a/modules/node_modules/@ncigdc/containers/cohort/CaseAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/cohort/CaseAggregations.js
@@ -65,7 +65,7 @@ export const CaseAggregationsComponent = (props: TProps) => (
     />
     <TermAggregation
       style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'cases.project__primary_site'}
+      field={'cases.primary_site'}
       title="Primary Site"
       buckets={props.aggregations.project__primary_site.buckets}
     />
@@ -83,7 +83,7 @@ export const CaseAggregationsComponent = (props: TProps) => (
     />
     <TermAggregation
       style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
-      field={'cases.project__disease_type'}
+      field={'cases.disease_type'}
       title="Disease Type"
       buckets={props.aggregations.project__disease_type.buckets}
     />

--- a/modules/node_modules/@ncigdc/containers/cohort/CaseTable.js
+++ b/modules/node_modules/@ncigdc/containers/cohort/CaseTable.js
@@ -44,7 +44,7 @@ export const CaseTableComponent = (props: TTableProps) => {
           downloadFields={[
             'case_id',
             'project.project_id',
-            'project.primary_site',
+            'cases.primary_site',
             'demographic.gender',
             'summary.data_categories.file_count',
             'summary.data_categories.data_category',
@@ -55,7 +55,7 @@ export const CaseTableComponent = (props: TTableProps) => {
               name: 'Project',
             },
             {
-              id: 'project.primary_site',
+              id: 'cases.primary_site',
               name: 'Primary Site',
             },
             {

--- a/modules/node_modules/@ncigdc/containers/cohort/CaseTr.js
+++ b/modules/node_modules/@ncigdc/containers/cohort/CaseTr.js
@@ -18,11 +18,11 @@ export type TProps = {|
   index: number,
   node: {|
     case_id: string,
+    primary_site: string,
     demographic: {|
       gender: string,
     |},
     project: {|
-      primary_site: string,
       project_id: string,
     |},
     summary: {|
@@ -56,7 +56,7 @@ export const CaseTrComponent = ({ node, index, theme }: TProps) => {
     >
       <Td><CaseLink id={node.case_id} merge whitelist={['filters']} /></Td>
       <Td>{node.project.project_id}</Td>
-      <Td>{node.project.primary_site}</Td>
+      <Td>{node.primary_site}</Td>
       <Td style={{ textTransform: 'capitalize' }}>{node.demographic.gender}</Td>
       <Td>
         <FilesLink>{sumDataCategories(node.summary.data_categories)}</FilesLink>
@@ -112,9 +112,9 @@ export const CaseTrQuery = {
     node: () => Relay.QL`
       fragment on Case {
         case_id
+        primary_site
         project {
           project_id
-          primary_site
         }
         demographic {
           gender

--- a/modules/node_modules/@ncigdc/uikit/CollapsibleList.js
+++ b/modules/node_modules/@ncigdc/uikit/CollapsibleList.js
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+import { withState } from 'recompose';
+
+import styled from '@ncigdc/theme/styled';
+
+const List = styled.ul({
+  listStyle: 'none',
+  paddingLeft: 0,
+  marginBottom: 0,
+});
+
+const NotUnderlinedLink = styled.a({
+  ':link': {
+    textDecoration: 'none',
+  },
+});
+
+const Toggle = styled.li({
+  textAlign: 'right',
+  fontStyle: 'italic',
+  padding: '0 1rem',
+  color: ({ theme }) => theme.primary,
+});
+
+const CollapsibleList = ({ style, data, limit = 2, expanded, toggleExpand, ...props }) => (
+  <List style={style || {}} {...props}>
+    {data
+      .slice(0, expanded ? data.length : limit)
+      .map((d, i) => <li key={i}>{d}</li>)
+    }
+    {data.length > limit &&
+      <Toggle>
+        <NotUnderlinedLink onClick={() => toggleExpand(v => !v)}>
+          {expanded ? '\u25B4 less' : `\u25BE ${data.length - limit} more`}
+        </NotUnderlinedLink>
+      </Toggle>
+    }
+  </List>
+);
+
+export default withState('expanded', 'toggleExpand', false)(CollapsibleList);


### PR DESCRIPTION
The primary site and disease type have moved to Case entity.
A project could potentially have N primary sites / N disease Types.

We have updated the UI accordingly.
This wiki describes the impacts for the UI:
https://wiki.oicr.on.ca/display/GDCSPECS/Move+Primary+Site+and+Disease+Type+to+Case+entity
