### PR TITLE
🐛 always mount notification

### DIFF
--- a/src/packages/@ncigdc/components/NotificationContainer.js
+++ b/src/packages/@ncigdc/components/NotificationContainer.js
@@ -2,20 +2,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Notification from '@ncigdc/uikit/Notification';
-import { Row } from '@ncigdc/uikit/Flex';
 
-const NotificationContainer = ({ notification }) =>
-  <Row className="test-notification-wrapper">
-    {notification &&
-      notification.component &&
-      <Notification
-        id={notification.id}
-        action={notification.action}
-        {...notification}
-      >
-        {notification.component}
-      </Notification>}
-  </Row>;
+const NotificationContainer = ({ notification }) => {
+  return (
+    <Notification {...notification} className="test-notification-wrapper">
+      {notification && notification.component}
+    </Notification>
+  );
+};
 
 export default connect(state => ({ notification: state.notification }))(
   NotificationContainer,

--- a/src/packages/@ncigdc/uikit/Notification.js
+++ b/src/packages/@ncigdc/uikit/Notification.js
@@ -12,17 +12,20 @@ import { center, zDepth1 } from '@ncigdc/theme/mixins';
 /*----------------------------------------------------------------------------*/
 
 const styles = {
-  container: {
+  wrapper: {
     position: 'fixed',
     top: 0,
     width: '100vw',
     zIndex: 100,
-    margin: '1rem 0',
-    transition: 'transform 0.25s ease',
     pointerEvents: 'none',
     textAlign: 'center',
     wordBreak: 'break-word',
+    overflow: 'hidden',
     ...center,
+  },
+  container: {
+    margin: '1rem 0',
+    transition: 'transform 0.25s ease',
   },
   inactive: {
     transform: 'translateY(-140%)',
@@ -69,18 +72,20 @@ const styles = {
   },
 };
 
-const Notification = ({ style, visible, action, close, children }) =>
-  <div
-    style={{
-      ...styles.container,
-      ...(visible ? styles.active : styles.inactive),
-      ...style,
-    }}
-    className="test-notification"
-  >
-    <div style={{ ...styles.toast, ...(styles[action] || styles.add) }}>
-      <CloseIcon style={styles.closeIcon} onClick={close} />
-      {children}
+const Notification = ({ style, visible, action, close, children, className }) =>
+  <div style={styles.wrapper} className={className}>
+    <div
+      style={{
+        ...styles.container,
+        ...(visible ? styles.active : styles.inactive),
+        ...style,
+      }}
+      className="test-notification"
+    >
+      <div style={{ ...styles.toast, ...(styles[action] || styles.add) }}>
+        <CloseIcon style={styles.closeIcon} onClick={close} />
+        {children}
+      </div>
     </div>
   </div>;
 


### PR DESCRIPTION
My previous pr to add a condition to only mount notification when `notification.component` exists broke the first notification. The notification doesn't show until the second call to `shouldUpdate`. 
Added overflow hidden so the notification isn't visible when it's hidden.