### PR TITLE
Revert "✨ [PRTL-1260] remove impact option in lolliplot (#1774)"

### DIFF
--- a/src/packages/@ncigdc/containers/Lolliplot.js
+++ b/src/packages/@ncigdc/containers/Lolliplot.js
@@ -655,8 +655,17 @@ const LolliplotComponent = compose(
                       </span>}
                   </div>
                   <div style={{ marginTop: '6px' }}>
-                    {/* <select> removed for https://jira.opensciencedatacloud.org/browse/PRTL-1260 */}
-                    <b>Consequence Type</b>
+                    <select
+                      value={blacklist}
+                      onChange={e => {
+                        e.persist();
+                        setState(s => ({ ...s, blacklist: e.target.value }));
+                      }}
+                      aria-label="Color by:"
+                    >
+                      <option value="consequence">Consequence</option>
+                      <option value="impact">Impact (VEP)</option>
+                    </select>
                   </div>
                   <div style={{ marginTop: '6px' }}>
                     <div


### PR DESCRIPTION
This reverts commit 62379b0e07f258b2b789db193dea58f1216680d4.