### PR TITLE
⚡️ PRTL-744 project page performance tweaks

### DIFF
--- a/modules/node_modules/@ncigdc/components/CancerDistribution.js
+++ b/modules/node_modules/@ncigdc/components/CancerDistribution.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { compose } from 'recompose';
 
 import { Row, Column } from '@ncigdc/uikit/Flex';
@@ -19,7 +19,7 @@ const styles = {
 };
 
 const enhance = compose(
-  withSize({ refreshRate: 200 }),
+  withSize(),
   withTheme
 );
 

--- a/modules/node_modules/@ncigdc/components/CancerDistribution.js
+++ b/modules/node_modules/@ncigdc/components/CancerDistribution.js
@@ -19,7 +19,7 @@ const styles = {
 };
 
 const enhance = compose(
-  withSize(),
+  withSize({ refreshRate: 200 }),
   withTheme
 );
 

--- a/modules/node_modules/@ncigdc/components/Oncogrid/OncogridWrapper.js
+++ b/modules/node_modules/@ncigdc/components/Oncogrid/OncogridWrapper.js
@@ -190,7 +190,7 @@ const OncoGridWrapper = compose(
     },
   }),
   connect(),
-  withSize(),
+  withSize({ refreshRate: 200 }),
   lifecycle({
     componentWillReceiveProps(nextProps: Object): void {
       const {

--- a/modules/node_modules/@ncigdc/components/Oncogrid/OncogridWrapper.js
+++ b/modules/node_modules/@ncigdc/components/Oncogrid/OncogridWrapper.js
@@ -5,7 +5,7 @@ import OncoGrid from 'oncogrid';
 import { uniqueId } from 'lodash';
 import { insertRule } from 'glamor';
 import { connect } from 'react-redux';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 
 import { exitFullScreen, enterFullScreen, isFullScreen } from '@ncigdc/utils/fullscreen';
 import { getFilterValue } from '@ncigdc/utils/filters';
@@ -190,7 +190,7 @@ const OncoGridWrapper = compose(
     },
   }),
   connect(),
-  withSize({ refreshRate: 200 }),
+  withSize(),
   lifecycle({
     componentWillReceiveProps(nextProps: Object): void {
       const {

--- a/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
+++ b/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
@@ -118,7 +118,7 @@ const ProjectVisualizations = enhance(({
         </h1>
         <Column>
           <Row>
-            <Column flex="1">
+            <Column flex="none" style={{ width: '50%' }}>
               <FrequentlyMutatedGenesChart
                 defaultFilters={fmFilters}
                 projectId={projectId}
@@ -126,7 +126,7 @@ const ProjectVisualizations = enhance(({
                 numCasesAggByProject={numCasesAggByProject}
               />
             </Column>
-            <Column flex="1">
+            <Column flex="none" style={{ width: '50%' }}>
               <SurvivalPlotWrapper
                 {...mutatedGenesSurvivalData}
                 onReset={() => setSelectedMutatedGenesSurvivalData({})}
@@ -220,6 +220,7 @@ const ProjectVisualizations = enhance(({
         <MostAffectedCasesChart
           cohort={viewer.mostAffectedCasesChartFragment}
           defaultFilters={macFilters}
+          style={{ width: '50%', flexGrow: 0 }}
         />
         <MostAffectedCasesTable
           cohort={viewer.mostAffectedCasesTableFragment}

--- a/modules/node_modules/@ncigdc/components/SummaryCard.js
+++ b/modules/node_modules/@ncigdc/components/SummaryCard.js
@@ -3,7 +3,7 @@
 // Vendor
 import React, { PropTypes } from 'react';
 import { compose, withState, withPropsOnChange } from 'recompose';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 
 // Custom
 import PieChart from '@ncigdc/components/Charts/PieChart';
@@ -27,7 +27,7 @@ const Footer = styled(Row, {
 
 const SummaryCard = compose(
   withState('showTable', 'setShowTable', true),
-  withSize({ monitorHeight: true, refreshRate: 200 }),
+  withSize({ monitorHeight: true }),
   withPropsOnChange(['size'], ({ size }) => ({
     pieDiameter: Math.max(Math.min(size.width, size.height - 100), 120),
   }))

--- a/modules/node_modules/@ncigdc/components/SummaryCard.js
+++ b/modules/node_modules/@ncigdc/components/SummaryCard.js
@@ -27,7 +27,7 @@ const Footer = styled(Row, {
 
 const SummaryCard = compose(
   withState('showTable', 'setShowTable', true),
-  withSize({ monitorHeight: true }),
+  withSize({ monitorHeight: true, refreshRate: 200 }),
   withPropsOnChange(['size'], ({ size }) => ({
     pieDiameter: Math.max(Math.min(size.width, size.height - 100), 120),
   }))

--- a/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
+++ b/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
@@ -21,7 +21,7 @@ type TProps = {
 };
 
 const CancerDistributionChartComponent = compose(
-  withSize(),
+  withSize({ refreshRate: 200 }),
   withTheme
 )(({
   cases,

--- a/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
+++ b/modules/node_modules/@ncigdc/containers/CancerDistributionChart.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { compose } from 'recompose';
 import { makeFilter } from '@ncigdc/utils/filters';
 import { buildCancerDistributionData } from '@ncigdc/utils/data';
@@ -21,7 +21,7 @@ type TProps = {
 };
 
 const CancerDistributionChartComponent = compose(
-  withSize({ refreshRate: 200 }),
+  withSize(),
   withTheme
 )(({
   cases,

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { lifecycle, compose } from 'recompose';
 import withRouter from '@ncigdc/utils/withRouter';
 import { parseFilterParam } from '@ncigdc/utils/uri';
@@ -27,7 +27,7 @@ const FrequentMutationsChartComponent = compose(
     },
   }),
   withTheme,
-  withSize({ refreshRate: 200 })
+  withSize()
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsChart.js
@@ -27,7 +27,7 @@ const FrequentMutationsChartComponent = compose(
     },
   }),
   withTheme,
-  withSize()
+  withSize({ refreshRate: 200 })
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -149,7 +149,7 @@ const FrequentMutationsTableComponent = compose(
     },
   }),
   withTheme,
-  withSize()
+  withSize({ refreshRate: 200 })
 )(({
   projectId = '',
   showSurvivalPlot = false,

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { startCase, truncate, isEqual, get } from 'lodash';
 import { lifecycle, compose, withState } from 'recompose';
 import { scaleOrdinal, schemeCategory10 } from 'd3';
@@ -149,7 +149,7 @@ const FrequentMutationsTableComponent = compose(
     },
   }),
   withTheme,
-  withSize({ refreshRate: 200 })
+  withSize()
 )(({
   projectId = '',
   showSurvivalPlot = false,

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesChart.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesChart.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { lifecycle, compose } from 'recompose';
 import withRouter from '@ncigdc/utils/withRouter';
 import { parseFilterParam } from '@ncigdc/utils/uri';
@@ -27,7 +27,7 @@ const FrequentlyMutatedGenesChartComponent = compose(
     },
   }),
   withTheme,
-  withSize({ refreshRate: 200 })
+  withSize()
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesChart.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesChart.js
@@ -27,7 +27,7 @@ const FrequentlyMutatedGenesChartComponent = compose(
     },
   }),
   withTheme,
-  withSize()
+  withSize({ refreshRate: 200 })
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { isEqual } from 'lodash';
 import { scaleOrdinal, schemeCategory10 } from 'd3';
 import { lifecycle, compose, withState } from 'recompose';
@@ -46,7 +46,7 @@ const FrequentlyMutatedGenesTableComponent = compose(
       }
     },
   }),
-  withSize({ refreshRate: 200 })
+  withSize()
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
@@ -46,7 +46,7 @@ const FrequentlyMutatedGenesTableComponent = compose(
       }
     },
   }),
-  withSize()
+  withSize({ refreshRate: 200 })
 )(({
   numCasesAggByProject,
   projectId = '',

--- a/modules/node_modules/@ncigdc/containers/MostAffectedCasesChart.js
+++ b/modules/node_modules/@ncigdc/containers/MostAffectedCasesChart.js
@@ -13,7 +13,7 @@ import Loader from '@ncigdc/uikit/Loaders/Loader';
 
 const MostAffectedCasesChartComponent = compose(
   withTheme,
-  withSize(),
+  withSize({ refreshRate: 200 }),
   withRouter,
   lifecycle({
     componentDidMount() {

--- a/modules/node_modules/@ncigdc/containers/MostAffectedCasesChart.js
+++ b/modules/node_modules/@ncigdc/containers/MostAffectedCasesChart.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { compose, lifecycle } from 'recompose';
 import withRouter from '@ncigdc/utils/withRouter';
 import { parseFilterParam } from '@ncigdc/utils/uri';
@@ -13,7 +13,7 @@ import Loader from '@ncigdc/uikit/Loaders/Loader';
 
 const MostAffectedCasesChartComponent = compose(
   withTheme,
-  withSize({ refreshRate: 200 }),
+  withSize(),
   withRouter,
   lifecycle({
     componentDidMount() {

--- a/modules/node_modules/@ncigdc/containers/MostAffectedCasesTable.js
+++ b/modules/node_modules/@ncigdc/containers/MostAffectedCasesTable.js
@@ -45,7 +45,7 @@ const MostAffectedCasesTableComponent = compose(
     },
   }),
   withTheme,
-  withSize()
+  withSize({ refreshRate: 200 })
 )(({
   cohort: { cases, mutationsCount },
   relay,

--- a/modules/node_modules/@ncigdc/containers/MostAffectedCasesTable.js
+++ b/modules/node_modules/@ncigdc/containers/MostAffectedCasesTable.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import withSize from 'react-sizeme';
+import withSize from '@ncigdc/utils/withSize';
 import { isEqual } from 'lodash';
 import { lifecycle, compose } from 'recompose';
 
@@ -45,7 +45,7 @@ const MostAffectedCasesTableComponent = compose(
     },
   }),
   withTheme,
-  withSize({ refreshRate: 200 })
+  withSize()
 )(({
   cohort: { cases, mutationsCount },
   relay,

--- a/modules/node_modules/@ncigdc/utils/withSize.js
+++ b/modules/node_modules/@ncigdc/utils/withSize.js
@@ -1,0 +1,4 @@
+// @flow
+import withSize from 'react-sizeme';
+
+export default (options = {}) => withSize({ ...options, refreshRate: 200 });


### PR DESCRIPTION
Higher green lines (FPS) is better, shorter yellow blocks is better, shorter periods of low FPS is better, fewer solid red rectangles at the top is better 

Before:
![image](https://cloud.githubusercontent.com/assets/743976/24555635/e80e7cc0-15ff-11e7-9dc0-7b47f4537dd0.png)

After:
![image](https://cloud.githubusercontent.com/assets/743976/24555651/f84216c4-15ff-11e7-955c-542a573fa7e7.png)

Stats (note: using timeline slows absolute performance)
Before: ~10.7s of 0 FPS, 13.8s total scripting time
After: ~4.7s of 0 FPS, 7.3s total scripting time

Should result in a shorter period where user interaction feels jolt-y