### PR TITLE
🐛 overflow hidden to prevent tooltip causing scrollbars

### DIFF
--- a/src/packages/@ncigdc/components/PortalContainer.js
+++ b/src/packages/@ncigdc/components/PortalContainer.js
@@ -96,7 +96,14 @@ const PortalContainer = ({
 }: {
   notifications: Array<{ dismissed: string }>,
 }) =>
-  <div style={{ position: 'relative', minHeight: '100vh', minWidth: 1024 }}>
+  <div
+    style={{
+      position: 'relative',
+      minHeight: '100vh',
+      minWidth: 1024,
+      overflowX: 'hidden',
+    }}
+  >
     <SkipLink href="#skip">Skip to Main Content</SkipLink>
     <ProgressContainer />
     <Header />


### PR DESCRIPTION
removes these scrollbars that appear when the mouse is near the edge.
![image](https://user-images.githubusercontent.com/3953093/30133248-339e7318-9321-11e7-8e0e-3c182e3d2837.png)
