### PR TITLE
🔥 no annotation id half measure

### DIFF
--- a/modules/node_modules/@ncigdc/containers/CaseTr.js
+++ b/modules/node_modules/@ncigdc/containers/CaseTr.js
@@ -14,8 +14,11 @@ import { makeFilter } from '@ncigdc/utils/filters';
 
 import type { TCategory } from '@ncigdc/utils/data/types';
 import { Tr, Td } from '@ncigdc/uikit/Table';
+import { Tooltip } from '@ncigdc/uikit/Tooltip';
 import { withTheme } from '@ncigdc/theme';
 import ProjectLink from '@ncigdc/components/Links/ProjectLink';
+import AnnotationLink from '@ncigdc/components/Links/AnnotationLink';
+import AnnotationsLink from '@ncigdc/components/Links/AnnotationsLink';
 import styled from '@ncigdc/theme/styled';
 
 export type TProps = {|
@@ -23,6 +26,7 @@ export type TProps = {|
   total: number,
   relay: {},
   node: {|
+    annotations: Object,
     case_id: string,
     demographic: {|
       gender: string,
@@ -106,7 +110,17 @@ export const CaseTrComponent = ({ node, index, theme, relay, total }: TProps) =>
           );
         })
       }
-      <TdNum>{node.annotations.hits.total}</TdNum>
+      <TdNum>
+        {node.annotations.hits.total === 0 ? node.annotations.hits.total.toLocaleString() :
+        <AnnotationsLink
+          query={{
+            filters: makeFilter([{ field: 'annotations.case_id', value: node.case_id }], false),
+          }}
+        >
+          {node.annotations.hits.total.toLocaleString()}
+        </AnnotationsLink>
+        }
+      </TdNum>
     </Tr>
   );
 };

--- a/modules/node_modules/@ncigdc/containers/CaseTr.js
+++ b/modules/node_modules/@ncigdc/containers/CaseTr.js
@@ -14,11 +14,8 @@ import { makeFilter } from '@ncigdc/utils/filters';
 
 import type { TCategory } from '@ncigdc/utils/data/types';
 import { Tr, Td } from '@ncigdc/uikit/Table';
-import { Tooltip } from '@ncigdc/uikit/Tooltip';
 import { withTheme } from '@ncigdc/theme';
 import ProjectLink from '@ncigdc/components/Links/ProjectLink';
-import AnnotationLink from '@ncigdc/components/Links/AnnotationLink';
-import AnnotationsLink from '@ncigdc/components/Links/AnnotationsLink';
 import styled from '@ncigdc/theme/styled';
 
 export type TProps = {|
@@ -57,31 +54,6 @@ function massageRelayFiles(files: Object): Array<{}> {
       .map(edge => edge.node),
     }));
 }
-
-const getAnnotationsCount = (annotations) => {
-  if (annotations.total === 1) {
-    return (<AnnotationLink uuid={annotations.edges[0].node.annotation_id}>
-      {annotations.total.toLocaleString()}
-    </AnnotationLink>);
-  } else if (annotations.total > 1 && annotations.total <= 20) {
-    return (<AnnotationsLink
-      query={{
-        filters: makeFilter([{ field: 'annotations.annotation_id',
-          value: annotations.edges.map(({ node: annotation }) => annotation.annotation_id) }], false),
-      }}
-    >
-      {annotations.total.toLocaleString()}
-    </AnnotationsLink>);
-  } else if (annotations.total > 20) {
-    return (
-      <Tooltip Component={<span>Link to the Annotation List page is temporarily unavailable if number > 20</span>}>
-        {annotations.total.toLocaleString()}
-      </Tooltip>
-    );
-  }
-
-  return annotations.total.toLocaleString();
-};
 
 export const CaseTrComponent = ({ node, index, theme, relay, total }: TProps) => {
   type TFilesLinkProps = { fields?: Array<Object>, children?: mixed };
@@ -134,7 +106,7 @@ export const CaseTrComponent = ({ node, index, theme, relay, total }: TProps) =>
           );
         })
       }
-      <TdNum>{getAnnotationsCount(node.annotations.hits)}</TdNum>
+      <TdNum>{node.annotations.hits.total}</TdNum>
     </Tr>
   );
 };
@@ -154,13 +126,8 @@ export const CaseTrQuery = {
           project_id
         }
         annotations {
-          hits(first:20) {
+          hits(first:0) {
             total
-            edges {
-              node {
-                annotation_id
-              }
-            }
           }
         }
         demographic {
@@ -173,7 +140,7 @@ export const CaseTrQuery = {
           }
           file_count
         }
-        
+
         files @include(if: $isFileDataRequired){
           hits(first:99) {
             edges {

--- a/modules/node_modules/@ncigdc/containers/FileTable.js
+++ b/modules/node_modules/@ncigdc/containers/FileTable.js
@@ -165,13 +165,8 @@ export const FileTableQuery = {
               }
             }
             annotations {
-              hits(first:20) {
+              hits(first:0) {
                 total
-                edges {
-                  node {
-                    annotation_id
-                  }
-                }
               }
             }
           }

--- a/modules/node_modules/@ncigdc/containers/FileTr.js
+++ b/modules/node_modules/@ncigdc/containers/FileTr.js
@@ -89,29 +89,6 @@ function getCaseLink({ cases: { hits: { total = 0, edges: cases } }, file_id: fi
   return total.toLocaleString();
 }
 
-const getAnnotationsCount = (annotations) => {
-  if (annotations.total === 1) {
-    return (<AnnotationLink uuid={annotations.edges[0].node.annotation_id}>
-      {annotations.total.toLocaleString()}
-    </AnnotationLink>);
-  } else if (annotations.total > 1 && annotations.total <= 20) {
-    return (<AnnotationsLink
-      query={{
-        filters: makeFilter([{ field: 'annotations.annotation_id',
-          value: annotations.edges.map(({ node: annotation }) => annotation.annotation_id) }], false),
-      }}
-    >
-      {annotations.total.toLocaleString()}
-    </AnnotationsLink>);
-  } else if (annotations.total > 20) {
-    return (<Tooltip Component={<span>Link to the Annotation List page is temporarily unavailable if number > 20</span>}>
-      {annotations.total.toLocaleString()}
-    </Tooltip>);
-  }
-
-  return annotations.total.toLocaleString();
-};
-
 export const FileTrComponent = ({ node, index, theme, canAddToCart = true, dispatch }: TProps) => (
   <Tr
     style={{
@@ -165,7 +142,7 @@ export const FileTrComponent = ({ node, index, theme, canAddToCart = true, dispa
     <Td>{node.data_category}</Td>
     <Td>{node.data_format}</Td>
     <TdNum><FileSize bytes={node.file_size} /></TdNum>
-    <TdNum>{getAnnotationsCount(node.annotations.hits)}</TdNum>
+    <TdNum>{node.annotations.hits.total}</TdNum>
   </Tr>
 );
 


### PR DESCRIPTION
We ask for annotation ids such that we can link to the annotations list page, filtered. For files specifically, we need a better solution (filter annotations by file somehow).

This solves relay trying to be smart and asking for missing annotation ids on nested case/file nodes