### PR TITLE
🔥♻️ get file project_info not from nested cases

### DIFF
--- a/modules/node_modules/@ncigdc/components/File.js
+++ b/modules/node_modules/@ncigdc/components/File.js
@@ -347,7 +347,11 @@ const File = ({
                       action: (
                         <Row>
                           <AddToCartButtonSingle
-                            file={file}
+                            file={{
+                              ...file,
+                              projects: [node.cases.hits.edges[0].node.project.project_id],
+                              acl: node.acl,
+                            }}
                             style={{ padding: '3px 5px' }}
                           />
                           <DownloadFile

--- a/modules/node_modules/@ncigdc/containers/CaseTr.js
+++ b/modules/node_modules/@ncigdc/containers/CaseTr.js
@@ -14,10 +14,8 @@ import { makeFilter } from '@ncigdc/utils/filters';
 
 import type { TCategory } from '@ncigdc/utils/data/types';
 import { Tr, Td } from '@ncigdc/uikit/Table';
-import { Tooltip } from '@ncigdc/uikit/Tooltip';
 import { withTheme } from '@ncigdc/theme';
 import ProjectLink from '@ncigdc/components/Links/ProjectLink';
-import AnnotationLink from '@ncigdc/components/Links/AnnotationLink';
 import AnnotationsLink from '@ncigdc/components/Links/AnnotationsLink';
 import styled from '@ncigdc/theme/styled';
 
@@ -49,13 +47,12 @@ const TdNum = styled(Td, {
   textAlign: 'right',
 });
 
-function massageRelayFiles(files: Object): Array<{}> {
+function massageRelayFiles(files: Object, projectId: string): Array<{}> {
   return _.get(files, 'hits.edges', [])
     .map(edge => edge.node)
     .map(file => ({
       ...file,
-      cases: file.cases.hits.edges
-      .map(edge => edge.node),
+      projects: [projectId],
     }));
 }
 
@@ -81,8 +78,8 @@ export const CaseTrComponent = ({ node, index, theme, relay, total }: TProps) =>
       <Td>
         <AddCaseFilesToCartButton
           hasFiles={_.sum(node.summary.data_categories.map(dataCategory => dataCategory.file_count)) > 0}
-          files={massageRelayFiles(node.files)}
-          filteredFiles={massageRelayFiles(node.filteredFiles)}
+          files={massageRelayFiles(node.files, node.project.project_id)}
+          filteredFiles={massageRelayFiles(node.filteredFiles, node.project.project_id)}
           relay={relay}
           dropdownStyle={total - 1 === index ? { top: 'auto', bottom: '100%' } : {}}
         />
@@ -163,17 +160,6 @@ export const CaseTrQuery = {
                 file_id
                 access
                 file_size
-                cases {
-                  hits(first:1) {
-                    edges {
-                      node {
-                        project {
-                          project_id
-                        }
-                      }
-                    }
-                  }
-                }
               }
             }
           }
@@ -187,17 +173,6 @@ export const CaseTrQuery = {
                 file_id
                 access
                 file_size
-                cases {
-                  hits(first:1) {
-                    edges {
-                      node {
-                        project {
-                          project_id
-                        }
-                      }
-                    }
-                  }
-                }
               }
             }
           }

--- a/modules/node_modules/@ncigdc/containers/FilePage.js
+++ b/modules/node_modules/@ncigdc/containers/FilePage.js
@@ -97,17 +97,6 @@ export const FilePageQuery = {
                         data_type
                         data_format
                         file_size
-                        cases {
-                          hits(first: 1) {
-                            edges {
-                              node {
-                                project {
-                                  project_id
-                                }
-                              }
-                            }
-                          }
-                        }
                       }
                     }
                   }
@@ -141,10 +130,12 @@ export const FilePageQuery = {
           hits(first:99) {
             edges {
               node {
-          case_id
-          entity_id
-          entity_type
-          }}}
+                case_id
+                entity_id
+                entity_type
+              }
+            }
+          }
         }
         metadata_files {
           hits(first:99) {

--- a/modules/node_modules/@ncigdc/containers/FileTr.js
+++ b/modules/node_modules/@ncigdc/containers/FileTr.js
@@ -21,8 +21,6 @@ import { withTheme } from '@ncigdc/theme';
 import styled from '@ncigdc/theme/styled';
 import { makeFilter } from '@ncigdc/utils/filters';
 import ProjectLink from '@ncigdc/components/Links/ProjectLink';
-import AnnotationLink from '@ncigdc/components/Links/AnnotationLink';
-import AnnotationsLink from '@ncigdc/components/Links/AnnotationsLink';
 
 type TNode = {
   access: string,

--- a/modules/node_modules/@ncigdc/dux/cart.js
+++ b/modules/node_modules/@ncigdc/dux/cart.js
@@ -37,7 +37,7 @@ export const CLEAR_CART = 'CLEAR_CART';
 export const CART_FULL = 'CART_FULL';
 
 export const MAX_CART_SIZE = 10000;
-const MAX_CART_WARNING = `The cart is limited to ${MAX_CART_SIZE.toLocaleString()} files. 
+const MAX_CART_WARNING = `The cart is limited to ${MAX_CART_SIZE.toLocaleString()} files.
   Please narrow the search criteria or remove some files from the cart to add more.`;
 
 const getNotificationComponent = (action, id, notification: TNotification, dispatch) => ({
@@ -317,10 +317,7 @@ export function reducer(state: Object = initialState, action: Object): Object {
           access: file.access,
           file_id: file.file_id,
           file_size: file.file_size,
-          projects: file.projects
-          || (Array.isArray(file.cases)
-            ? file.cases.map(c => c.project.project_id)
-            : file.cases.hits.edges.map(c => c.node.project.project_id)),
+          projects: file.projects,
         }))),
       };
     case CLEAR_CART:
@@ -337,10 +334,7 @@ export function reducer(state: Object = initialState, action: Object): Object {
           access: file.access,
           file_id: file.file_id,
           file_size: file.file_size,
-          projects: file.projects
-          || (Array.isArray(file.cases)
-            ? file.cases.map(c => c.project.project_id)
-            : file.cases.hits.edges.map(c => c.node.project.project_id)),
+          projects: file.projects,
         })),
       };
     case CART_FULL:


### PR DESCRIPTION
This removes instances of `cases.files.cases` and `files[something_nested].cases` for project info, which can be passed in from above