### PR TITLE
✨ QoL: add flag to hide mutations count

### DIFF
--- a/modules/node_modules/@ncigdc/containers/MutationsCount.js
+++ b/modules/node_modules/@ncigdc/containers/MutationsCount.js
@@ -18,6 +18,9 @@ const MutationsCountComponent = compose(
   withState('queueItem', 'setQueueItem', undefined),
   withProps(({ relay, setQueueItem }) => ({
     setRelayFilters: ({ filters }, onReadyStateChange) => {
+      if (JSON.parse(localStorage.getItem('disableMutationsCount'))) {
+        return;
+      }
       const variables = { ssmsFilters: filters, fetchData: !!filters };
       const queueItem = (cb) => relay.setVariables(variables, (readyState) => {
         if (some([readyState.ready, readyState.aborted, readyState.error])) {


### PR DESCRIPTION
To disable mutation count requests, set `disableMutationsCount` in localStorage to truthy