### PR TITLE
🐛 [SV-766] do not close login popup on /auth

### DIFF
--- a/src/packages/@ncigdc/components/LoginButton.js
+++ b/src/packages/@ncigdc/components/LoginButton.js
@@ -23,7 +23,10 @@ const openAuthWindow = ({ pathname, dispatch }) => {
         // Must check this block (if the login window has been closed) first!
         if (win.closed) {
           clearInterval(interval);
-        } else if (win.document.URL.includes(location.origin)) {
+        } else if (
+          win.document.URL.includes(location.origin) &&
+          !win.document.URL.includes(location.origin + '/auth')
+        ) {
           win.close();
 
           setTimeout(() => {


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/SV-766

phillis [3:12 PM] shared this post
Problem:
Some users can login to the portal, but can't download token nor protected files
How to trigger the bug:
This only happens if a user's previous token is expired recently. And use the data-portal's login button to login.
Reason that the user can't get token:
The login process is:
1) user clicks login in portal, portal creates a popup and redirect to /auth
2) auth server redirects user to itrust to login
3) after login, the auth server checks if the user has a valid token
a) if True, redirect back to portal. Everything good
b) if False, it calls keystone(internal auth server) to generate a new token, and save it in database, then redirect back to portal
4) the portal keep checking if the popup's url starts with portal.gdc.cancer.gov now(Meaning the user is logged in via itrust). If so, it closes the popup.
The bug happens when the user is in state 3b). And portal checks that the user is already logged in from itrust. Then it closes the popup too early before auth server generates the new token.
The bug is introduced when we updates the portal to close the popup when the window's url is starts with portal.gdc.cancer.gov
The fix is to update the close popup criteria to be:
1) the url starts with portal.gdc.cancer.gov
2) the url doesn't start with portal.gdc.cancer.gov/auth (Meaning the auth process is finished, and the popup is already redirected back to data-portal)