### PR TITLE
:bug: PRTL-883 correct link to data relase notes

### DIFF
--- a/modules/node_modules/@ncigdc/components/PortalSummary.js
+++ b/modules/node_modules/@ncigdc/components/PortalSummary.js
@@ -51,7 +51,7 @@ const PortalSummary = (props: TProps) => (
         <a
           target="_blank"
           rel="noopener noreferrer"
-          href="https://gdc-docs.nci.nih.gov/Data_Portal/Release_Notes/Data_Portal_Release_Notes/"
+          href="https://docs.gdc.cancer.gov/Data/Release_Notes/Data_Release_Notes/"
         >
           {props.dataRelease}
         </a>


### PR DESCRIPTION
`>> it links to the Data Portal release notes but it should link to the Data Release notes`