### PR TITLE
Isolated component route

### DIFF
--- a/src/packages/@ncigdc/components/PortalContainer.js
+++ b/src/packages/@ncigdc/components/PortalContainer.js
@@ -37,6 +37,8 @@ import styled from '@ncigdc/theme/styled';
 import { setModal } from '@ncigdc/dux/modal';
 import FirstTimeModal from '@ncigdc/components/Modals/FirstTimeModal';
 
+import * as ModernComponents from '@ncigdc/modern_components';
+
 const SkipLink = styled.a({
   position: 'absolute',
   left: '-999px',
@@ -104,6 +106,15 @@ const PortalContainer = ({
         <Route path="/annotations/:id" component={AnnotationRoute} />
         <Route path="/genes/:id" component={GeneRoute} />
         <Route path="/ssms/:id" component={SSMRoute} />
+        <Route
+          path="/components/:component"
+          component={({ match, ...props }) => {
+            const Component = ModernComponents[match.params.component];
+            return Component
+              ? <Component />
+              : <h1>No matching component found.</h1>;
+          }}
+        />
         <Route component={NotFound} />
       </Switch>
     </div>

--- a/src/packages/@ncigdc/modern_components/AffectedCasesBarChart/index.js
+++ b/src/packages/@ncigdc/modern_components/AffectedCasesBarChart/index.js
@@ -1,0 +1,2 @@
+import AffectedCasesBarChart from './AffectedCasesBarChart';
+export default AffectedCasesBarChart;

--- a/src/packages/@ncigdc/modern_components/AffectedCasesTable/index.js
+++ b/src/packages/@ncigdc/modern_components/AffectedCasesTable/index.js
@@ -1,0 +1,2 @@
+import AffectedCasesTable from './AffectedCasesTable';
+export default AffectedCasesTable;

--- a/src/packages/@ncigdc/modern_components/ExploreCasesPies/index.js
+++ b/src/packages/@ncigdc/modern_components/ExploreCasesPies/index.js
@@ -1,0 +1,2 @@
+import ExploreCasesPies from './ExploreCasesPies';
+export default ExploreCasesPies;

--- a/src/packages/@ncigdc/modern_components/ExploreCasesTable/index.js
+++ b/src/packages/@ncigdc/modern_components/ExploreCasesTable/index.js
@@ -1,0 +1,2 @@
+import ExploreCasesTable from './ExploreCasesTable';
+export default ExploreCasesTable;

--- a/src/packages/@ncigdc/modern_components/GenesBarChart/index.js
+++ b/src/packages/@ncigdc/modern_components/GenesBarChart/index.js
@@ -1,0 +1,2 @@
+import GenesBarChart from './GenesBarChart';
+export default GenesBarChart;

--- a/src/packages/@ncigdc/modern_components/GenesTable/index.js
+++ b/src/packages/@ncigdc/modern_components/GenesTable/index.js
@@ -1,0 +1,2 @@
+import GenesTable from './GenesTable';
+export default GenesTable;

--- a/src/packages/@ncigdc/modern_components/ProjectBreakdown/index.js
+++ b/src/packages/@ncigdc/modern_components/ProjectBreakdown/index.js
@@ -1,0 +1,2 @@
+import ProjectBreakdown from './ProjectBreakdown';
+export default ProjectBreakdown;

--- a/src/packages/@ncigdc/modern_components/SsmsBarChart/index.js
+++ b/src/packages/@ncigdc/modern_components/SsmsBarChart/index.js
@@ -1,0 +1,2 @@
+import SsmsBarChart from './SsmsBarChart';
+export default SsmsBarChart;

--- a/src/packages/@ncigdc/modern_components/SsmsTable/index.js
+++ b/src/packages/@ncigdc/modern_components/SsmsTable/index.js
@@ -1,0 +1,2 @@
+import SsmsTable from './SsmsTable';
+export default SsmsTable;

--- a/src/packages/@ncigdc/modern_components/index.js
+++ b/src/packages/@ncigdc/modern_components/index.js
@@ -1,0 +1,21 @@
+import AffectedCasesBarChart from './AffectedCasesBarChart';
+import AffectedCasesTable from './AffectedCasesTable';
+import ExploreCasesPies from './ExploreCasesPies';
+import ExploreCasesTable from './ExploreCasesTable';
+import GenesBarChart from './GenesBarChart';
+import GenesTable from './GenesTable';
+import ProjectBreakdown from './ProjectBreakdown';
+import SsmsBarChart from './SsmsBarChart';
+import SsmsTable from './SsmsTable';
+
+export {
+  AffectedCasesBarChart,
+  AffectedCasesTable,
+  ExploreCasesPies,
+  ExploreCasesTable,
+  GenesBarChart,
+  GenesTable,
+  ProjectBreakdown,
+  SsmsBarChart,
+  SsmsTable,
+};


### PR DESCRIPTION
I've wanted to do this for a while.. a quick way to test a component by itself.

this makes a route at `/components/:component_name` and loads just that component. Should be a really good way to test default props and performance per component.. lots of things really. I was thinking about storybook for a while but this seems easier for now

![image](https://user-images.githubusercontent.com/2880089/27139019-e63683ea-50ef-11e7-93b5-18a1dcf3b50b.png)
