### PR TITLE
🐛 [PRTL-1107] use react-lolliplot/dist/lib

### DIFF
--- a/modules/node_modules/@ncigdc/containers/Lolliplot.js
+++ b/modules/node_modules/@ncigdc/containers/Lolliplot.js
@@ -7,7 +7,7 @@ import { compose, lifecycle, withProps, withPropsOnChange, withState } from 'rec
 import { insertRule } from 'glamor';
 import * as d3 from 'd3';
 import { startCase } from 'lodash';
-import Lolliplot from '@oncojs/react-lolliplot';
+import Lolliplot from '@oncojs/react-lolliplot/dist/lib';
 import withRouter from '@ncigdc/utils/withRouter';
 import groupByType from '@ncigdc/utils/groupByType';
 import { buildProteinLolliplotData } from '@ncigdc/utils/data';


### PR DESCRIPTION
~WIP~
the umd build is broken in IE, using `/dist/lib` directly