### PR TITLE
🎛 PRTL-1152 remove genes.is_cancer_gene_census from top charts filter

### DIFF
--- a/modules/node_modules/@ncigdc/components/ProjectsCharts.js
+++ b/modules/node_modules/@ncigdc/components/ProjectsCharts.js
@@ -101,13 +101,6 @@ function getGenes({ relay, projectIds }: TProps): void {
         {
           op: 'in',
           content: {
-            field: 'genes.is_cancer_gene_census',
-            value: [true],
-          },
-        },
-        {
-          op: 'in',
-          content: {
             field: 'ssms.consequence.transcript.consequence_type',
             value: [
               'missense_variant',


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/743976/25668237/236affc4-2ff4-11e7-8f25-f707e8e426ad.png)
