### PR TITLE
:bug: PRTL-1153 force fetch filteredCases

### DIFF
--- a/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentMutationsTable.js
@@ -138,6 +138,8 @@ const FrequentMutationsTableComponent = compose(
           ], false)
         ),
       });
+      // PRTL-1153 relay vars set correctly but fragment not being resent after 'Clear' button clicked unless forceFetch
+      relay.forceFetch();
     }
   ),
   withTheme,

--- a/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
+++ b/modules/node_modules/@ncigdc/containers/FrequentlyMutatedGenesTable.js
@@ -51,6 +51,8 @@ const FrequentlyMutatedGenesTableComponent = compose(
           ], false)
         ),
       });
+      // PRTL-1153 relay vars set correctly but fragment not being resent after 'Clear' button clicked unless forceFetch
+      relay.forceFetch();
     }
   ),
   withSize()


### PR DESCRIPTION
Rely confuses me muchly. Issue was, if the 'Clear' button was clicked, the "# Affected Cases in Cohort" column in exploration Gene tab did not go back to no-query numbers. ie, if TCGA-LUAD was added as project id, and then clear is clicked this happens:
<img width="512" alt="tp53_relay_1024" src="https://cloud.githubusercontent.com/assets/1314446/25677633/bbee99c0-3014-11e7-8f85-c0d53f5f3f32.png">
TP53 is supposed to be at the top with 3,997 / 10,196. The front end sorting didn't fix it because the numbers themselves are wrong. When `Clear` is clicked, I do see the `geneCaseFilter` correctly being reset to having no project_id. Forcing relay to refetch fixes it, but there might be a better way? :/

also added forceFetch to mutations table because that's also problematic