### PR TITLE
:bug: CreateSaveSetBtn: dont die when currentFilters value is not a string

### DIFF
--- a/src/packages/@ncigdc/components/CurrentFilters.js
+++ b/src/packages/@ncigdc/components/CurrentFilters.js
@@ -279,7 +279,7 @@ const CurrentFilters = (
         pathname={linkPathname}
         disabled={currentFilters
           .reduce((acc, f) => [...acc, ...f.content.value], [])
-          .some(v => v.includes('set_id:'))}
+          .some(v => v.toString().includes('set_id:'))}
         query={
           currentFilters.length && {
             filters: {

--- a/src/packages/@ncigdc/modern_components/CreateSetButton/CreateSetButtonBase.js
+++ b/src/packages/@ncigdc/modern_components/CreateSetButton/CreateSetButtonBase.js
@@ -48,7 +48,7 @@ const CreateSetButton = ({
   const setOnlyInCurrentFilters = filters
     ? filters.content.length === 1 &&
         content.value.length === 1 &&
-        content.value[0].includes('set_id:') &&
+        content.value[0].toString().includes('set_id:') &&
         content.field === field
     : false;
 


### PR DESCRIPTION
My bad, the create save set button reuses the set_id between the repo and explore page if current filters only contains set id. However the check fails when a range facet is added and the type of value is not a string but a number. Fix by casting toString().