### PR TITLE
🎛 Increase default number of cases to fetch for survival plot to 500

### DIFF
--- a/modules/node_modules/@ncigdc/components/Case.js
+++ b/modules/node_modules/@ncigdc/components/Case.js
@@ -298,6 +298,7 @@ const Case = compose(
                 numCasesAggByProject={numCasesAggByProject}
                 defaultFilters={fmFilters}
                 cohort={viewer.frequentMutationsTableFragment}
+                survivalPlotSampleSize={2000}
               />
             </Column>
           </Column>

--- a/modules/node_modules/@ncigdc/components/Cohort/GenesTab.js
+++ b/modules/node_modules/@ncigdc/components/Cohort/GenesTab.js
@@ -33,10 +33,12 @@ compose(
   withState('defaultSurvivalData', 'setDefaultSurvivalData', {}),
   withState('selectedSurvivalData', 'setSelectedSurvivalData', {}),
   withState('state', 'setState', initialState),
+  withProps({ survivalPlotSampleSize: 500 }),
   withProps(({
     selectedSurvivalData,
     defaultSurvivalData,
     setDefaultSurvivalData,
+    survivalPlotSampleSize,
     filters,
     setState,
   }) => ({
@@ -48,6 +50,7 @@ compose(
       const survivalData = await getDefaultCurve({
         currentFilters: filters,
         slug: 'Cohort',
+        size: survivalPlotSampleSize,
       });
 
       setDefaultSurvivalData(survivalData);
@@ -68,6 +71,7 @@ compose(
   survivalData,
   selectedSurvivalData,
   setSelectedSurvivalData,
+  survivalPlotSampleSize,
   viewer,
   filters,
 }) =>
@@ -107,6 +111,7 @@ compose(
           selectedSurvivalData={selectedSurvivalData}
           cohort={viewer.frequentlyMutatedGenesTableFragment}
           projectBreakdown={viewer.geneProjectBreakdownFragment}
+          survivalPlotSampleSize={survivalPlotSampleSize}
         />
       </Column>
     </Column>

--- a/modules/node_modules/@ncigdc/components/Cohort/MutationsTab.js
+++ b/modules/node_modules/@ncigdc/components/Cohort/MutationsTab.js
@@ -32,10 +32,12 @@ compose(
   withState('defaultSurvivalData', 'setDefaultSurvivalData', {}),
   withState('selectedSurvivalData', 'setSelectedSurvivalData', {}),
   withState('state', 'setState', initialState),
+  withProps({ survivalPlotSampleSize: 500 }),
   withProps(({
     selectedSurvivalData,
     defaultSurvivalData,
     setDefaultSurvivalData,
+    survivalPlotSampleSize,
     filters,
     setState,
   }) => ({
@@ -47,6 +49,7 @@ compose(
       const survivalData = await getDefaultCurve({
         currentFilters: filters,
         slug: 'Cohort',
+        size: survivalPlotSampleSize,
       });
 
       setDefaultSurvivalData(survivalData);
@@ -66,6 +69,7 @@ compose(
   survivalData,
   selectedSurvivalData,
   setSelectedSurvivalData,
+  survivalPlotSampleSize,
 }) => (
   <Column style={styles.card}>
     <h1 style={{ ...styles.heading, padding: '1rem' }} id="mutated-genes">
@@ -97,6 +101,7 @@ compose(
       selectedSurvivalData={selectedSurvivalData}
       setSelectedSurvivalData={setSelectedSurvivalData}
       showSurvivalPlot
+      survivalPlotSampleSize={survivalPlotSampleSize}
     />
   </Column>
 ));

--- a/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
+++ b/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { compose, withState, lifecycle, withPropsOnChange } from 'recompose';
+import { compose, withState, lifecycle, withProps, withPropsOnChange } from 'recompose';
 import LocationSubscriber from '@ncigdc/components/LocationSubscriber';
 
 import { parseFilterParam } from '@ncigdc/utils/uri';
@@ -44,11 +44,12 @@ const initialState = {
 };
 
 const enhance = compose(
+  withProps({ survivalPlotSampleSize: 2000 }),
   withState('selectedMutatedGenesSurvivalData', 'setSelectedMutatedGenesSurvivalData', {}),
   withState('selectedFrequentMutationsSurvivalData', 'setSelectedFrequentMutationsSurvivalData', {}),
   withState('state', 'setState', initialState),
   withState('numCasesAggByProject', 'setNumCasesAggByProject', undefined),
-  withPropsOnChange(['projectId', 'numCasesAggByProject'], async ({ projectId, setState, numCasesAggByProject }) => {
+  withPropsOnChange(['projectId', 'numCasesAggByProject', 'survivalPlotSampleSize'], async ({ projectId, setState, numCasesAggByProject, survivalPlotSampleSize }) => {
     if (!numCasesAggByProject) {
       return;
     }
@@ -57,7 +58,7 @@ const enhance = compose(
       totalCases: numCasesAggByProject[projectId],
       currentFilters: { op: '=', content: { field: 'cases.project.project_id', value: projectId } },
       slug: projectId,
-      size: 2000,
+      size: survivalPlotSampleSize,
     });
 
     setState(s => ({
@@ -95,6 +96,7 @@ const ProjectVisualizations = enhance(({
     loadingSurvival,
     loadingAggregation,
   },
+  survivalPlotSampleSize,
   selectedMutatedGenesSurvivalData,
   setSelectedMutatedGenesSurvivalData,
   selectedFrequentMutationsSurvivalData,
@@ -151,6 +153,7 @@ const ProjectVisualizations = enhance(({
             cohort={viewer.frequentlyMutatedGenesTableFragment}
             numCasesAggByProject={numCasesAggByProject}
             projectBreakdown={viewer.geneProjectBreakdownFragment}
+            survivalPlotSampleSize={survivalPlotSampleSize}
           />
         </Column>
       </Column>
@@ -213,6 +216,7 @@ const ProjectVisualizations = enhance(({
                 selectedSurvivalData={selectedFrequentMutationsSurvivalData}
                 setSelectedSurvivalData={setSelectedFrequentMutationsSurvivalData}
                 showSurvivalPlot
+                survivalPlotSampleSize={survivalPlotSampleSize}
               />
             )
           }

--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -146,6 +146,7 @@ const FrequentMutationsTableComponent = compose(
 )(({
   projectId = '',
   showSurvivalPlot = false,
+  survivalPlotSampleSize,
   selectedSurvivalData = { id: '' },
   setSelectedSurvivalData = () => {},
   cohort: { ssms, cases },
@@ -324,7 +325,7 @@ const FrequentMutationsTableComponent = compose(
                             content: [{ op: '=', content: { field: 'cases.project.project_id', value: projectId } }],
                           }
                           : null,
-                        size: includes(location.pathname, '/projects') ? 2000 : 25,
+                        size: survivalPlotSampleSize,
                       })
                         .then((data) => {
                           setSelectedSurvivalData(data);

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
@@ -50,6 +50,7 @@ const FrequentlyMutatedGenesTableComponent = compose(
   survivalLoadingId,
   setSelectedSurvivalData,
   selectedSurvivalData,
+  survivalPlotSampleSize,
   projectBreakdown,
   location,
 }) => {
@@ -213,7 +214,7 @@ const FrequentlyMutatedGenesTableComponent = compose(
                           },
                         ],
                       } : null,
-                      size: includes(location.pathname, '/projects') ? 2000 : 25,
+                      size: survivalPlotSampleSize,
                     })
                       .then(data => {
                         setSelectedSurvivalData(data);

--- a/modules/node_modules/@ncigdc/containers/GenePage.js
+++ b/modules/node_modules/@ncigdc/containers/GenePage.js
@@ -125,6 +125,7 @@ export const GenePageComponent = (props: TProps) => {
               defaultFilters={fmFilters}
               cohort={props.viewer.frequentMutationsTableFragment}
               shouldShowGeneSymbol={false}
+              survivalPlotSampleSize={2000}
             />
           </Column>
         </Column>

--- a/modules/node_modules/@ncigdc/utils/survivalplot.js
+++ b/modules/node_modules/@ncigdc/utils/survivalplot.js
@@ -20,8 +20,7 @@ export const enoughData = (data: Object) => (
   data.results.length && data.results.every(r => r.donors.length >= MINIMUM_CASES)
 );
 
-// default size is 25 because 30 sometimes makes the API's ES query time out
-async function fetchCurves(filters: ?Array<Object>, size: number = 25): Promise<Object> {
+async function fetchCurves(filters: ?Array<Object>, size: number = 500): Promise<Object> {
   const url = `${API}analysis/survival?${filters ? `filters=${JSON.stringify(filters)}` : ''}&size=${size}`;
   const res = await fetch(url);
   const rawData = await res.json();


### PR DESCRIPTION
Doesn't seem to time out anymore
I wonder what was causing this to time out before
Worst case scenario (0 filters) should also be cached by varnish so this may work