### PR TITLE
:bug: PRTL-1481 ArrangeColumns restores default in itself

### DIFF
--- a/src/packages/@ncigdc/components/ArrangeColumns.js
+++ b/src/packages/@ncigdc/components/ArrangeColumns.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import { connect } from 'react-redux';
-import { compose, withState, pure } from 'recompose';
+import { compose, withState, pure, withPropsOnChange } from 'recompose';
 import ArrangeIcon from 'react-icons/lib/fa/bars';
 
 import { Row } from '@ncigdc/uikit/Flex';
@@ -28,6 +28,20 @@ const ArrangeColumns = compose(
       .slice()
       .sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id)),
   })),
+  withPropsOnChange(
+    ['tableColumns'],
+    ({ tableColumns, entityType, setState }) => {
+      setState({
+        columns: tableModels[entityType]
+          .slice()
+          .sort(
+            (a, b) =>
+              tableColumns.order.indexOf(a.id) -
+              tableColumns.order.indexOf(b.id),
+          ),
+      });
+    },
+  ),
   pure,
 )(({ dispatch, tableColumns, setState, state, searchTerm, entityType }) => {
   const filteredColumns = state.columns.filter(


### PR DESCRIPTION
'Restore Default' button in ArrangeColumns restored columns in the table, but did not in the dropdown itself. This PR fixes that but there's still an issue with the last item not being able to be dragged past the hidden items if the rest of the list is the same. Thoughts @alex-wilmer?

(changes outside of src/packages/@ncigdc/components/ArrangeColumns.js are just adding types or a setDisplayName)