### PR TITLE
:bug: PRTL-1015 StackedBar add margin left so more digits fit in y-axis

### DIFF
--- a/modules/node_modules/@ncigdc/components/Charts/StackedBarChart.js
+++ b/modules/node_modules/@ncigdc/components/Charts/StackedBarChart.js
@@ -13,7 +13,7 @@ import './style.css';
 const drawChart = ({ data, yAxis, styles, width, height, colors, projectsIdtoName, setTooltip }) => {
   const el = ReactFauxDOM.createElement('div');
 
-  const margin = { top: 10, right: 0, bottom: 55, left: 40 };
+  const margin = { top: 10, right: 0, bottom: 55, left: 60 };
   const x = d3.scaleBand()
     .rangeRound([0, width])
     .padding(0.1)

--- a/modules/node_modules/@ncigdc/components/ProjectsCharts.js
+++ b/modules/node_modules/@ncigdc/components/ProjectsCharts.js
@@ -289,7 +289,7 @@ const ProjectsChartsComponent = compose(
 
   return (
     <Container>
-      <Column flex={3} style={{ paddingRight: '10px', minWidth: '450px' }}>
+      <Column style={{ paddingRight: '10px', minWidth: '550px', flexGrow: '2', flexBasis: '66%' }}>
         <div style={{ alignSelf: 'center', color: '#6b6262', padding: '1.5rem 0 0.5rem', fontWeight: 'bold' }}>
           Top Mutated Genes in Selected Projects
         </div>
@@ -301,7 +301,7 @@ const ProjectsChartsComponent = compose(
             <Measure key='bar-chart'>
               {({ width }) =>
                 <StackedBarChart
-                  width={width + 100}
+                  width={width}
                   height={170}
                   data={stackedBarData}
                   projectsIdtoName={projects.reduce((acc, p) => ({ ...acc, [p.project_id]: p.name }), {})}
@@ -323,7 +323,7 @@ const ProjectsChartsComponent = compose(
         </Row>
         }
       </Column>
-      <Column flex={2} style={{ minWidth: '200px' }}>
+      <Column style={{ minWidth: '200px', flexGrow: '1', flexBasis: '33%' }}>
         <div style={{ alignSelf: 'center', color: '#6b6262', padding: '1.5rem 0 0.5rem', fontWeight: 'bold' }}>
           Case Distribution per Project
         </div>


### PR DESCRIPTION
<img width="1028" alt="screen shot 2017-04-10 at 12 11 57 pm" src="https://cloud.githubusercontent.com/assets/1314446/24871238/f3515de8-1de6-11e7-896e-395ea275ce0a.png">
- also fix flexbox of project list viz so last bar of StackedBar isn't
  covered by piechart flexbox and can be clicked on laptop screen