### PR TITLE
🐛 left align title bar

### DIFF
--- a/modules/node_modules/@ncigdc/components/Layouts/FullWidthLayout.js
+++ b/modules/node_modules/@ncigdc/components/Layouts/FullWidthLayout.js
@@ -15,6 +15,7 @@ const styles = {
     zIndex: 55,
     boxShadow: '0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)',
     fontSize: '2.2rem',
+    left: 0,
   }),
   type: theme => ({
     backgroundColor: theme.primary,


### PR DESCRIPTION
in firefox and IE the title bar is about 50% off
![image](https://cloud.githubusercontent.com/assets/3953093/24683562/d40ffdb8-196d-11e7-8672-86eec0d4df79.png)

in chrome just a little bit
![image](https://cloud.githubusercontent.com/assets/3953093/24683571/dfd4dc9a-196d-11e7-9a6d-d5a4124124c2.png)
