### PR TITLE
🐛PRTL-1173 add "Available Variation Data is SSM" to filters

### DIFF
--- a/modules/node_modules/@ncigdc/containers/CancerDistributionTable.js
+++ b/modules/node_modules/@ncigdc/containers/CancerDistributionTable.js
@@ -86,6 +86,7 @@ const CancerDistributionTableComponent = compose(
               searchTableTab: 'cases',
               filters: makeFilter([
                 { field: 'cases.project.project_id', value: [b.key] },
+                { field: 'cases.available_variation_data', value: 'ssm' },
               ], false),
             }}
           >


### PR DESCRIPTION
This was lost in a merge conflict
https://github.com/NCI-GDC/portal-ui/pull/1639/commits