### PR TITLE
:bug:PRTL-1831: UploadAndSaveModal, fix Submit disable

### DIFF
--- a/src/packages/@ncigdc/components/Modals/UploadSet/CreateSetButton.js
+++ b/src/packages/@ncigdc/components/Modals/UploadSet/CreateSetButton.js
@@ -26,12 +26,13 @@ export default enhance(
     CreateButton,
     idMap,
     idKey,
+    disabled = false,
     ...props
   }: TProps) => {
     return (
       <CreateButton
         {...props}
-        disabled={!hits.length}
+        disabled={disabled || !hits.length}
         onComplete={setId => {
           onClose();
           push({


### PR DESCRIPTION
- Submit stays disabled when has name but no validated hits

The other issue in the ticket was a varnish cache issue, fixed with varnish restart.