### PR TITLE
🚀 Limit concurrent Mutation Count requests so it does not take up all available http connections

### DIFF
--- a/modules/node_modules/@ncigdc/containers/MutationsCount.js
+++ b/modules/node_modules/@ncigdc/containers/MutationsCount.js
@@ -1,24 +1,43 @@
 // @flow
+/* eslint fp/no-mutating-methods: 0 */
+
 import React from 'react';
 import Relay from 'react-relay';
-import { lifecycle, compose } from 'recompose';
-import { isEqual } from 'lodash';
+import { lifecycle, compose, withProps, withPropsOnChange, withState } from 'recompose';
+import { isEqual, some } from 'lodash';
 import GreyBox from '@ncigdc/uikit/GreyBox';
+import queue from 'queue';
+
+const requestQueue = queue({
+  concurrency: 4,
+  autostart: true,
+});
 
 const MutationsCountComponent = compose(
-  lifecycle({
-    componentDidMount(): void {
-      this.props.relay.setVariables({
-        fetchData: true,
-        ssmsFilters: this.props.filters,
+  withState('queueItem', 'setQueueItem', undefined),
+  withProps(({ relay, setQueueItem }) => ({
+    setRelayVariables: (variables, onReadyStateChange) => {
+      const queueItem = (cb) => relay.setVariables(variables, (readyState) => {
+        if (some([readyState.ready, readyState.aborted, readyState.error])) {
+          cb();
+          setQueueItem(undefined);
+        }
+        if (onReadyStateChange) { onReadyStateChange(readyState); }
       });
+      requestQueue.push(queueItem);
+      setQueueItem(() => queueItem);
     },
-    componentWillReceiveProps(nextProps: Object): void {
-      if (!isEqual(this.props.filters, nextProps.filters)) {
-        this.props.relay.setVariables({
-          fetchData: true,
-          ssmsFilters: nextProps.filters,
-        });
+  })),
+  withPropsOnChange(
+    ({ filters }, { filters: nextFilters }) => !isEqual(filters, nextFilters),
+    ({ filters, setRelayVariables }) => setRelayVariables({ ssmsFilters: filters, fetchData: !!filters })
+  ),
+  lifecycle({
+    componentWillUnmount(): void {
+      // Remove request from queue since it's no longer needed
+      const queueItem = this.props.queueItem;
+      if (queueItem && requestQueue.indexOf(queueItem) !== -1) {
+        requestQueue.splice(requestQueue.indexOf(queueItem), 1);
       }
     },
   })

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "moment": "2.17.1",
     "oncogrid": "1.2.0",
     "query-string": "^4.3.1",
+    "queue": "^4.2.1",
     "react": "15.4.2",
     "react-addons-shallow-compare": "15.4.2",
     "react-dates": "4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,6 +5299,12 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+queue@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-4.2.1.tgz#5318ed8a227a9734e6bfeeb24a057782922751db"
+  dependencies:
+    inherits "~2.0.0"
+
 randomatic@^1.1.3:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.5.tgz#5e9ef5f2d573c67bd2b8124ae90b5156e457840b"


### PR DESCRIPTION
Chrome Firefox and Safari have a limit of 6 simultaneous HTTP connections per domain

Limiting this to < 6 would prevent Mutation Count requests (40 of them in the cohort page when showing the default 20 rows per table, 20 in the project page) from blocking off other requests

4 works alright