### PR TITLE
♻️ PRTL-1447 className instead of data-attribute

### DIFF
--- a/src/packages/@ncigdc/components/AddCaseFilesToCartButton.js
+++ b/src/packages/@ncigdc/components/AddCaseFilesToCartButton.js
@@ -69,14 +69,13 @@ const AddCaseFilesToCartButton = compose(
     dropdownStyle = {},
   }) =>
     <Dropdown
-      data-test="add-case-files-to-cart-dropdown"
+      className="test-add-case-files-to-cart-dropdown"
       dropdownStyle={{ ...styles.dropdownContainer, ...dropdownStyle }}
       dropdownClassName={isLoading ? 'hidden' : 'dropdown-menu'}
       isDisabled={!hasFiles}
       button={
         hasFiles
           ? <button
-              data-test="case-actions"
               className="btn btn-default dropdown-toggle fa fa-shopping-cart"
               style={{ padding: '0 4px' }}
             >
@@ -88,7 +87,6 @@ const AddCaseFilesToCartButton = compose(
             </button>
           : <Tooltip Component={<span>This case has no files.</span>}>
               <button
-                data-test="case-actions"
                 className="btn disabled fa fa-shopping-cart"
                 style={{ padding: '0px 17px 0 4px' }}
                 aria-label="This case has no files"
@@ -101,7 +99,7 @@ const AddCaseFilesToCartButton = compose(
       {!isLoading && [
         !!(files.length && files.length > filesInCart.length) &&
           <DropdownItem
-            data-test="add-all-files"
+            className="test-add-all-files"
             onClick={() => dispatch(addAllFilesInCart(files))}
             aria-label="Add all Case files to the Cart"
             role="button"
@@ -115,7 +113,7 @@ const AddCaseFilesToCartButton = compose(
 
         !!(files.length && filesInCart.length) &&
           <DropdownItem
-            data-test="remove-all-files"
+            className="test-remove-all-files"
             onClick={() => dispatch(removeFilesFromCart(files))}
             aria-label="Remove all Case files from the Cart"
             role="button"
@@ -133,7 +131,7 @@ const AddCaseFilesToCartButton = compose(
           filteredFiles.length < files.length,
         ]) &&
           <DropdownItem
-            data-test="add-filtered-files"
+            className="test-add-filtered-files"
             onClick={() => dispatch(addAllFilesInCart(filteredFiles))}
             aria-label="Add filtered Case files to the Cart"
             role="button"
@@ -147,7 +145,7 @@ const AddCaseFilesToCartButton = compose(
 
         !!(filteredFiles.length && filteredFilesInCart.length) &&
           <DropdownItem
-            data-test="remove-filtered-files"
+            className="test-remove-filtered-files"
             onClick={() => dispatch(removeFilesFromCart(filteredFiles))}
             aria-label="Remove filtered Case files from the Cart"
             role="button"

--- a/src/packages/@ncigdc/components/AddToCartButtonAll.js
+++ b/src/packages/@ncigdc/components/AddToCartButtonAll.js
@@ -81,7 +81,7 @@ const AddToCartButtonAll = ({ edges, files, total, dispatch }: TProps) =>
       return (
         <Row>
           <CartButton
-            data-test="toggle-all-files-in-cart"
+            className="test-toggle-all-files-in-cart"
             active={inCart}
             onClick={() =>
               inCart
@@ -96,7 +96,7 @@ const AddToCartButtonAll = ({ edges, files, total, dispatch }: TProps) =>
           </CartButton>
           <Dropdown
             dropdownStyle={DropDownStyle}
-            data-test="add-to-cart-dropdown"
+            className="test-add-to-cart-dropdown"
             button={
               <Row>
                 <DropDownCaret>
@@ -106,7 +106,7 @@ const AddToCartButtonAll = ({ edges, files, total, dispatch }: TProps) =>
             }
           >
             <DropdownItem
-              data-test="add-all-files"
+              className="test-add-all-files"
               onClick={() => dispatch(fetchFilesAndAdd(currentFilters, total))}
               aria-label="Add all files to cart"
               style={DropDownItemStyle}
@@ -116,7 +116,7 @@ const AddToCartButtonAll = ({ edges, files, total, dispatch }: TProps) =>
               Add all files to the Cart
             </DropdownItem>
             <DropdownItem
-              data-test="remove-all-files"
+              className="test-remove-all-files"
               onClick={() =>
                 dispatch(fetchFilesAndRemove(currentFilters, total))}
               aria-label="Remove all files from cart"

--- a/src/packages/@ncigdc/components/AddToCartButtonSingle.js
+++ b/src/packages/@ncigdc/components/AddToCartButtonSingle.js
@@ -41,7 +41,7 @@ const fileInCart = (files, file) => files.some(f => f.file_id === file.file_id);
 
 const AddToCartButtonSingle = ({ dispatch, file, files, theme }) =>
   <Button
-    data-test="add-to-cart"
+    className="test-add-to-cart"
     style={{
       ...styles.button(theme),
       ...(fileInCart(files, file)

--- a/src/packages/@ncigdc/components/Aggregations/DateFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/DateFacet.js
@@ -67,7 +67,7 @@ const DateFacet = (props: TProps) => {
   };
 
   return (
-    <Container style={{ ...props.style }} data-test="date-facet">
+    <Container style={{ ...props.style }} className="test-date-facet">
       {!props.collapsed &&
         <Row>
           <Label

--- a/src/packages/@ncigdc/components/Aggregations/ExactMatchFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/ExactMatchFacet.js
@@ -40,7 +40,7 @@ const ExactMatchFacet = compose(
             dotField: `${doctype}.${fieldNoDoctype}`,
           }) || { content: { value: [] } };
           return (
-            <Container style={style} data-test="exact-match-facet">
+            <Container style={style} className="test-exact-match-facet">
               {!collapsed &&
                 <Column>
                   {currentValues.content.value.map(v =>

--- a/src/packages/@ncigdc/components/Aggregations/FacetHeader.js
+++ b/src/packages/@ncigdc/components/Aggregations/FacetHeader.js
@@ -72,7 +72,7 @@ const FacetHeader = compose(
         const currentFilters =
           ctx.query && parseFilterParam((ctx.query || {}).filters, {});
         return (
-          <Header data-test="facet-header">
+          <Header className="test-facet-header">
             <span
               style={{ cursor: 'pointer' }}
               onClick={() => setCollapsed(!collapsed)}

--- a/src/packages/@ncigdc/components/Aggregations/FacetResetButton.js
+++ b/src/packages/@ncigdc/components/Aggregations/FacetResetButton.js
@@ -47,7 +47,7 @@ const FacetResetButton = ({
   });
   return (
     <StyledLink
-      data-test="facet-reset-button"
+      className="test-facet-reset-button"
       style={{ display: inCurrent ? 'inline' : 'none', ...style }}
       query={newQuery}
     >

--- a/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
@@ -34,7 +34,7 @@ const NotMissingFacet = (props: TProps) => {
             parseFilterParam((ctx.query || {}).filters, {}).content) ||
           [];
         return (
-          <Container style={props.style} data-test="not-mission-facet">
+          <Container style={props.style} className="test-not-missing-facet">
             {!props.collapsed &&
               <Column>
                 <BucketRow>

--- a/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
@@ -260,7 +260,7 @@ const RangeFacet = (props: TProps) => {
   const { maxDisplayed, minDisplayed } = props.state;
 
   return (
-    <Container style={{ ...props.style }} data-test="range-facet">
+    <Container style={{ ...props.style }} className="test-range-facet">
       {!props.collapsed &&
         props.convertDays &&
         <Row style={{ marginBottom: '0.5rem' }}>

--- a/src/packages/@ncigdc/components/Aggregations/SuggestionFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/SuggestionFacet.js
@@ -144,7 +144,7 @@ const SuggestionFacet = compose(
             dotField: `${doctype}.${fieldNoDoctype}`,
           }) || { content: { value: [] } };
           return (
-            <Container style={style} data-test="suggestion-facet">
+            <Container style={style} className="test-suggestion-facet">
               {!collapsed &&
                 <Column>
                   {currentValues.content.value.map(v =>

--- a/src/packages/@ncigdc/components/Aggregations/TermAggregation.js
+++ b/src/packages/@ncigdc/components/Aggregations/TermAggregation.js
@@ -66,7 +66,7 @@ const TermAggregation = (props: TProps) => {
             parseFilterParam((ctx.query || {}).filters, {}).content) ||
           [];
         return (
-          <Container style={props.style} data-test="term-aggregation">
+          <Container style={props.style} className="test-term-aggregation">
             {!props.collapsed &&
               props.showingValueSearch &&
               <Row>

--- a/src/packages/@ncigdc/components/Annotation.js
+++ b/src/packages/@ncigdc/components/Annotation.js
@@ -11,7 +11,7 @@ import ProjectLink from '@ncigdc/components/Links/ProjectLink';
 import { withTheme } from '@ncigdc/theme';
 
 const Annotation = ({ node, theme }: { node: Object, theme: Object }) =>
-  <Column spacing={theme.spacing} data-test="annotation">
+  <Column spacing={theme.spacing} className="test-annotation">
     <EntityPageVerticalTable
       id="summary"
       title={<span><i className="fa fa-table" /> Summary</span>}

--- a/src/packages/@ncigdc/components/ArrangeColumns.js
+++ b/src/packages/@ncigdc/components/ArrangeColumns.js
@@ -34,10 +34,10 @@ const ArrangeColumns = compose(
   );
 
   return (
-    <div data-test="arrange-columns">
+    <div className="test-arrange-columns">
       {filteredColumns.map((column, i) =>
         <SortableItem
-          data-test="column"
+          className="test-column"
           key={column.id}
           updateState={nextState =>
             setState(state => {

--- a/src/packages/@ncigdc/components/ArrangeColumnsButton.js
+++ b/src/packages/@ncigdc/components/ArrangeColumnsButton.js
@@ -37,7 +37,7 @@ const ArrangeColumnsButton = compose(
   withState('searchTerm', 'setState', ''),
 )(({ searchTerm, setState, dispatch, entityType, style = {} }) =>
   <Dropdown
-    data-test="arrange-columns-button"
+    className="test-arrange-columns-button"
     autoclose={false}
     button={
       <Tooltip Component={<span>Arrange Columns</span>}>
@@ -52,7 +52,7 @@ const ArrangeColumnsButton = compose(
       <Row>
         <SearchIcon />
         <input
-          data-test="filter-columns"
+          className="test-filter-columns"
           style={{
             width: '100%',
             padding: '0.3rem 0.5rem',
@@ -66,7 +66,7 @@ const ArrangeColumnsButton = compose(
         />
       </Row>
       <RestoreDefaults
-        data-test="restore-defaults"
+        className="test-restore-defaults"
         onClick={() => {
           dispatch(restoreColumns(entityType));
           setState(() => '');

--- a/src/packages/@ncigdc/components/BAMSlicingButton.js
+++ b/src/packages/@ncigdc/components/BAMSlicingButton.js
@@ -37,7 +37,7 @@ const BAMSlicingButton = ({
   active,
 }: TProps) =>
   <BAMButton
-    data-test="bam-button"
+    className="test-bam-button"
     style={{ marginLeft: '0.5rem' }}
     leftIcon={active ? <Spinner /> : <CutleryIcon />}
     disabled={active}
@@ -46,7 +46,7 @@ const BAMSlicingButton = ({
         setModal(
           user && userCanDownloadFile({ user, file })
             ? <BAMModal
-                data-test="bam-modal"
+                className="test-bam-modal"
                 file={file}
                 closeModal={() => dispatch(setModal(null))}
                 setActive={setActive}

--- a/src/packages/@ncigdc/components/BioTreeView.js
+++ b/src/packages/@ncigdc/components/BioTreeView.js
@@ -28,7 +28,7 @@ const BioTreeView = ({
   const expanded =
     ex || (query && entities.hits.edges.some(e => search(query, e).length));
   return (
-    <div data-test="biotree-view">
+    <div className="test-biotree-view">
       {entities.hits.total > 0 &&
         <div
           onClick={e => {

--- a/src/packages/@ncigdc/components/BiospecimenCard.js
+++ b/src/packages/@ncigdc/components/BiospecimenCard.js
@@ -76,13 +76,13 @@ const BiospecimenCard = ({
 
   return (
     <Card
-      data-test="biospecimen-card"
+      className="test-biospecimen-card"
       style={{ flex: 1 }}
       title={
         <Row style={{ justifyContent: 'space-between' }}>
           <span>Biospecimen</span>
           <DownloadButton
-            data-test="download-biospecimen"
+            className="test-download-biospecimen"
             style={visualizingButton}
             filename={`biospecimen.case-${p.case_id}`}
             endpoint="cases"

--- a/src/packages/@ncigdc/components/CartDownloadDropdown.js
+++ b/src/packages/@ncigdc/components/CartDownloadDropdown.js
@@ -148,7 +148,7 @@ const CartDownloadDropdown = ({
 }) =>
   <Row>
     <Dropdown
-      data-test="cart-download-dropdown"
+      className="test-cart-download-dropdown"
       dropdownStyle={{
         marginTop: '2px',
         borderRadius: '4px',
@@ -170,7 +170,7 @@ const CartDownloadDropdown = ({
     >
       <Column>
         <DownloadButton
-          data-test="download-manifest"
+          className="test-download-manifest"
           style={styles.button(theme)}
           endpoint="manifest"
           activeText="Manifest"
@@ -184,7 +184,7 @@ const CartDownloadDropdown = ({
           }}
         />
         <Button
-          data-test="download-cart"
+          className="test-download-cart"
           style={styles.button(theme)}
           disabled={state.cartDownloading}
           onClick={() => downloadCart(user, files, dispatch, setState)}

--- a/src/packages/@ncigdc/components/Case.js
+++ b/src/packages/@ncigdc/components/Case.js
@@ -227,10 +227,10 @@ const Case = compose(
     ]);
 
     return (
-      <Column spacing={theme.spacing} data-test="case">
+      <Column spacing={theme.spacing} className="test-case">
         <Row style={{ justifyContent: 'flex-end' }}>
           <Button
-            data-test="cart-file-toggle"
+            className="test-cart-file-toggle"
             onClick={() => dispatch(cartOperation(files))}
             leftIcon={<ShoppingCartIcon />}
           >
@@ -265,7 +265,7 @@ const Case = compose(
 
           <Column style={{ width: '200px' }} spacing={theme.spacing}>
             <CountCard
-              data-test="files-count"
+              className="test-files-count"
               style={{ width: 'auto' }}
               title="FILES"
               count={totalFiles.toLocaleString()}
@@ -286,7 +286,7 @@ const Case = compose(
               }
             />
             <CountCard
-              data-test="annotations-count"
+              className="test-annotations-count"
               style={{ width: 'auto' }}
               title="ANNOTATIONS"
               count={p.annotations.hits.total.toLocaleString()}
@@ -299,7 +299,7 @@ const Case = compose(
         <Row style={{ flexWrap: 'wrap' }} spacing={theme.spacing}>
           <span style={{ flex: 1 }}>
             <SummaryCard
-              data-test="experimental-strategy-summary"
+              className="test-experimental-strategy-summary"
               tableTitle="File Counts by Experimental Strategy"
               pieChartTitle="File Counts by Experimental Strategy"
               data={experimentalStrategies}
@@ -348,7 +348,7 @@ const Case = compose(
           </span>
           <span style={{ flex: 1 }}>
             <SummaryCard
-              data-test="data-category-summary"
+              className="test-data-category-summary"
               tableTitle="File Counts by Data Category"
               pieChartTitle="File Counts by Experimental Strategy"
               data={dataCategories}

--- a/src/packages/@ncigdc/components/CasesCount.js
+++ b/src/packages/@ncigdc/components/CasesCount.js
@@ -9,7 +9,7 @@ type TProps = {
 };
 
 const CasesCount = (props: TProps) =>
-  <span data-test={props['data-test'] || 'cases-count'}>
+  <span className={props.className || 'test-cases-count'}>
     {props.hits.total > 0
       ? props.hits.total.toLocaleString()
       : <span className="fa fa-spinner fa-spin" />}

--- a/src/packages/@ncigdc/components/Charts/BarChart.js
+++ b/src/packages/@ncigdc/components/Charts/BarChart.js
@@ -26,7 +26,7 @@ const BarChart = (() => ({
 }) => {
   const el = ReactFauxDOM.createElement('div');
   el.style.width = '100%';
-  el.setAttribute('data-test', 'bar-chart');
+  el.setAttribute('class', 'test-bar-chart');
   const innerPadding = 0.3;
   const outerPadding = 0.3;
 

--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -22,7 +22,7 @@ const DoubleRingChart = ({
   const node = ReactFauxDOM.createElement('div');
   node.style.setProperty('display', 'flex');
   node.style.setProperty('justify-content', 'center');
-  node.setAttribute('data-test', 'double-ring-chart');
+  node.setAttribute('class', 'test-double-ring-chart');
 
   const svg = d3
     .select(node)

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -32,7 +32,7 @@ const PieChart = compose(
   const node = ReactFauxDOM.createElement('div');
   node.style.setProperty('display', 'flex');
   node.style.setProperty('justify-content', 'center');
-  node.setAttribute('data-test', 'pie-chart');
+  node.setAttribute('class', 'test-pie-chart');
 
   const pie = d3
     .pie()

--- a/src/packages/@ncigdc/components/Charts/StackedBarChart.js
+++ b/src/packages/@ncigdc/components/Charts/StackedBarChart.js
@@ -36,7 +36,7 @@ const drawChart = ({
   };
 
   const el = ReactFauxDOM.createElement('div');
-  el.setAttribute('data-test', 'stacked-bar-chart');
+  el.setAttribute('class', 'test-stacked-bar-chart');
 
   const margin = { top: 10, right: 0, bottom: 55, left: 70 };
   const x = d3

--- a/src/packages/@ncigdc/components/ClinicalCard.js
+++ b/src/packages/@ncigdc/components/ClinicalCard.js
@@ -32,7 +32,7 @@ const ClinicalCard = ({
   theme: Object,
 }) =>
   <Card
-    data-test="clinical-card"
+    className="test-clinical-card"
     style={{ flex: 1 }}
     title={
       <Row style={{ justifyContent: 'space-between' }}>

--- a/src/packages/@ncigdc/components/CountCard.js
+++ b/src/packages/@ncigdc/components/CountCard.js
@@ -9,13 +9,13 @@ import Link from '@ncigdc/components/Links/Link';
 
 const CountCard = ({ title, count, icon, style, linkParams, ...props }) =>
   <Card
-    data-test={props['data-test'] || 'count-card'}
+    className={props.className || 'test-count-card'}
     style={{ padding: '1rem', width: '15rem', ...style }}
   >
     <Row>
       <Column>
         <Row style={{ fontSize: '1.1rem' }}>{title}</Row>
-        <Row style={{ fontSize: '2rem', width: '5em' }} data-test="count">
+        <Row style={{ fontSize: '2rem', width: '5em' }} className="test-count">
           {linkParams ? <Link {...linkParams}>{count}</Link> : count}
         </Row>
       </Column>

--- a/src/packages/@ncigdc/components/CurrentFilters.js
+++ b/src/packages/@ncigdc/components/CurrentFilters.js
@@ -167,7 +167,7 @@ const CurrentFilters = (
     getDisplayValue,
   }: TProps = {},
 ) =>
-  <Info style={style} data-test="current-filters">
+  <Info style={style} className="test-current-filters">
     {!currentFilters.length &&
       <span
         style={{
@@ -191,7 +191,7 @@ const CurrentFilters = (
       >
         <Row wrap spacing="0.3rem">
           <NotUnderlinedLink
-            data-test="clear"
+            className="test-clear"
             style={styles.groupPadding}
             query={omit(query, 'filters')}
           >
@@ -206,7 +206,7 @@ const CurrentFilters = (
               style={styles.groupPadding}
             >
               <NotUnderlinedLink
-                data-test="field-name"
+                className="test-field-name"
                 merge="toggle"
                 query={{
                   offset: 0,
@@ -231,7 +231,7 @@ const CurrentFilters = (
                 ? filter.content.value
                 : take(filter.content.value, 2)).map(value =>
                 <NotUnderlinedLink
-                  data-test="field-value"
+                  className="test-field-value"
                   key={value}
                   merge="toggle"
                   query={{
@@ -257,7 +257,7 @@ const CurrentFilters = (
               )}
               {filter.content.value.length > 2 &&
                 <UnstyledButton
-                  data-test="toggle"
+                  className="test-toggle"
                   style={styles.rightParen}
                   onClick={() => onLessClicked(filter)}
                 >
@@ -265,7 +265,7 @@ const CurrentFilters = (
                 </UnstyledButton>}
               {isFilterExpanded(filter) &&
                 <UnstyledButton
-                  data-test="toggle"
+                  className="test-toggle"
                   style={{ display: 'flex', alignItems: 'center' }}
                   onClick={() => onLessClicked(filter)}
                 >

--- a/src/packages/@ncigdc/components/DismissibleBanner.js
+++ b/src/packages/@ncigdc/components/DismissibleBanner.js
@@ -8,7 +8,7 @@ import Button from '@ncigdc/uikit/Button';
 import { setModal } from '@ncigdc/dux/modal';
 
 const DismissibleBanner = ({ dispatch }) =>
-  <Row data-test="banner">
+  <Row className="test-banner">
     <strong>{`Can't find your data?`}</strong>
     <span
       className="header-banner-link"

--- a/src/packages/@ncigdc/components/DownloadButton.js
+++ b/src/packages/@ncigdc/components/DownloadButton.js
@@ -59,7 +59,7 @@ const DownloadButton = ({
 
   return (
     <Button
-      data-test={props['data-test'] || 'download-button'}
+      className={props.className || 'test-download-button'}
       style={{
         ...style,
       }}

--- a/src/packages/@ncigdc/components/DownloadFile.js
+++ b/src/packages/@ncigdc/components/DownloadFile.js
@@ -30,7 +30,7 @@ function DownloadFile({
   if (userCanDownloadFile({ user, file })) {
     return (
       <DownloadButton
-        data-test="download-button"
+        className="test-download-button"
         extraParams={{ ids: file.file_id }}
         filename={file.file_name}
         endpoint="data?annotations=true&related_files=true"
@@ -43,7 +43,7 @@ function DownloadFile({
 
   return (
     <Button
-      data-test="download-button"
+      className="test-download-button"
       style={{ flex: 'none', marginLeft: '0.2rem', ...style }}
       onClick={() =>
         dispatch(

--- a/src/packages/@ncigdc/components/DownloadVisualizationButton.js
+++ b/src/packages/@ncigdc/components/DownloadVisualizationButton.js
@@ -66,7 +66,7 @@ const DownloadVisualizationButton = ({
   ...props
 }: TProps) =>
   <DropDown
-    data-test={props['data-test'] || 'download-viz-button'}
+    className={props.className || 'test-download-viz-button'}
     button={
       <Tooltip Component={tooltipHTML}>
         <Button leftIcon={!noText && <Download />} style={visualizingButton}>
@@ -81,7 +81,7 @@ const DownloadVisualizationButton = ({
     {svg &&
       <DropdownItem
         key="svg"
-        data-test="download-svg"
+        className="test-download-svg"
         style={styles.row(theme)}
         onClick={() => {
           downloadSvg({
@@ -97,7 +97,7 @@ const DownloadVisualizationButton = ({
     {svg &&
       <DropdownItem
         key="png"
-        data-test="download-png"
+        className="test-download-png"
         style={{
           ...styles.row(theme),
           ...(supportsSvgToPng()

--- a/src/packages/@ncigdc/components/EntityPageHorizontalTable.js
+++ b/src/packages/@ncigdc/components/EntityPageHorizontalTable.js
@@ -39,7 +39,7 @@ const EntityPageHorizontalTable = ({
   ...props
 }) =>
   <Column
-    data-test={props['data-test'] || 'entity-table-wrapper'}
+    className={props.className || 'test-entity-table-wrapper'}
     style={{
       flexWrap: 'wrap',
       overflow: 'auto',

--- a/src/packages/@ncigdc/components/EntityPageVerticalTable.js
+++ b/src/packages/@ncigdc/components/EntityPageVerticalTable.js
@@ -37,8 +37,7 @@ const EntityPageVerticalTable = ({
   return (
     <Column
       id={id}
-      data-test={props['data-test'] || 'entity-table-wrapper'}
-      className={className}
+      className={className + ' test-entity-table-wrapper'}
       style={{
         flexWrap: 'wrap',
         overflow: 'auto',

--- a/src/packages/@ncigdc/components/ExploringLinks.js
+++ b/src/packages/@ncigdc/components/ExploringLinks.js
@@ -44,7 +44,7 @@ const Icon = styled.i({
 });
 
 const ExploringLinks = () =>
-  <Row spacing="2rem" data-test="explore-links">
+  <Row spacing="2rem" className="test-explore-links">
     <Projects backgroundColor="#1c7960">
       <Icon className="icon-gdc-projects" />
       &nbsp; <span>Projects</span>

--- a/src/packages/@ncigdc/components/FacetSelection.js
+++ b/src/packages/@ncigdc/components/FacetSelection.js
@@ -241,7 +241,7 @@ export default compose(
     },
   }),
 )(props =>
-  <div data-test="facet-selection">
+  <div className="test-facet-selection">
     <div {...css(styles.header)}>
       <h2 data-translate className="modal-title">
         <span>{props.title}</span>
@@ -275,7 +275,7 @@ export default compose(
 
       <label tabIndex={0} role="button" className="pull-right">
         <input
-          data-test="filter-useful-facet"
+          className="test-filter-useful-facet"
           type="checkbox"
           onChange={event =>
             props.setUselessFacetVisibility(event.target.checked)}
@@ -287,13 +287,13 @@ export default compose(
 
     </div>
 
-    <ul {...css(styles.facetList)} data-test="search-result-list">
+    <ul {...css(styles.facetList)} className="test-search-result-list">
       {_.map(props.filteredFacets, facet => {
         const isFocused =
           props.focusedFacet && facet.full === props.focusedFacet.full;
         return (
           <li
-            data-test="search-result-item"
+            className="test-search-result-item"
             key={facet.full}
             onClick={() => props.handleSelectFacet(facet)}
             onMouseEnter={() => props.setFocusedFacet(facet)}

--- a/src/packages/@ncigdc/components/FacetWrapper.js
+++ b/src/packages/@ncigdc/components/FacetWrapper.js
@@ -169,7 +169,7 @@ const FacetWrapper = compose(
         .length >= 20;
 
     return (
-      <FacetWrapperDiv style={style} data-test="facet">
+      <FacetWrapperDiv style={style} className="test-facet">
         <FacetHeader
           title={displayTitle}
           field={facet.full}

--- a/src/packages/@ncigdc/components/File.js
+++ b/src/packages/@ncigdc/components/File.js
@@ -155,13 +155,13 @@ const File = ({
       </RepositoryFilesLink>
     : <span>0</span>;
   return (
-    <Column data-test="file">
+    <Column className="test-file">
       <Row
         style={{ justifyContent: 'flex-end', padding: '1rem 0' }}
         spacing="0.2rem"
       >
         <Button
-          data-test="toggle-cart"
+          className="test-toggle-cart"
           onClick={() => dispatch(toggleFilesInCart(node))}
           leftIcon={<ShoppingCartIcon />}
         >
@@ -179,7 +179,7 @@ const File = ({
       </Row>
       <Row style={{ alignItems: 'flex-start' }}>
         <EntityPageVerticalTable
-          data-test="file-properties"
+          className="test-file-properties"
           title="File Properties"
           style={{ width: '58%', marginRight: '2rem' }}
           thToTd={[
@@ -205,7 +205,7 @@ const File = ({
           ]}
         />
         <EntityPageVerticalTable
-          data-test="data-information"
+          className="test-data-information"
           title="Data Information"
           style={{ width: '42%' }}
           thToTd={[
@@ -217,7 +217,7 @@ const File = ({
         />
       </Row>
       <LocalPaginationTable
-        data-test="associated-cases"
+        className="test-associated-cases"
         data={filteredAE}
         prefix={paginationPrefix}
         style={{ flexGrow: 1, backgroundColor: 'white', marginTop: '2rem' }}
@@ -287,7 +287,7 @@ const File = ({
       {displaySection('analysis', node.data_category) &&
         <Row style={{ paddingTop: '2rem', alignItems: 'flex-start' }}>
           <EntityPageVerticalTable
-            data-test="analysis"
+            className="test-analysis"
             title="Analysis"
             style={{ marginRight: '2rem', width: '50%' }}
             thToTd={[
@@ -314,7 +314,7 @@ const File = ({
             ]}
           />
           <EntityPageVerticalTable
-            data-test="reference-genome"
+            className="test-reference-genome"
             title="Reference Genome"
             style={{ width: '50%' }}
             thToTd={[
@@ -328,7 +328,7 @@ const File = ({
         <Row style={{ paddingTop: '2rem' }}>
           <Column style={{ flexGrow: 1 }}>
             <EntityPageHorizontalTable
-              data-test="read-groups"
+              className="test-read-groups"
               title="Read Groups"
               emptyMessage="No read group files found."
               headings={[
@@ -349,7 +349,7 @@ const File = ({
         <Row style={{ paddingTop: '2rem' }}>
           <Column style={{ flexGrow: 1 }}>
             <EntityPageHorizontalTable
-              data-test="metadata-files"
+              className="test-metadata-files"
               title="Metadata Files"
               emptyMessage="No metadata files found."
               headings={[
@@ -392,7 +392,7 @@ const File = ({
         <Row style={{ paddingTop: '2rem' }}>
           <Column style={{ flexGrow: 1 }}>
             <EntityPageHorizontalTable
-              data-test="downstream-analyses"
+              className="test-downstream-analyses"
               title="Downstream Analyses Files"
               emptyMessage="No Downstream Analysis files found."
               headings={[

--- a/src/packages/@ncigdc/components/FileInput.js
+++ b/src/packages/@ncigdc/components/FileInput.js
@@ -24,7 +24,7 @@ export default ({ addFiles, style, ...props }: TProps) => {
       style={{ ...baseStyle, ...style }}
       type="file"
       title="File Input"
-      data-test={props['data-test'] || 'file-input'}
+      className={props.className + ' test-file-input'}
       onChange={event => {
         addFiles(Array.prototype.slice.call(event.target.files));
 

--- a/src/packages/@ncigdc/components/FileSize.js
+++ b/src/packages/@ncigdc/components/FileSize.js
@@ -20,7 +20,7 @@ type TProps = {|
 |};
 
 const FileSize = (props: TProps) =>
-  <span data-test={props['data-test'] || 'file-size'}>
+  <span className={props.className + ' test-file-size'}>
     {formatFileSize(props.bytes, {
       ...props.options,
     })}

--- a/src/packages/@ncigdc/components/FilesCount.js
+++ b/src/packages/@ncigdc/components/FilesCount.js
@@ -9,7 +9,7 @@ type TProps = {
 };
 
 const FilesCount = (props: TProps) =>
-  <span data-test={props['data-test'] || 'files-count'}>
+  <span className={props.className + ' test-files-count'}>
     {props.hits.total > 0
       ? props.hits.total.toLocaleString()
       : <span className="fa fa-spinner fa-spin" />}

--- a/src/packages/@ncigdc/components/Footer.js
+++ b/src/packages/@ncigdc/components/Footer.js
@@ -59,7 +59,7 @@ export default compose(
     apiCommitHash,
     dataRelease,
   }) =>
-    <footer style={styles.footer(theme)} data-test="footer">
+    <footer style={styles.footer(theme)} className="test-footer">
       <div style={styles.outerContainer} role="contentinfo">
         <div style={styles.innerContainer}>
           <HomeLink style={styles.link}>Site Home</HomeLink>

--- a/src/packages/@ncigdc/components/Header.js
+++ b/src/packages/@ncigdc/components/Header.js
@@ -89,11 +89,7 @@ const Header = compose(
           className="navbar-toggle"
           data-ng-click="hc.toggleCollapsed()"
         >
-          <span
-            className="sr-only"
-            data-translate
-            data-test="toggle-navigation"
-          >
+          <span className="sr-only test-toggle-navigation" data-translate>
             Toggle navigation
           </span>
           <span className="icon-bar" />

--- a/src/packages/@ncigdc/components/Home.js
+++ b/src/packages/@ncigdc/components/Home.js
@@ -228,7 +228,7 @@ const Home = compose(
     },
   }),
 )(({ state: { humanBodyLoading }, config, ...props }) =>
-  <Column data-test="Home">
+  <Column className="test-home">
     <GradientContainer>
       <InsideContainer>
         <SubTitle style={{ fontSize: '2rem' }}>

--- a/src/packages/@ncigdc/components/HomeSearch.js
+++ b/src/packages/@ncigdc/components/HomeSearch.js
@@ -49,7 +49,7 @@ const HomeSearch = compose(
     selectableList: { handleKeyDown, focusedItem, setFocusedItem, selectItem },
   }) =>
     <Container
-      data-test="home-search"
+      className="test-home-search"
       onBlur={event => {
         const currentTarget = event.currentTarget;
         const relatedTarget = event.relatedTarget;
@@ -74,7 +74,7 @@ const HomeSearch = compose(
         }}
       />
       <Input
-        data-test="search-input"
+        className="test-search-input"
         type="text"
         placeholder="e.g. BRAF, Breast, TCGA-BLCA, TCGA-A5-A0G2"
         onChange={event => setQuery(event.target.value)}

--- a/src/packages/@ncigdc/components/HowToDownload.js
+++ b/src/packages/@ncigdc/components/HowToDownload.js
@@ -10,7 +10,7 @@ import Card from '@ncigdc/uikit/Card';
 const title = <span>How to download files in my Cart?</span>;
 
 const HowToDownload = ({ style = {} }) =>
-  <Card style={style} title={title} data-test="how-to-download">
+  <Card style={style} title={title} className="test-how-to-download">
     <div style={{ padding: '1rem' }}>
       <strong>Download Manifest:</strong>
       <br />

--- a/src/packages/@ncigdc/components/Layouts/FullWidthLayout.js
+++ b/src/packages/@ncigdc/components/Layouts/FullWidthLayout.js
@@ -41,7 +41,7 @@ const styles = {
 };
 
 const FullWidthLayout = props =>
-  <Row data-test={props['data-test'] || 'full-width'}>
+  <Row className={props.className || ''}>
     <Column flex="1" style={styles.wrapper}>
       <Row style={styles.title(props.theme)}>
         <span style={styles.type(props.theme)}>{props.entityType}</span>

--- a/src/packages/@ncigdc/components/Legends.js
+++ b/src/packages/@ncigdc/components/Legends.js
@@ -54,7 +54,7 @@ export const SwatchLegend = ({ colorMap }) => {
   );
 
   return (
-    <Row style={styles.table} data-test="legends">
+    <Row style={styles.table} className="test-legends">
       <Column style={styles.td}>{labels.slice(0, 2)}</Column>
       <Column style={styles.td}>{labels.slice(2, 4)}</Column>
       <Column style={styles.td}>{labels.slice(4, 6)}</Column>

--- a/src/packages/@ncigdc/components/LocalPaginationTable.js
+++ b/src/packages/@ncigdc/components/LocalPaginationTable.js
@@ -29,7 +29,7 @@ const LocalPaginationTable = ({
   const tableData = enablePagination ? data.slice(offset, offset + size) : data;
 
   return (
-    <div style={style} data-test={props['data-test']}>
+    <div style={style} className={props.className}>
       <Row
         style={{
           backgroundColor: 'white',

--- a/src/packages/@ncigdc/components/LoginButton.js
+++ b/src/packages/@ncigdc/components/LoginButton.js
@@ -65,7 +65,7 @@ const LoginButton = ({ children, dispatch }: TLoginButtonProps) =>
   <LocationSubscriber>
     {({ pathname }) =>
       <Link
-        data-test="login-button"
+        className="test-login-button"
         onClick={() => openAuthWindow({ pathname, dispatch })}
       >
         {children ||

--- a/src/packages/@ncigdc/components/MutationsCount.js
+++ b/src/packages/@ncigdc/components/MutationsCount.js
@@ -14,11 +14,11 @@ const MutationsCount = ({ ssmCount, filters, isLoading = false }) => {
           searchTableTab: 'mutations',
           filters,
         }}
-        data-test="mutations-count"
+        className="test-mutations-count"
       >
         {ssmCount.toLocaleString()}
       </ExploreLink>
-    : <span data-test="mutations-count">0</span>;
+    : <span className="test-mutations-count">0</span>;
 };
 
 export default MutationsCount;

--- a/src/packages/@ncigdc/components/NoResultsMessage.js
+++ b/src/packages/@ncigdc/components/NoResultsMessage.js
@@ -10,7 +10,7 @@ type TNoResultsProps = {
 const NoResultsMessage = withTheme(
   ({ children, style, theme }: TNoResultsProps) =>
     <span
-      data-test="no-results-message"
+      className="test-no-results-message"
       style={Object.assign({ padding: 10, color: theme.greyScale3 }, style)}
     >
       {children || 'No results found'}

--- a/src/packages/@ncigdc/components/NotificationContainer.js
+++ b/src/packages/@ncigdc/components/NotificationContainer.js
@@ -5,7 +5,7 @@ import Notification from '@ncigdc/uikit/Notification';
 import { Row } from '@ncigdc/uikit/Flex';
 
 const NotificationContainer = ({ notification }) =>
-  <Row data-test="notification-wrapper">
+  <Row className="test-notification-wrapper">
     {notification &&
       <Notification
         id={notification.id}

--- a/src/packages/@ncigdc/components/Oncogrid/OncogridWrapper.js
+++ b/src/packages/@ncigdc/components/Oncogrid/OncogridWrapper.js
@@ -420,7 +420,7 @@ const OncoGridWrapper = compose(
   }) =>
     <Loader loading={isLoading} height="800px">
       <div
-        data-test="oncogrid-wrapper"
+        className="test-oncogrid-wrapper"
         style={{
           ...styles.container,
           ...(isFullScreen() && styles.fullscreen),

--- a/src/packages/@ncigdc/components/Pagination/PaginationLink.js
+++ b/src/packages/@ncigdc/components/Pagination/PaginationLink.js
@@ -16,11 +16,10 @@ export type TProps = {|
 const PaginationLink = (props: TProps) =>
   props.pred
     ? <Link
-        data-test="pagination-link"
         merge
         query={{ [props.prfOff]: props.offset }}
         style={props.style || {}}
-        className={props.className || ''}
+        className={props.className || 'test-pagination-link'}
       >
         {props.children}
       </Link>

--- a/src/packages/@ncigdc/components/Pagination/Showing.js
+++ b/src/packages/@ncigdc/components/Pagination/Showing.js
@@ -22,7 +22,7 @@ const Sizes = (props: TProps) => {
   );
 
   return (
-    <Row spacing="0.5rem" data-test="showing">
+    <Row spacing="0.5rem" className="test-showing">
       <span>Showing</span>
       <strong>{start.toLocaleString()}</strong>
       <span>-</span>

--- a/src/packages/@ncigdc/components/Pagination/Sizes.js
+++ b/src/packages/@ncigdc/components/Pagination/Sizes.js
@@ -22,7 +22,7 @@ const Sizes = ({
   return (
     <span>
       <Dropdown
-        data-test="page-size-selection"
+        className="test-page-size-selection"
         selected={size}
         dropdownStyle={{
           minWidth: '40px',
@@ -33,7 +33,7 @@ const Sizes = ({
       >
         {sizes.map(x =>
           <DropdownItem
-            data-test="page-size-option"
+            className="test-page-size-option"
             key={x}
             style={{
               display: 'flex',

--- a/src/packages/@ncigdc/components/PortalSummary.js
+++ b/src/packages/@ncigdc/components/PortalSummary.js
@@ -44,7 +44,7 @@ type TProps = {
   ssmsCountData: Object,
 };
 const PortalSummary = (props: TProps) =>
-  <Container data-test="portal-summary">
+  <Container className="test-portal-summary">
     <Row style={{ padding: '2rem', alignItems: 'baseline' }}>
       <div style={{ fontSize: '2.3rem', color: 'rgb(70, 70, 70)' }}>
         Data Portal Summary
@@ -57,7 +57,7 @@ const PortalSummary = (props: TProps) =>
         }}
       >
         <a
-          data-test="release"
+          className="test-release"
           target="_blank"
           rel="noopener noreferrer"
           href="https://docs.gdc.cancer.gov/Data/Release_Notes/Data_Release_Notes/"
@@ -123,7 +123,10 @@ const PortalSummary = (props: TProps) =>
           <Row>
             <DoubleHelix color="#01b987" width={20} height={35} />
             <span style={{ fontSize: '2.5rem', marginLeft: '0.5rem' }}>
-              <CasesCount data-test="genes-count" hits={props.genesCountData} />
+              <CasesCount
+                className="test-genes-count"
+                hits={props.genesCountData}
+              />
             </span>
           </Row>
         </CountBox>
@@ -133,7 +136,7 @@ const PortalSummary = (props: TProps) =>
             <MutationIcon color="#01b987" width="32px" height="39px" />
             <span style={{ fontSize: '2.5rem', marginLeft: '0.5rem' }}>
               <FilesCount
-                data-test="mutations-count"
+                className="test-mutations-count"
                 hits={props.ssmsCountData}
               />
             </span>

--- a/src/packages/@ncigdc/components/PrimarySitesCount.js
+++ b/src/packages/@ncigdc/components/PrimarySitesCount.js
@@ -11,7 +11,7 @@ export type TProps = {
 };
 
 const PrimarySitesCount = (props: TProps) =>
-  <span data-test="primary-sites-count">
+  <span className="test-primary-sites-count">
     {props.aggregations.primary_site.buckets.length > 0
       ? props.aggregations.primary_site.buckets.length.toLocaleString()
       : <span className="fa fa-spinner fa-spin" />}

--- a/src/packages/@ncigdc/components/ProgressContainer.js
+++ b/src/packages/@ncigdc/components/ProgressContainer.js
@@ -16,7 +16,7 @@ const ProgressContainer = compose(
   withTheme,
 )(({ percent, theme }) =>
   <ProgressBar
-    data-test="progress-bar"
+    className="test-progress-bar"
     percent={percent}
     color={theme.primaryLight1}
     height={3}

--- a/src/packages/@ncigdc/components/Project.js
+++ b/src/packages/@ncigdc/components/Project.js
@@ -105,11 +105,11 @@ const Project = (
   const dataExportFilters = makeFilter(projectFilter);
 
   return (
-    <span data-test="project">
+    <span className="test-project">
       <Row>
         <Row style={{ ...styles.margin, marginLeft: 'auto' }} spacing="0.2rem">
           <DownloadButton
-            data-test="download-biospecimen"
+            className="test-download-biospecimen"
             disabled={!biospecimenCount}
             filename={`biospecimen.project-${projectId}`}
             endpoint="cases"
@@ -134,7 +134,7 @@ const Project = (
           />
 
           <DownloadButton
-            data-test="download-clinical"
+            className="test-download-clinical"
             disabled={!clinicalCount}
             filename={`clinical.project-${projectId}`}
             endpoint="cases"
@@ -162,7 +162,7 @@ const Project = (
             }
           >
             <DownloadButton
-              data-test="download-manifest"
+              className="test-download-manifest"
               disabled={!fileCount}
               endpoint="files"
               activeText="Downloading"
@@ -197,7 +197,7 @@ const Project = (
 
         <Column style={{ ...styles.margin, width: '200px' }}>
           <CountCard
-            data-test="case-count"
+            className="test-case-count"
             title="CASES"
             count={caseCount.toLocaleString()}
             icon={<CaseIcon style={styles.icon} className="fa-3x" />}
@@ -215,7 +215,7 @@ const Project = (
             }
           />
           <CountCard
-            data-test="file-count"
+            className="test-file-count"
             title="FILES"
             count={fileCount.toLocaleString()}
             icon={<FileIcon style={styles.icon} className="fa-3x" />}
@@ -234,7 +234,7 @@ const Project = (
             }
           />
           <CountCard
-            data-test="annotation-count"
+            className="test-annotation-count"
             title="ANNOTATIONS"
             count={totalAnnotations.toLocaleString()}
             icon={<AnnotationIcon style={styles.icon} className="fa-3x" />}
@@ -266,7 +266,7 @@ const Project = (
       <Row style={{ flexWrap: 'wrap' }} spacing={SPACING}>
         <span style={{ ...styles.column, ...styles.margin, flex: 1 }}>
           <SummaryCard
-            data-test="experimental-strategy-summary"
+            className="test-experimental-strategy-summary"
             tableTitle="Cases and File Counts by Experimental Strategy"
             pieChartTitle="File Counts by Experimental Strategy"
             data={experimentalStrategies.map((item, i) => {
@@ -422,7 +422,7 @@ const Project = (
         </span>
         <span style={{ ...styles.column, ...styles.margin, flex: 1 }}>
           <SummaryCard
-            data-test="data-category-summary"
+            className="test-data-category-summary"
             tableTitle="Cases and File Counts by Data Category"
             pieChartTitle="File Counts by Data Category"
             data={dataCategories.map((item, i) => {

--- a/src/packages/@ncigdc/components/ProjectVisualizations.js
+++ b/src/packages/@ncigdc/components/ProjectVisualizations.js
@@ -135,7 +135,7 @@ const ProjectVisualizations = enhance(
     ]);
 
     return (
-      <div data-test="project-viz">
+      <div className="test-project-viz">
         <Column style={styles.card}>
           <Row style={{ padding: '1rem 1rem 2rem' }}>
             <h1 style={{ ...styles.heading }} id="mutated-genes">

--- a/src/packages/@ncigdc/components/ProjectsCharts.js
+++ b/src/packages/@ncigdc/components/ProjectsCharts.js
@@ -444,7 +444,7 @@ const ProjectsChartsComponent = compose(
     );
 
     return (
-      <Container data-test="projects-charts">
+      <Container className="test-projects-charts">
         <Column
           style={{
             paddingRight: '10px',
@@ -587,7 +587,7 @@ const ProjectsChartsComponent = compose(
         </Column>
         <Column
           style={{ minWidth: '200px', flexGrow: '1', flexBasis: '33%' }}
-          data-test="case-distribution-per-project"
+          className="test-case-distribution-per-project"
         >
           <div
             style={{

--- a/src/packages/@ncigdc/components/ProjectsCount.js
+++ b/src/packages/@ncigdc/components/ProjectsCount.js
@@ -9,7 +9,7 @@ type TProps = {
 };
 
 const ProjectsCount = (props: TProps) =>
-  <span data-test="projects-count">
+  <span className="test-projects-count">
     {props.hits.total > 0
       ? props.hits.total.toLocaleString()
       : <span className="fa fa-spinner fa-spin" />}

--- a/src/packages/@ncigdc/components/QuickSearch/QuickSearch.js
+++ b/src/packages/@ncigdc/components/QuickSearch/QuickSearch.js
@@ -85,7 +85,7 @@ export default compose(
     style,
   }) =>
     <a
-      data-test="quick-search-toggle"
+      className="quick-search-toggle"
       tabIndex={tabIndex}
       onClick={() =>
         !state.isInSearchMode && setState({ isInSearchMode: true })}
@@ -136,7 +136,7 @@ export default compose(
       {state.isInSearchMode &&
         <SearchInput
           autoFocus
-          data-test="quick-search-input"
+          className="quick-search-input"
           placeholder="Quick Search"
           type="text"
           onChange={event => setQuery(event.target.value)}

--- a/src/packages/@ncigdc/components/QuickSearch/QuickSearchResults.js
+++ b/src/packages/@ncigdc/components/QuickSearch/QuickSearchResults.js
@@ -159,7 +159,7 @@ export default ({
 }: TProps) =>
   <ul
     style={{ ...styles.container, ...style.container }}
-    data-test="quick-search-results"
+    className="test-quick-search-results"
   >
     {results.map((item, i) =>
       <li

--- a/src/packages/@ncigdc/components/RelayLoadingContainer.js
+++ b/src/packages/@ncigdc/components/RelayLoadingContainer.js
@@ -8,7 +8,7 @@ import Particle from '@ncigdc/uikit/Loaders/Particle';
 export default compose(
   connect(state => ({ relayLoading: state.relayLoading })),
 )(({ relayLoading }) =>
-  <Overlay show={relayLoading} data-test="loading-container">
+  <Overlay show={relayLoading} className="test-loading-container">
     <Particle />
   </Overlay>,
 );

--- a/src/packages/@ncigdc/components/RemoveFromCartButton.js
+++ b/src/packages/@ncigdc/components/RemoveFromCartButton.js
@@ -36,7 +36,7 @@ const getUnauthorizedFiles = files =>
   files.filter(file => file.access === 'controlled');
 
 const RemoveFromCartButton = ({ style, files, theme, dispatch }) =>
-  <Row data-test="remove-from-cart-button-container">
+  <Row className="test-remove-from-cart-button-container">
     <Dropdown
       dropdownStyle={{
         marginTop: '2px',
@@ -46,7 +46,7 @@ const RemoveFromCartButton = ({ style, files, theme, dispatch }) =>
       dropdownItemClass={false}
       button={
         <Button
-          data-test="remove-from-cart"
+          className="test-remove-from-cart"
           style={{
             backgroundColor: '#A62924',
             marginLeft: '10px',
@@ -63,7 +63,7 @@ const RemoveFromCartButton = ({ style, files, theme, dispatch }) =>
     >
       <Column>
         <Button
-          data-test="remove-all-files"
+          className="test-remove-all-files"
           style={styles.row(theme)}
           onClick={() => dispatch(toggleFilesInCart(files))}
           leftIcon={<XIcon />}
@@ -73,7 +73,7 @@ const RemoveFromCartButton = ({ style, files, theme, dispatch }) =>
           </span>
         </Button>
         <Button
-          data-test="remove-unauthorized-files"
+          className="test-remove-unauthorized-files"
           style={styles.row(theme)}
           onClick={() =>
             dispatch(toggleFilesInCart(getUnauthorizedFiles(files)))}

--- a/src/packages/@ncigdc/components/SampleSize.js
+++ b/src/packages/@ncigdc/components/SampleSize.js
@@ -19,7 +19,7 @@ export default ({
 }) =>
   <span
     {...css({ ...styles.deemphasizedHeading, ...style })}
-    data-test="sample-size"
+    className="test-sample-size"
   >
     <small>( </small> {symbol}=
     {n ? formatter(n) : `--`}

--- a/src/packages/@ncigdc/components/SearchPage.js
+++ b/src/packages/@ncigdc/components/SearchPage.js
@@ -59,7 +59,7 @@ const SearchPage = (
     ...props
   }: TProps = {},
 ) =>
-  <Container data-test={props['data-test'] || 'search-page'}>
+  <Container className={props.className + ' test-search-page'}>
     {showFacets &&
       <FacetsPanel>
         <TabbedLinks

--- a/src/packages/@ncigdc/components/SpinnerCentered.js
+++ b/src/packages/@ncigdc/components/SpinnerCentered.js
@@ -10,7 +10,7 @@ type TProps = {
 
 const SpinnerCentered = ({ style, ...props }: TProps) =>
   <Column
-    data-test="spinner"
+    className="test-spinner"
     style={{
       alignItems: 'center',
       justifyContent: 'center',

--- a/src/packages/@ncigdc/components/SummaryCard.js
+++ b/src/packages/@ncigdc/components/SummaryCard.js
@@ -26,7 +26,7 @@ const SummaryCard = compose(
     pieDiameter: Math.max(Math.min(size.width, size.height - 100), 120),
   })),
 )(({ data, title, tableTitle, style = {}, footer, path, headings, ...props }) =>
-  <Card style={style} data-test={props['data-test'] || 'summary-card'}>
+  <Card style={style} className={props.className + ' test-summary-card'}>
     <Column>
       <Header>
         <span style={{ flexGrow: 1, fontSize: '1.7rem' }}>

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -91,7 +91,7 @@ const SurvivalPlotWrapper = ({
       className={uniqueClass}
     >
       {!survivalPlotloading &&
-        <Column data-test="survival-plot-meta">
+        <Column className="test-survival-plot-meta">
           <VisualizationHeader
             title={TITLE}
             buttons={[
@@ -191,8 +191,7 @@ const SurvivalPlotWrapper = ({
           </div>
         </Column>}
       <div
-        data-test="survival-plot-container"
-        className={CLASS_NAME}
+        className={CLASS_NAME + ' test-survival-plot-container'}
         ref={setSurvivalContainer}
         style={{
           overflow: 'hidden',

--- a/src/packages/@ncigdc/components/TabPieCharts/RepoCasesPies.js
+++ b/src/packages/@ncigdc/components/TabPieCharts/RepoCasesPies.js
@@ -32,7 +32,7 @@ const RepoCasesPiesComponent = ({ aggregations, query, push }: TProps) => {
   const currentFieldNames = currentFilters.map(f => f.content.field);
   return (
     <RowCenter>
-      <ColumnCenter data-test="primary-site">
+      <ColumnCenter className="test-primary-site">
         <PieTitle>Primary Site</PieTitle>
         <SelfFilteringPie
           buckets={_.get(aggregations, 'primary_site.buckets')}
@@ -47,7 +47,7 @@ const RepoCasesPiesComponent = ({ aggregations, query, push }: TProps) => {
           width={125}
         />
       </ColumnCenter>
-      <ColumnCenter data-test="project">
+      <ColumnCenter className="test-project">
         <PieTitle>Project</PieTitle>
         <SelfFilteringPie
           buckets={_.get(aggregations, 'project__project_id.buckets')}
@@ -62,7 +62,7 @@ const RepoCasesPiesComponent = ({ aggregations, query, push }: TProps) => {
           width={125}
         />
       </ColumnCenter>
-      <ColumnCenter data-test="disease-type">
+      <ColumnCenter className="test-disease-type">
         <PieTitle>Disease Type</PieTitle>
         <SelfFilteringPie
           buckets={_.get(aggregations, 'disease_type.buckets')}
@@ -77,7 +77,7 @@ const RepoCasesPiesComponent = ({ aggregations, query, push }: TProps) => {
           width={125}
         />
       </ColumnCenter>
-      <ColumnCenter data-test="gender">
+      <ColumnCenter className="test-gender">
         <PieTitle>Gender</PieTitle>
         <SelfFilteringPie
           buckets={_.get(aggregations, 'demographic__gender.buckets')}
@@ -92,7 +92,7 @@ const RepoCasesPiesComponent = ({ aggregations, query, push }: TProps) => {
           width={125}
         />
       </ColumnCenter>
-      <ColumnCenter data-test="vital-status">
+      <ColumnCenter className="test-vital-status">
         <PieTitle>Vital Status</PieTitle>
         <SelfFilteringPie
           buckets={_.get(aggregations, 'diagnoses__vital_status.buckets')}

--- a/src/packages/@ncigdc/components/TabPieCharts/RepoFilesPies.js
+++ b/src/packages/@ncigdc/components/TabPieCharts/RepoFilesPies.js
@@ -52,12 +52,12 @@ const RepoFilesPiesComponent = ({
   const currentFieldNames = currentFilters.map(f => f.content.field);
   const pieColMinWidth = width / 5;
   return (
-    <div data-test="repo-files-pies">
+    <div className="test-repo-files-pies">
       <BottomBorderedBox>
         <WrappedRow style={{ maxWidth: `${width}px`, width: '100%' }}>
           <ColumnCenter
             style={{ minWidth: `${pieColMinWidth}px` }}
-            data-test="primary-site-pie"
+            className="test-primary-site-pie"
           >
             <PieTitle>Primary Site</PieTitle>
             <SelfFilteringPie
@@ -75,7 +75,7 @@ const RepoFilesPiesComponent = ({
           </ColumnCenter>
           <ColumnCenter
             style={{ minWidth: `${pieColMinWidth}px` }}
-            data-test="project-pie"
+            className="test-project-pie"
           >
             <PieTitle>Project</PieTitle>
             <SelfFilteringPie
@@ -96,7 +96,7 @@ const RepoFilesPiesComponent = ({
           </ColumnCenter>
           <ColumnCenter
             style={{ minWidth: `${pieColMinWidth}px` }}
-            data-test="data-category-pie"
+            className="test-data-category-pie"
           >
             <PieTitle>Data Category</PieTitle>
             <SelfFilteringPie
@@ -114,7 +114,7 @@ const RepoFilesPiesComponent = ({
           </ColumnCenter>
           <ColumnCenter
             style={{ minWidth: `${pieColMinWidth}px` }}
-            data-test="data-type"
+            className="test-data-type"
           >
             <PieTitle>Data Type</PieTitle>
             <SelfFilteringPie
@@ -132,7 +132,7 @@ const RepoFilesPiesComponent = ({
           </ColumnCenter>
           <ColumnCenter
             style={{ minWidth: `${pieColMinWidth}px` }}
-            data-test="data-format"
+            className="test-data-format"
           >
             <PieTitle>Data Format</PieTitle>
             <SelfFilteringPie
@@ -152,7 +152,7 @@ const RepoFilesPiesComponent = ({
             <ColumnCenter
               style={{ minWidth: `${pieColMinWidth}px` }}
               key="files.experimental_strategy"
-              data-test="experimental-strategy"
+              className="test-experimental-strategy"
             >
               <PieTitle>Experimental Strategy</PieTitle>
               <SelfFilteringPie
@@ -171,7 +171,7 @@ const RepoFilesPiesComponent = ({
             <ColumnCenter
               key="files.access"
               style={{ minWidth: `${pieColMinWidth}px` }}
-              data-test="access-level"
+              className="test-access-level"
             >
               <PieTitle>Access Level</PieTitle>
               <SelfFilteringPie

--- a/src/packages/@ncigdc/components/TabbedLinks.js
+++ b/src/packages/@ncigdc/components/TabbedLinks.js
@@ -27,7 +27,7 @@ const TabbedLinks: TTabbedLinks = (
 
       return (
         <Tabs
-          data-test="tabbed-links"
+          className="test-tabbed-links"
           style={style}
           tabToolbar={tabToolbar}
           tabStyle={{ padding: 0 }}
@@ -44,7 +44,7 @@ const TabbedLinks: TTabbedLinks = (
                     key={x.id}
                     query={{ [queryParam]: x.id }}
                     merge
-                    data-test={x.id}
+                    className={x.id}
                   >
                     {x.text}
                   </Link>,

--- a/src/packages/@ncigdc/components/TableActions.js
+++ b/src/packages/@ncigdc/components/TableActions.js
@@ -49,7 +49,7 @@ const TableActions = (
 ) =>
   <LocationSubscriber>
     {({ query }: {| query: TRawQuery |}) =>
-      <Row style={style} spacing="0.2rem" data-test="table-actions">
+      <Row style={style} spacing="0.2rem" className="test-table-actions">
         {entityType &&
           <ArrangeColumnsButton
             entityType={entityType}

--- a/src/packages/@ncigdc/components/UserDropdown.js
+++ b/src/packages/@ncigdc/components/UserDropdown.js
@@ -41,7 +41,7 @@ const UserDropdown = connect(state => ({
   token: state.auth.token,
   user: state.auth.user,
 }))(({ user, dispatch }) =>
-  <Row style={{ alignSelf: 'stretch' }} data-test="user-dropdown">
+  <Row style={{ alignSelf: 'stretch' }} className="test-user-dropdown">
     <Dropdown
       button={
         <NavLink>

--- a/src/packages/@ncigdc/components/VisualizationHeader.js
+++ b/src/packages/@ncigdc/components/VisualizationHeader.js
@@ -36,7 +36,7 @@ const VisualizationHeader = ({
   return (
     <Row
       style={{ ...style, margin: '0 1.2rem' }}
-      data-test="visualization-header"
+      className="test-visualization-header"
     >
       <Title style={{ marginLeft: buttonsWidth + SPACING }}>
         {title}

--- a/src/packages/@ncigdc/containers/AnnotationAggregations.js
+++ b/src/packages/@ncigdc/containers/AnnotationAggregations.js
@@ -94,7 +94,7 @@ const annotationFacets = [
 export const AnnotationAggregationsComponent = compose(
   withState('annotationIdCollapsed', 'setAnnotationIdCollapsed', false),
 )((props: TProps) =>
-  <div data-test="annotation-aggregations">
+  <div className="test-annotation-aggregations">
     <FacetHeader
       title="Annotation ID"
       field="annotations.annotation_id"

--- a/src/packages/@ncigdc/containers/AnnotationPage.js
+++ b/src/packages/@ncigdc/containers/AnnotationPage.js
@@ -30,7 +30,7 @@ export const AnnotationPageComponent = ({ node }: TProps) =>
   <FullWidthLayout
     title={node.entity_id}
     entityType="AN"
-    data-test="annotation-page"
+    className="test-annotation-page"
   >
     <Annotation node={node} />
   </FullWidthLayout>;

--- a/src/packages/@ncigdc/containers/AnnotationsPage.js
+++ b/src/packages/@ncigdc/containers/AnnotationsPage.js
@@ -24,7 +24,7 @@ export type TProps = {
 
 export const AnnotationsPageComponent = (props: TProps) =>
   <SearchPage
-    data-test="annotations-page"
+    className="test-annotations-page"
     facetTabs={[
       {
         id: 'cases',

--- a/src/packages/@ncigdc/containers/AnnotationsTable.js
+++ b/src/packages/@ncigdc/containers/AnnotationsTable.js
@@ -32,7 +32,7 @@ export const SearchTable = compose(
     const prefix = 'annotations';
 
     return (
-      <div data-test="annotations-table">
+      <div className="test-annotations-table">
         {tableHeader &&
           <h3
             className="panel-title"

--- a/src/packages/@ncigdc/containers/CancerDistributionChart.js
+++ b/src/packages/@ncigdc/containers/CancerDistributionChart.js
@@ -169,7 +169,7 @@ const CancerDistributionChartComponent = compose(
       }));
 
     return (
-      <div style={style} data-test="cancer-distribution-chart">
+      <div style={style} className="test-cancer-distribution-chart">
         {chartData.length >= 5 &&
           <Loader loading={!cases.filtered} height={CHART_HEIGHT}>
             <Column style={{ padding: '0 0 0 2rem' }}>

--- a/src/packages/@ncigdc/containers/CancerDistributionTable.js
+++ b/src/packages/@ncigdc/containers/CancerDistributionTable.js
@@ -236,7 +236,7 @@ const CancerDistributionTableComponent = compose(
     return (
       <Loader loading={!cases.filtered} height="387px">
         <LocalPaginationTable
-          data-test="cancer-distribution-table"
+          className="test-cancer-distribution-table"
           style={{ width: '100%', minWidth: 450 }}
           data={cancerDistData}
           prefix={paginationPrefix}

--- a/src/packages/@ncigdc/containers/CartPage.js
+++ b/src/packages/@ncigdc/containers/CartPage.js
@@ -76,7 +76,7 @@ const CartPage: TCartPage = ({ viewer, files, user, theme } = {}) => {
   const fileSize = viewer.summary.aggregations.fs.value;
 
   return (
-    <Column style={styles.container} data-test="cart-page">
+    <Column style={styles.container} className="test-cart-page">
       {!files.length && <h1>Your cart is empty.</h1>}
       {!!files.length &&
         !!viewer.repository.files.hits &&

--- a/src/packages/@ncigdc/containers/CaseAggregations.js
+++ b/src/packages/@ncigdc/containers/CaseAggregations.js
@@ -177,7 +177,7 @@ const styles = {
 };
 
 export const CaseAggregationsComponent = (props: TProps) =>
-  <div data-test="case-aggregations">
+  <div className="test-case-aggregations">
     <div
       className="text-right"
       style={{

--- a/src/packages/@ncigdc/containers/CasePage.js
+++ b/src/packages/@ncigdc/containers/CasePage.js
@@ -63,7 +63,7 @@ export type TProps = {
 
 export const CasePageComponent = ({ node, viewer }: TProps) =>
   <FullWidthLayout
-    data-test="case-page"
+    className="test-case-page"
     title={`${node.project.project_id} / ${node.submitter_id}`}
     entityType="CA"
   >

--- a/src/packages/@ncigdc/containers/CasesTable.js
+++ b/src/packages/@ncigdc/containers/CasesTable.js
@@ -20,7 +20,7 @@ export const SearchTable = compose(
     .filter(x => tableColumns.includes(x.id));
 
   return (
-    <div data-test="cases-table">
+    <div className="test-cases-table">
       <Row
         style={{
           backgroundColor: 'white',

--- a/src/packages/@ncigdc/containers/ConsequencesTable.js
+++ b/src/packages/@ncigdc/containers/ConsequencesTable.js
@@ -133,7 +133,7 @@ const ConsequencesTableComponent = compose(
     }: TProps = {},
   ) =>
     <LocalPaginationTable
-      data-test="consequences-table"
+      className="test-consequences-table"
       style={{ width: '100%', minWidth: 450 }}
       data={dataRows}
       prefix={paginationPrefix}

--- a/src/packages/@ncigdc/containers/FileAggregations.js
+++ b/src/packages/@ncigdc/containers/FileAggregations.js
@@ -100,7 +100,7 @@ export type TProps = {
 };
 
 export const FileAggregationsComponent = (props: TProps) =>
-  <div data-test="file-aggregations">
+  <div className="test-file-aggregations">
     <div
       className="text-right"
       style={{

--- a/src/packages/@ncigdc/containers/FilePage.js
+++ b/src/packages/@ncigdc/containers/FilePage.js
@@ -27,7 +27,7 @@ export const FilePageComponent = (props: TProps) =>
   <FullWidthLayout
     title={props.node.file_name}
     entityType="FL"
-    data-test="file-page"
+    className="test-file-page"
   >
     <File node={props.node} />
   </FullWidthLayout>;

--- a/src/packages/@ncigdc/containers/FilesTable.js
+++ b/src/packages/@ncigdc/containers/FilesTable.js
@@ -51,7 +51,7 @@ export const SearchTable = compose(
     const prefix = 'files';
 
     return (
-      <div data-test="files-table">
+      <div className="test-files-table">
         {tableHeader &&
           <h3
             className="panel-title"

--- a/src/packages/@ncigdc/containers/GeneSymbol.js
+++ b/src/packages/@ncigdc/containers/GeneSymbol.js
@@ -35,13 +35,13 @@ const GeneSymbolComponent = compose(
 )(
   ({ explore, geneId }) =>
     explore.genes.hits
-      ? <span data-test="gene-symbol">
+      ? <span className="test-gene-symbol">
           {
             (head(explore.genes.hits.edges) || { node: { symbol: geneId } })
               .node.symbol
           }
         </span>
-      : <span data-test="gene-symbol" style={{ width: '45px' }}>&nbsp;</span>,
+      : <span className="test-gene-symbol" style={{ width: '45px' }} />,
 );
 
 export const GeneSymbolQuery = {

--- a/src/packages/@ncigdc/containers/ProjectAggregations.js
+++ b/src/packages/@ncigdc/containers/ProjectAggregations.js
@@ -72,7 +72,7 @@ const projectFacets = [
 export const ProjectAggregationsComponent = compose(
   withState('projectIdCollapsed', 'setProjectIdCollapsed', false),
 )((props: TProps) =>
-  <div data-test="project-aggregations">
+  <div className="test-project-aggregations">
     <FacetHeader
       title="Project"
       field="projects.project_id"

--- a/src/packages/@ncigdc/containers/ProjectPage.js
+++ b/src/packages/@ncigdc/containers/ProjectPage.js
@@ -67,7 +67,7 @@ export const ProjectPageComponent = ({ node, viewer }: TProps) =>
   <FullWidthLayout
     title={node.project_id}
     entityType="PR"
-    data-test="project-page"
+    className="test-project-page"
   >
     <LocationSubscriber>
       {(ctx: {| pathname: string, query: TRawQuery |}) =>

--- a/src/packages/@ncigdc/containers/ProjectsPage.js
+++ b/src/packages/@ncigdc/containers/ProjectsPage.js
@@ -28,7 +28,7 @@ export type TProps = {
 
 export const ProjectsPageComponent = (props: TProps) =>
   <SearchPage
-    data-test="projects-page"
+    className="test-projects-page"
     filtersLinkProps={{
       linkPathname: '/repository',
       linkText: 'Open Query in Repository',

--- a/src/packages/@ncigdc/containers/ProjectsTable.js
+++ b/src/packages/@ncigdc/containers/ProjectsTable.js
@@ -27,7 +27,7 @@ export const SearchTable = compose(
       .filter(x => tableColumns.includes(x.id));
 
     return (
-      <div data-test="projects-table">
+      <div className="test-projects-table">
         <Row
           style={{
             backgroundColor: 'white',

--- a/src/packages/@ncigdc/containers/RepositoryPage.js
+++ b/src/packages/@ncigdc/containers/RepositoryPage.js
@@ -91,7 +91,7 @@ export const RepositoryPageComponent = (props: TProps) => {
   const fileSize = props.viewer.cart_summary.aggregations.fs.value;
 
   return (
-    <div data-test="repository-page">
+    <div className="test-repository-page">
       <SearchPage
         filtersLinkProps={{
           hideLinkOnEmpty: false,

--- a/src/packages/@ncigdc/containers/SmartSearchPage.js
+++ b/src/packages/@ncigdc/containers/SmartSearchPage.js
@@ -114,7 +114,7 @@ class SmartSearchComponent extends React.Component {
 
   render(): void {
     return (
-      <div style={{ padding: '3rem 8rem' }} data-test="smart-search">
+      <div style={{ padding: '3rem 8rem' }} className="test-smart-search">
         <div
           ref={c => {
             this.container = c;
@@ -127,7 +127,7 @@ class SmartSearchComponent extends React.Component {
           defaultIndex={0}
           tabToolbar={
             <Row spacing="2rem" style={{ alignItems: 'center' }}>
-              <AnnotationsLink data-test="annotations-link">
+              <AnnotationsLink className="test-annotations-link">
                 <Button leftIcon={<i className="fa fa-edit" />}>
                   Browse Annotations
                 </Button>

--- a/src/packages/@ncigdc/containers/explore/CaseAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/CaseAggregations.js
@@ -185,7 +185,7 @@ const styles = {
 };
 
 export const CaseAggregationsComponent = (props: TProps) =>
-  <div data-test="case-aggregations">
+  <div className="test-case-aggregations">
     <div
       className="text-right"
       style={{

--- a/src/packages/@ncigdc/containers/explore/ExplorePage.js
+++ b/src/packages/@ncigdc/containers/explore/ExplorePage.js
@@ -103,7 +103,7 @@ const enhance = compose(
 );
 export const ExplorePageComponent = (props: TProps) =>
   <SearchPage
-    data-test="explore-page"
+    className="test-explore-page"
     geneSymbolFragment={get(props, 'viewer.geneSymbolFragment', {})}
     facetTabs={[
       {

--- a/src/packages/@ncigdc/containers/explore/GeneAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/GeneAggregations.js
@@ -64,7 +64,7 @@ export const GeneAggregationsComponent = compose(
   connect(),
   withTheme,
 )((props: TProps) =>
-  <div data-test="gene-aggregations">
+  <div className="test-gene-aggregations">
     <FacetHeader
       title="Gene"
       field="genes.symbol"

--- a/src/packages/@ncigdc/containers/explore/SSMAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/SSMAggregations.js
@@ -111,7 +111,7 @@ export const SSMAggregationsComponent = compose(
   withState('cosmicIdCollapsed', 'setCosmicIdCollapsed', false),
   withState('dbSNPCollapsed', 'setDbSNPCollapsed', false),
 )((props: TProps) =>
-  <div data-test="ssm-aggregations">
+  <div className="test-ssm-aggregations">
     <FacetHeader
       title="Mutation"
       field="ssms.ssm_id"

--- a/src/packages/@ncigdc/containers/legacy/FilesPage.js
+++ b/src/packages/@ncigdc/containers/legacy/FilesPage.js
@@ -33,7 +33,7 @@ export const FilesPageComponent = (props: TProps) => {
 
   return (
     <SearchPage
-      data-test="legacy-files-page"
+      className="test-legacy-files-page"
       facetTabs={[
         {
           text: 'cases',

--- a/src/packages/@ncigdc/theme/icons/BubbleIcon.js
+++ b/src/packages/@ncigdc/theme/icons/BubbleIcon.js
@@ -18,10 +18,7 @@ type TProps = {
 };
 
 export default ({ text, toolTipText, backgroundColor, ...props }: TProps) =>
-  <Tooltip
-    Component={toolTipText}
-    data-test={props['data-test'] || 'bubble-icon'}
-  >
+  <Tooltip Component={toolTipText} className={props.className + ' bubble-icon'}>
     <span
       style={{
         ...bubbleStyle,

--- a/src/packages/@ncigdc/uikit/Button.js
+++ b/src/packages/@ncigdc/uikit/Button.js
@@ -57,7 +57,7 @@ const Button = (
     <StyledButton
       disabled={disabled}
       {...validAttributes(props)}
-      data-test={props['data-test']}
+      className={props.className + ' button'}
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {leftIcon}

--- a/src/packages/@ncigdc/uikit/Dropdown.js
+++ b/src/packages/@ncigdc/uikit/Dropdown.js
@@ -19,11 +19,11 @@ const Dropdown = ({
   button = null,
   isDisabled = false,
   autoclose = true,
-  ...props
+  className,
 }) =>
   <span
     style={{ position: 'relative', ...style }}
-    data-test={props['data-test']}
+    className={className + ' dropdown'}
   >
     <span
       onMouseDown={mouseDownHandler}

--- a/src/packages/@ncigdc/uikit/Links/ExternalLink.js
+++ b/src/packages/@ncigdc/uikit/Links/ExternalLink.js
@@ -16,7 +16,7 @@ export default function ExternalLink({
       rel="noopener noreferrer"
       style={style}
       title={title}
-      data-test={props['data-test'] || 'external-link'}
+      className={props.className + ' test-external-link'}
     >
       {hasExternalIcon &&
         <ExternalLinkIcon style={{ marginRight: '0.5rem' }} />}

--- a/src/packages/@ncigdc/uikit/Modal.js
+++ b/src/packages/@ncigdc/uikit/Modal.js
@@ -35,7 +35,7 @@ const Modal = ({ isOpen, onRequestClose, style, children }) =>
     isOpen={isOpen}
     onRequestClose={onRequestClose || (() => {})}
     contentLabel="Modal"
-    data-test="modal"
+    className="test-modal"
   >
     {Children.map(children, child => cloneElement(child, { ...child.props }))}
   </ReactModal>;

--- a/src/packages/@ncigdc/uikit/Notification.js
+++ b/src/packages/@ncigdc/uikit/Notification.js
@@ -76,7 +76,7 @@ const Notification = ({ style, visible, action, close, children }) =>
       ...(visible ? styles.active : styles.inactive),
       ...style,
     }}
-    data-test="notification"
+    className="test-notification"
   >
     <div style={{ ...styles.toast, ...(styles[action] || styles.add) }}>
       <CloseIcon style={styles.closeIcon} onClick={close} />

--- a/src/packages/@ncigdc/uikit/SparkMeter.js
+++ b/src/packages/@ncigdc/uikit/SparkMeter.js
@@ -11,7 +11,7 @@ export default ({ value, width = 30, max = 30, style, ...props }) =>
       pointerEvents: 'none',
       ...style,
     }}
-    data-test="spark-meter"
+    className="test-spark-meter"
     {...props}
   >
     <div

--- a/src/packages/@ncigdc/uikit/Tabs.js
+++ b/src/packages/@ncigdc/uikit/Tabs.js
@@ -90,11 +90,11 @@ const Tabs = ({
   ...props
 }) =>
   side
-    ? <Row style={style} flex="1" {...props} data-test="tabs">
+    ? <Row style={style} flex="1" {...props} className="test-tabs">
         <Column>
           {Children.map(tabs, (child, i) =>
             <Tab
-              data-test="tab"
+              className="test-tab"
               onClick={() => (onTabClick ? onTabClick(i) : () => {})}
               active={i === activeIndex}
               sibling={i}
@@ -111,11 +111,11 @@ const Tabs = ({
           {children}
         </Column>
       </Row>
-    : <Column style={style} data-test="tabs" {...props}>
+    : <Column style={style} className="test-tabs" {...props}>
         <Row style={{ alignItems: 'center' }}>
           {Children.map(tabs, (child, i) =>
             <Tab
-              data-test="tab"
+              className="test-tab"
               onClick={() => (onTabClick ? onTabClick(i) : () => {})}
               active={i === activeIndex}
               sibling={i}


### PR DESCRIPTION
As discussed in the developer channel, digging selectors out from the html is challenging due to excessive noise from inlined styles and numerous wrapper DOM elements. 

Challenge - find the selector:

![image](https://user-images.githubusercontent.com/743976/28370839-54ab0dfc-6c69-11e7-98c6-7a4c4e80636b.png)

Now repeat the process to find selectors for the parents of the element you wish to target to ensure that you won't get the element with the same class/attr in a different section.

Chrome's "Copy Selector" may give a better starting point, even if it shouldn't be directly used for targeting an element due to brittleness.  