### PR TITLE
✨ enable ip to be used in addition to localhost

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -10,6 +10,8 @@ const config = merge(
   webpackConfig,
   {
     devServer: {
+      host: '0.0.0.0',
+      disableHostCheck: true,
       proxy: {
         '/api': {
           target: `${host}:${port}`,


### PR DESCRIPTION
allows you to use http://localhost:8080 or http://192.168.*.*:8080