### PR TITLE
Use default tables configs

### DIFF
--- a/src/packages/@ncigdc/dux/tableColumns.js
+++ b/src/packages/@ncigdc/dux/tableColumns.js
@@ -42,9 +42,7 @@ const initialState = Object.keys(tableModels).reduce(
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case REHYDRATE: {
-      const incoming = action.payload.tableColumns;
-      if (incoming) return incoming;
-      return state;
+      return { ...state, ...action.payload.tableColumns };
     }
 
     case tableColumns.TOGGLE_COLUMN: {


### PR DESCRIPTION
if a table is missing from the local storage, this will just use the default. 