### PR TITLE
🐛 move polyfills back for IE11

### DIFF
--- a/modules/node_modules/webpack_entry/index.js
+++ b/modules/node_modules/webpack_entry/index.js
@@ -2,9 +2,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-// babel-polyfill needs to load after react and react-dom to work in IE11
-import 'babel-polyfill';
-
 import { setTheme } from '@ncigdc/theme';
 
 import Root from './Root';

--- a/modules/node_modules/webpack_entry/index.js
+++ b/modules/node_modules/webpack_entry/index.js
@@ -1,7 +1,9 @@
 /* @flow */
-import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
+
+// babel-polyfill needs to load after react and react-dom to work in IE11
+import 'babel-polyfill';
 
 import { setTheme } from '@ncigdc/theme';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,6 @@
 const webpackConfig = require('@knit/webpack-config-socks-app');
 
+const libs = webpackConfig.entry.libs;
+libs.unshift(libs.splice(libs.indexOf('babel-polyfill'), 1)[0]);
+
 module.exports = webpackConfig;

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -22,4 +22,7 @@ const config = merge(
   }
 );
 
+const libs = config.entry.libs;
+libs.unshift(libs.splice(libs.indexOf('babel-polyfill'), 1)[0]);
+
 module.exports = config;


### PR DESCRIPTION
~Move this to the top when we remove hot reloading, looks like I was wrong and it still needs to be after react. (waiting to test on collab)~
That ~was~ wasn't it