### PR TITLE
:bug: PRTL-1451 Gene facet: fix field so reset appears

### DIFF
--- a/src/packages/@ncigdc/containers/explore/GeneAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/GeneAggregations.js
@@ -33,6 +33,11 @@ export type TProps = {
   },
   setAutocomplete: Function,
   theme: Object,
+  idCollapsed: boolean,
+  setSsmIdCollapsed: Function,
+  geneSymbolFragment: Object,
+  suggestions: Object,
+  relay: Object,
 };
 
 const presetFacets = [
@@ -67,7 +72,7 @@ export const GeneAggregationsComponent = compose(
   <div>
     <FacetHeader
       title="Gene"
-      field="genes.symbol"
+      field="genes.gene_id"
       collapsed={props.idCollapsed}
       setCollapsed={props.setSsmIdCollapsed}
     />


### PR DESCRIPTION
<img width="359" alt="screen shot 2017-07-18 at 2 12 27 pm" src="https://user-images.githubusercontent.com/1314446/28332539-2d7b50a8-6bc3-11e7-870d-3e54df3f4e49.png">
the grey reset icon now appears