### PR TITLE
✨ always create new set in save set modal

### DIFF
--- a/src/packages/@ncigdc/components/Modals/SaveSetModal.js
+++ b/src/packages/@ncigdc/components/Modals/SaveSetModal.js
@@ -35,6 +35,7 @@ const SaveSetModal = ({
       title={title}
       extraButtons={
         <CreateSetButton
+          forceCreate
           disabled={!input}
           filters={filters}
           onComplete={setId => {

--- a/src/packages/@ncigdc/modern_components/setButtons/SetButtonBase.js
+++ b/src/packages/@ncigdc/modern_components/setButtons/SetButtonBase.js
@@ -28,6 +28,7 @@ const SetButtonBase = ({
   field,
   input,
   mutation,
+  forceCreate,
 }) => {
   return (
     <span>
@@ -48,8 +49,9 @@ const SetButtonBase = ({
             : false;
 
           if (
-            (setOnlyInCurrentFilters && !input.set_id) ||
-            input.set_id === get(content, 'value[0]', '')
+            !forceCreate &&
+            ((setOnlyInCurrentFilters && !input.set_id) ||
+              input.set_id === get(content, 'value[0]', ''))
           ) {
             const setId = get(content, 'value[0]', '').substring(
               'set_id:'.length,


### PR DESCRIPTION
prevents `input set` being renamed if it's the only filter