### PR TITLE
:fire: PRTL-1866 replace react-highlighter with our own

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,11 +1534,6 @@
       "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
       "dev": true
     },
-    "blacklist": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/blacklist/-/blacklist-1.1.4.tgz",
-      "integrity": "sha1-st0J1hd2JbLKppg1o3somV+povI="
-    },
     "bluebird": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
@@ -10111,17 +10106,6 @@
         "object-assign": "4.1.1",
         "prop-types": "15.5.10",
         "react-side-effect": "1.1.3"
-      }
-    },
-    "react-highlighter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-highlighter/-/react-highlighter-0.4.0.tgz",
-      "integrity": "sha1-WTg2dXNI4RmxZ6pHvNUogphBn8M=",
-      "requires": {
-        "blacklist": "1.1.4",
-        "create-react-class": "15.5.3",
-        "escape-string-regexp": "1.0.5",
-        "prop-types": "15.5.10"
       }
     },
     "react-icon-base": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-dom": "16.0.0",
     "react-faux-dom": "3.1.0",
     "react-helmet": "5.1.3",
-    "react-highlighter": "0.4.0",
     "react-icons": "2.2.5",
     "react-loadable": "4.0.2",
     "react-modal": "3.0.0",

--- a/src/packages/@ncigdc/components/FacetSelection.js
+++ b/src/packages/@ncigdc/components/FacetSelection.js
@@ -14,7 +14,7 @@ import {
 } from 'recompose';
 import { fetchApi } from '@ncigdc/utils/ajax';
 import entityShortnameMapping from '@ncigdc/utils/entityShortnameMapping';
-import Highlight from 'react-highlighter';
+import Highlight from '@ncigdc/uikit/Highlight';
 import withSelectableList from '@ncigdc/utils/withSelectableList';
 import withPropsOnChange from '@ncigdc/utils/withPropsOnChange';
 

--- a/src/packages/@ncigdc/components/QuickSearch/QuickSearchResults.js
+++ b/src/packages/@ncigdc/components/QuickSearch/QuickSearchResults.js
@@ -5,6 +5,7 @@ import React from 'react';
 import _ from 'lodash';
 import entityShortnameMapping from '@ncigdc/utils/entityShortnameMapping';
 import type { TSearchHit } from './types';
+import { internalHighlight } from '@ncigdc/uikit/Highlight';
 
 const styles = {
   container: {
@@ -114,25 +115,6 @@ export const findMatchingToken = (item, lq, value = '') => {
   }
 
   return value;
-};
-
-const internalHighlight = (query, foundText) => {
-  const index = (foundText || '')
-    .toLocaleLowerCase()
-    .indexOf(query.toLocaleLowerCase());
-  if (foundText && index !== -1) {
-    const seg1 = foundText.substring(0, index);
-    const foundQuery = foundText.substring(index, index + query.length);
-    const seg2 = foundText.substring(index + query.length);
-    return (
-      <span>
-        {seg1}
-        <b>{foundQuery}</b>
-        {seg2}
-      </span>
-    );
-  }
-  return <span>{foundText}</span>;
 };
 
 const ResultHighlights = ({

--- a/src/packages/@ncigdc/modern_components/BiospecimenCard/BioTreeItem.js
+++ b/src/packages/@ncigdc/modern_components/BiospecimenCard/BioTreeItem.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { css } from 'glamor';
-import Highlight from 'react-highlighter';
+import Highlight from '@ncigdc/uikit/Highlight';
 import { search } from './utils';
 import BioTreeView from './BioTreeView';
 

--- a/src/packages/@ncigdc/uikit/Highlight.js
+++ b/src/packages/@ncigdc/uikit/Highlight.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react';
+
+export const internalHighlight = (query: string, foundText: string) => {
+  const index = (foundText || '')
+    .toLocaleLowerCase()
+    .indexOf(query.toLocaleLowerCase());
+  if (foundText && index !== -1) {
+    const seg1 = foundText.substring(0, index);
+    const foundQuery = foundText.substring(index, index + query.length);
+    const seg2 = foundText.substring(index + query.length);
+    return (
+      <span>
+        {seg1}
+        <b>{foundQuery}</b>
+        {seg2}
+      </span>
+    );
+  }
+  return <span>{foundText}</span>;
+};
+
+const Highlight = ({ search, children, ...props }: Object) => (
+  <span>{internalHighlight(search, children)}</span>
+);
+
+export default Highlight;


### PR DESCRIPTION
react-highlight started causing biospec tree & custom facet search pages to error out, we had our own inside quicksearch. Moved that out into its own component and replaced react-highlight.