### PR TITLE
:bug: PRTL-1032 suggestion facet on gene tab should add filter for gene_id

### DIFF
--- a/modules/node_modules/@ncigdc/containers/cohort/CohortPage.js
+++ b/modules/node_modules/@ncigdc/containers/cohort/CohortPage.js
@@ -209,6 +209,7 @@ export const CohortPageQuery = {
             ...on Gene {
               symbol
               name
+              gene_id
             }
           }
         }

--- a/modules/node_modules/@ncigdc/containers/cohort/GeneAggregations.js
+++ b/modules/node_modules/@ncigdc/containers/cohort/GeneAggregations.js
@@ -32,7 +32,7 @@ export type TProps = {
 };
 
 const presetFacets = [
-  { title: 'Gene Symbol', field: 'symbol', full: 'genes.symbol', doc_type: 'genes', type: 'id' },
+  { title: 'Gene', field: 'gene_id', full: 'genes.gene_id', doc_type: 'genes', type: 'id' },
   { title: 'Type', field: 'biotype', full: 'genes.biotype', doc_type: 'genes', type: 'terms' },
   { title: 'Curated Gene Set', field: 'is_cancer_gene_census', full: 'genes.is_cancer_gene_census', doc_type: 'genes', type: 'terms' },
 ];
@@ -51,8 +51,8 @@ export const GeneAggregationsComponent = compose(
       title="Gene"
       doctype="genes"
       collapsed={props.idCollapsed}
-      fieldNoDoctype="symbol"
-      placeholder="Search for symbol"
+      fieldNoDoctype="gene_id"
+      placeholder="Search for Gene Symbol or ID"
       hits={props.suggestions}
       setAutocomplete={props.setAutocomplete}
       dropdownItem={(x) => (
@@ -61,6 +61,9 @@ export const GeneAggregationsComponent = compose(
             <span style={{ fontWeight: 'bold' }}>
               {x.symbol}
             </span>
+            <span>
+              {x.gene_id}
+            </span>
             {x.name}
           </Column>
         </span>
@@ -68,7 +71,7 @@ export const GeneAggregationsComponent = compose(
       style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
     />
     {
-      _.reject(presetFacets, { full: 'genes.symbol' }).map((facet) => (
+      _.reject(presetFacets, { full: 'genes.gene_id' }).map((facet) => (
         <FacetWrapper
           key={facet.full}
           facet={facet}


### PR DESCRIPTION
- can still search by symbol
- so then links with gene_id in the filter show up in the facet panel