### PR TITLE
:bug: PRTL-1045 cohort pie charts filters self

### DIFF
--- a/modules/node_modules/@ncigdc/components/Cohort/CohortCasesCharts.js
+++ b/modules/node_modules/@ncigdc/components/Cohort/CohortCasesCharts.js
@@ -11,8 +11,8 @@ import styled from '@ncigdc/theme/styled';
 import type { TRawQuery } from '@ncigdc/utils/uri/types';
 import type { TBucket } from '@ncigdc/components/Aggregations/types';
 import withRouter from '@ncigdc/utils/withRouter';
-import { mergeQuery, makeFilter } from '@ncigdc/utils/filters';
-import { removeEmptyKeys } from '@ncigdc/utils/uri';
+import { mergeQuery, makeFilter, inCurrentFilters } from '@ncigdc/utils/filters';
+import { removeEmptyKeys, parseFilterParam } from '@ncigdc/utils/uri';
 
 export type TProps = {
   push: Function,
@@ -71,7 +71,8 @@ const enhance = compose(withRouter);
 const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
   <LocationSubscriber>{(ctx: {| pathname: string, query: TRawQuery |}) => {
     const clickHandler = addFilter(ctx.query, push);
-
+    const currentFilters = ctx.query && parseFilterParam((ctx.query || {}).filters, {}).content || [];
+    const currentFieldNames = currentFilters.map(f => f.content.field);
     return (
       <RowCenter>
         <ColumnCenter>
@@ -79,6 +80,11 @@ const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
           <PieChart
             data={
               aggregations.project__primary_site.buckets
+                .filter(bucket =>
+                  (currentFieldNames.includes('cases.primary_site') ?
+                      inCurrentFilters({ key: bucket.key, dotField: 'cases.primary_site', currentFilters }) : true
+                  )
+                )
                 .map(toPieData(({ data }) => clickHandler('cases.primary_site', data.id)))
             }
             path="doc_count"
@@ -91,7 +97,12 @@ const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
           <PieChart
             data={
               aggregations.project__project_id.buckets
-                .map(toPieData(({ data }) => clickHandler('cases.project.project_id', data.id)))
+              .filter(bucket =>
+                (currentFieldNames.includes('cases.project.project_id') ?
+                    inCurrentFilters({ key: bucket.key, dotField: 'cases.project.project_id', currentFilters }) : true
+                )
+              )
+              .map(toPieData(({ data }) => clickHandler('cases.project.project_id', data.id)))
             }
             path="doc_count"
             height={125}
@@ -103,6 +114,11 @@ const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
           <PieChart
             data={
               aggregations.project__disease_type.buckets
+                .filter(bucket =>
+                  (currentFieldNames.includes('cases.disease_type') ?
+                      inCurrentFilters({ key: bucket.key, dotField: 'cases.disease_type', currentFilters }) : true
+                  )
+                )
                 .map(toPieData(({ data }) => clickHandler('cases.disease_type', data.id)))
             }
             path="doc_count"
@@ -115,6 +131,11 @@ const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
           <PieChart
             data={
               aggregations.demographic__gender.buckets
+                .filter(bucket =>
+                  (currentFieldNames.includes('cases.demographic.gender') ?
+                      inCurrentFilters({ key: bucket.key, dotField: 'cases.demographic.gender', currentFilters }) : true
+                  )
+                )
                 .map(toPieData(({ data }) => clickHandler('cases.demographic.gender', data.id)))
             }
             path="doc_count"
@@ -127,6 +148,12 @@ const CohortCasesChartsComponent = ({ aggregations, push }: TProps) => (
           <PieChart
             data={
               aggregations.diagnoses__vital_status.buckets
+                .filter(bucket =>
+                  (currentFieldNames.includes('cases.diagnoses.vital_status') ?
+                      inCurrentFilters({ key: bucket.key, dotField: 'cases.diagnoses.vital_status', currentFilters }) :
+                      true
+                  )
+                )
                 .map(toPieData(({ data }) => clickHandler('cases.diagnoses.vital_status', data.id)))
             }
             path="doc_count"


### PR DESCRIPTION
Ticket was 'Cohort Pie Charts do not refresh', got a bit tripped up because thought the filters weren't being passed to the aggregations. They are, but https://github.com/NCI-GDC/gdcapi/blob/master/gdcapi/esutils/request.py#L196 aggregations don't filter themselves unless they are range, so it looked like the `gender` pie chart didn't update when `gender` was selected for example. Fixed by front end filtering per pie chart.