### PR TITLE
🐛 remove setState calls from withPropsOnChange

### DIFF
--- a/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
+++ b/modules/node_modules/@ncigdc/components/ProjectVisualizations.js
@@ -49,13 +49,6 @@ const enhance = compose(
   withState('state', 'setState', initialState),
   withState('numCasesAggByProject', 'setNumCasesAggByProject', undefined),
   withPropsOnChange(
-    ['projectId'],
-    ({ setSelectedMutatedGenesSurvivalData, setSelectedFrequentMutationsSurvivalData }) => {
-      setSelectedMutatedGenesSurvivalData({});
-      setSelectedFrequentMutationsSurvivalData({});
-    }
-  ),
-  withPropsOnChange(
     ['projectId', 'survivalPlotSampleSize'],
     async ({ projectId, setState, survivalPlotSampleSize }) => {
       if (!projectId) return;
@@ -74,6 +67,12 @@ const enhance = compose(
     }
   ),
   lifecycle({
+    componentWillReceiveProps(nextProps): void {
+      if (nextProps.projectId !== this.props.projectId) {
+        nextProps.setSelectedMutatedGenesSurvivalData({});
+        nextProps.setSelectedFrequentMutationsSurvivalData({});
+      }
+    },
     async componentDidMount(): Promise<*> {
       const mutatedCasesCountByProject = await fetchApi(
         'analysis/mutated_cases_count_by_project?size=0',

--- a/modules/node_modules/@ncigdc/containers/MutationsCount.js
+++ b/modules/node_modules/@ncigdc/containers/MutationsCount.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import Relay from 'react-relay';
-import { lifecycle, compose, withProps, withPropsOnChange, withState } from 'recompose';
+import { lifecycle, compose, withProps, withState } from 'recompose';
 import { isEqual, some } from 'lodash';
 import GreyBox from '@ncigdc/uikit/GreyBox';
 import queue from 'queue';
@@ -29,11 +29,12 @@ const MutationsCountComponent = compose(
       setQueueItem(() => queueItem);
     },
   })),
-  withPropsOnChange(
-    ({ filters }, { filters: nextFilters }) => !isEqual(filters, nextFilters),
-    ({ filters, setRelayVariables }) => setRelayVariables({ ssmsFilters: filters, fetchData: !!filters })
-  ),
   lifecycle({
+    componentWillReceiveProps(nextProps): void {
+      if (!isEqual(this.props.filters, nextProps.filters)) {
+        nextProps.setRelayVariables({ ssmsFilters: nextProps.filters, fetchData: !!nextProps.filters });
+      }
+    },
     componentWillUnmount(): void {
       // Remove request from queue since it's no longer needed
       const queueItem = this.props.queueItem;


### PR DESCRIPTION
Calling setState inside withPropsOnChange is throwing an error.