### PR TITLE
🐛 [PRTL-926] get project total ssm tested freq table

### DIFF
--- a/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
+++ b/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
@@ -198,7 +198,6 @@ const ProjectVisualizations = enhance(({
             loadingAggregation ? <SpinnerCentered /> : (
               <FrequentMutationsTable
                 projectId={projectId}
-                numCasesAggByProject={numCasesAggByProject}
                 defaultFilters={fmFilters}
                 cohort={viewer.frequentMutationsTableFragment}
                 selectedSurvivalData={selectedFrequentMutationsSurvivalData}

--- a/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
+++ b/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Relay from 'react-relay';
 import withSize from 'react-sizeme';
 import { compose } from 'recompose';
+import { makeFilter } from '@ncigdc/utils/filters';
 import { buildCancerDistributionData } from '@ncigdc/utils/data';
 import { Row, Column } from '@ncigdc/uikit/Flex';
 import DownloadVisualizationButton from '@ncigdc/components/DownloadVisualizationButton';
@@ -23,14 +24,14 @@ const CancerDistributionChartComponent = compose(
   withSize(),
   withTheme
 )(({
-  aggregations,
+  cases,
   node: gene,
   size: {
     width,
   },
   theme,
 }: TProps = {}) => {
-  const casesByProjectMap = aggregations.project__project_id.buckets.reduce((acc, bucket) =>
+  const casesByProjectMap = cases.aggregations.project__project_id.buckets.reduce((acc, bucket) =>
     ({ ...acc, [bucket.key]: bucket.doc_count }), {}
   );
 
@@ -104,6 +105,12 @@ const CancerDistributionChartComponent = compose(
 });
 
 const CancerDistributionChartQuery = {
+  initialVariables: {
+    ssmTested: makeFilter([{
+      field: 'available_variation_data',
+      value: 'ssm',
+    }], false),
+  },
   fragments: {
     node: () => Relay.QL`
       fragment on Gene {
@@ -133,12 +140,14 @@ const CancerDistributionChartQuery = {
         }
       }
     `,
-    aggregations: () => Relay.QL`
-      fragment on CaseAggregations {
-        project__project_id {
-          buckets {
-            doc_count
-            key
+    cases: () => Relay.QL`
+      fragment on CohortCases {
+        aggregations(filters: $ssmTested) {
+          project__project_id {
+            buckets {
+              doc_count
+              key
+            }
           }
         }
       }

--- a/modules/node_modules/@ncigdc/containers/CancerDistributionTable.js
+++ b/modules/node_modules/@ncigdc/containers/CancerDistributionTable.js
@@ -6,6 +6,7 @@ import { tableToolTipHint } from '@ncigdc/theme/mixins';
 import EntityPageHorizontalTable from '@ncigdc/components/EntityPageHorizontalTable';
 import { Tooltip } from '@ncigdc/uikit/Tooltip';
 import { Column } from '@ncigdc/uikit/Flex';
+import { makeFilter } from '@ncigdc/utils/filters';
 
 type TProps = {|
   node: Object,
@@ -14,9 +15,9 @@ type TProps = {|
 
 const CancerDistributionTableComponent = ({
   node: gene,
-  aggregations,
+  cases,
 }: TProps = {}) => {
-  const casesByProjectMap = aggregations.project__project_id.buckets.reduce((acc, bucket) =>
+  const casesByProjectMap = cases.aggregations.project__project_id.buckets.reduce((acc, bucket) =>
     ({ ...acc, [bucket.key]: bucket.doc_count }), {}
   );
 
@@ -72,11 +73,17 @@ const CancerDistributionTableComponent = ({
 };
 
 const CancerDistributionTableQuery = {
+  initialVariables: {
+    ssmTested: makeFilter([{
+      field: 'available_variation_data',
+      value: 'ssm',
+    }], false),
+  },
   fragments: {
     node: () => Relay.QL`
       fragment on Gene {
         case {
-          hits(first: 99) {
+          hits(first: 99 filters: $ssmTested) {
             edges {
               node {
                 submitter_id
@@ -101,12 +108,14 @@ const CancerDistributionTableQuery = {
         }
       }
     `,
-    aggregations: () => Relay.QL`
-      fragment on CaseAggregations {
-        project__project_id {
-          buckets {
-            doc_count
-            key
+    cases: () => Relay.QL`
+      fragment on CohortCases {
+        aggregations(filters: $ssmTested) {
+          project__project_id {
+            buckets {
+              doc_count
+              key
+            }
           }
         }
       }

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -318,8 +318,8 @@ export const FrequentMutationsTableQuery = {
       },
     },
     ssmTested: makeFilter([{
-      field: 'ssm_tested',
-      value: [true],
+      field: 'available_variation_data',
+      value: 'ssm',
     }], false),
   },
   fragments: {

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -92,14 +92,13 @@ const FrequentMutationsTableComponent = compose(
           fmTable_offset: parseIntParam(nextProps.query.fmTable_offset, 0),
           fmTable_size: parseIntParam(nextProps.query.fmTable_size, 10),
           fmTable_filters: parseFilterParam(nextProps.query.fmTable_filters, nextProps.defaultFilters || null),
-        })
+        });
       }
-    }
+    },
   }),
   withTheme,
   withSize()
 )(({
-  numCasesAggByProject = {},
   projectId = '',
   showSurvivalPlot = false,
   selectedSurvivalData = {},
@@ -113,6 +112,11 @@ const FrequentMutationsTableComponent = compose(
   if (ssms && !ssms.hits.edges.length) {
     return <Row style={{ padding: '1rem' }}>No mutation data found.</Row>;
   }
+
+  const numCasesAggByProject = cases.aggregations.project__project_id.buckets.reduce((acc, b) => ({
+    ...acc,
+    [b.key]: b.doc_count,
+  }), {});
 
   const frequentMutations = !ssms ? [] :
     mapData(ssms.hits.edges.map(x => x.node), projectId, shouldShowGeneSymbol);
@@ -313,12 +317,24 @@ export const FrequentMutationsTableQuery = {
         value: 'missing',
       },
     },
+    ssmTested: makeFilter([{
+      field: 'ssm_tested',
+      value: [true],
+    }], false),
   },
   fragments: {
     cohort: () => Relay.QL`
       fragment on Cohort {
         cases {
-          hits(first: 0) { total }
+          aggregations(filters: $ssmTested) {
+            project__project_id {
+              buckets {
+                doc_count
+                key
+              }
+            }
+          }
+          hits(first: 0, filters: $ssmTested) { total }
         }
         ssms @include (if: $fetchData) {
           hits(first: $fmTable_size offset: $fmTable_offset filters: $fmTable_filters, score: $score) {

--- a/modules/node_modules/@ncigdc/containers/GenePage.js
+++ b/modules/node_modules/@ncigdc/containers/GenePage.js
@@ -81,8 +81,8 @@ export const GenePageComponent = (props: TProps) => {
             </h1>
           </Row>
           <Column>
-            <CancerDistributionChart node={props.node} aggregations={props.viewer.cohort.cases.aggregations} />
-            <CancerDistributionTable node={props.node} aggregations={props.viewer.cohort.cases.aggregations} />
+            <CancerDistributionChart node={props.node} cases={props.viewer.cohort.cases} />
+            <CancerDistributionTable node={props.node} cases={props.viewer.cohort.cases} />
           </Column>
         </Column>
 
@@ -152,10 +152,8 @@ export const GenePageQuery = {
             ${Lolliplot.getFragment('ssms')}
           }
           cases {
-            aggregations {
-              ${CancerDistributionChart.getFragment('aggregations')}
-              ${CancerDistributionTable.getFragment('aggregations')}
-            }
+            ${CancerDistributionChart.getFragment('cases')}
+            ${CancerDistributionTable.getFragment('cases')}
           }
         }
       }


### PR DESCRIPTION
This will need to be updated when `ssm_tested` turns into an array, but for now is responsible for grabbing its own agg data rather than being passed from the analysis endpoint 