### PR TITLE
:bug: PRTL-1856 fix age diagnosis display years

### DIFF
--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
@@ -55,7 +55,7 @@ const transformAgeAtDiagnosis = (buckets, compareBuckets) => {
   const buildDisplayKeyAndFilters = (acc, { doc_count, key }) => {
     const displayRange = `${getLowerAgeYears(key)}${acc.nextAge === 0
       ? '+'
-      : ' - ' + getUpperAgeYears(acc.nextAge)}`;
+      : ' - ' + getUpperAgeYears(acc.nextAge - 1)}`;
     return {
       nextAge: key,
       data: [
@@ -76,7 +76,7 @@ const transformAgeAtDiagnosis = (buckets, compareBuckets) => {
                 op: '<=',
                 content: {
                   field: 'cases.diagnoses.age_at_diagnosis',
-                  value: [acc.nextAge],
+                  value: [acc.nextAge - 1],
                 },
               },
             ]),

--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
@@ -84,28 +84,11 @@ const transformAgeAtDiagnosis = (buckets, compareBuckets, total) => {
     };
   };
   return {
-    buckets: [
-      ...unionAndParsed
-        .sort((a, b) => b.key - a.key) // iterate descending to populate nextAge
-        .reduce(buildDisplayKeyAndFilters, { nextAge: 0, data: [] })
-        .data.slice(0)
-        .reverse(), // but display ascending
-      {
-        key: '_missing',
-        doc_count:
-          total -
-          unionAndParsed.reduce((acc, { doc_count }) => acc + doc_count, 0),
-        filters: [
-          {
-            op: 'is',
-            content: {
-              field: 'cases.diagnoses.age_at_diagnosis',
-              value: ['_missing'],
-            },
-          },
-        ],
-      },
-    ],
+    buckets: unionAndParsed
+      .sort((a, b) => b.key - a.key) // iterate descending to populate nextAge
+      .reduce(buildDisplayKeyAndFilters, { nextAge: 0, data: [] })
+      .data.slice(0)
+      .reverse(), // but display ascending
   };
 };
 

--- a/src/packages/@ncigdc/modern_components/CohortComparison/FacetTable.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/FacetTable.js
@@ -63,10 +63,10 @@ export default compose(
       return {
         term: k,
         casesS1,
-        percentS1: (casesS1 / result1.hits.total * 100).toFixed(0),
+        percentS1: (casesS1 / result1.hits.total * 100).toFixed(2),
         filters1: bucket1.filters,
         casesS2,
-        percentS2: (casesS2 / result2.hits.total * 100).toFixed(0),
+        percentS2: (casesS2 / result2.hits.total * 100).toFixed(2),
         filters2: bucket2.filters,
       };
     });
@@ -202,8 +202,8 @@ export default compose(
                             value: [`set_id:${set1}`],
                           },
                         },
-                        ...(row.filters
-                          ? row.filters
+                        ...(row.filters1
+                          ? row.filters1
                           : [
                               {
                                 op: 'in',
@@ -238,8 +238,8 @@ export default compose(
                             value: [`set_id:${set2}`],
                           },
                         },
-                        ...(row.filters
-                          ? row.filters
+                        ...(row.filters2
+                          ? row.filters2
                           : [
                               {
                                 op: 'in',

--- a/src/packages/@ncigdc/modern_components/CohortComparison/FacetTable.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/FacetTable.js
@@ -43,13 +43,8 @@ export default compose(
     palette,
     heading,
   }) => {
-    const buckets1 = get(data1, `['${field}'].buckets`, []).filter(
-      x => x.key !== '_missing',
-    );
-    const buckets2 = get(data2, `['${field}'].buckets`, []).filter(
-      x => x.key !== '_missing',
-    );
-
+    const buckets1 = get(data1, `['${field}'].buckets`, []);
+    const buckets2 = get(data2, `['${field}'].buckets`, []);
     const tableData = union(
       buckets1.map(b => b.key),
       buckets2.map(b => b.key),
@@ -206,7 +201,7 @@ export default compose(
                           ? row.filters1
                           : [
                               {
-                                op: 'in',
+                                op: row.term === '_missing' ? 'is' : 'in',
                                 content: {
                                   field: `cases.${field}`,
                                   value: [row.term],
@@ -242,7 +237,7 @@ export default compose(
                           ? row.filters2
                           : [
                               {
-                                op: 'in',
+                                op: row.term === '_missing' ? 'is' : 'in',
                                 content: {
                                   field: `cases.${field}`,
                                   value: [row.term],


### PR DESCRIPTION
- show 2 decimal places for percentages
- fix filter link for age of diagnosis

<img width="966" alt="screen shot 2017-11-02 at 4 47 36 pm" src="https://user-images.githubusercontent.com/1314446/32349486-a305b704-bfed-11e7-8627-d7db49270440.png">
instead of
<img width="1026" alt="screen shot 2017-11-02 at 4 48 05 pm" src="https://user-images.githubusercontent.com/1314446/32349490-a4792288-bfed-11e7-8b8d-97b527d2c658.png">
