### PR TITLE
:bug: PRTL-1888 fix large set id downloads

### DIFF
--- a/src/packages/@ncigdc/components/DownloadButton.js
+++ b/src/packages/@ncigdc/components/DownloadButton.js
@@ -18,7 +18,7 @@ type TDownloadButton = {
   disabled: boolean,
   filename: string,
   dataExportExpands: Array<string>,
-  setActive: () => {},
+  setActive: (active: boolean) => {},
   activeText: string,
   inactiveText: string,
   returnType: string,

--- a/src/packages/@ncigdc/components/analysis/SetOperations/OpsTable.js
+++ b/src/packages/@ncigdc/components/analysis/SetOperations/OpsTable.js
@@ -34,9 +34,7 @@ const ActionsTd = compose(
 
     return (
       <Td style={{ textAlign: 'right' }}>
-        {hide ? (
-          ''
-        ) : (
+        {!hide && (
           <span>
             <Tooltip
               Component={

--- a/src/packages/@ncigdc/routes/ManageSetsRoute/ManageSetsPage.js
+++ b/src/packages/@ncigdc/routes/ManageSetsRoute/ManageSetsPage.js
@@ -28,7 +28,6 @@ import { Tooltip } from '@ncigdc/uikit/Tooltip';
 import { ExclamationTriangleIcon } from '@ncigdc/theme/icons';
 import DatabaseIcon from '@ncigdc/theme/icons/Database';
 import UnstyledButton from '@ncigdc/uikit/UnstyledButton';
-import { SET_DOWNLOAD_FIELDS as downloadFields } from '@ncigdc/utils/constants';
 import DownloadButton from '@ncigdc/components/DownloadButton';
 import { iconButton, iconLink } from '@ncigdc/theme/mixins';
 import {
@@ -260,7 +259,12 @@ const ManageSetsPage = ({
                     {
                       id,
                       type,
-                      filename: `${type}_${filenameSafeLabel}.tsv`,
+                      filename:
+                        flattenedSets.length === 1
+                          ? `${type}_set_${filenameSafeLabel}_${moment().format(
+                              'YYYY-MM-DD:hh:mm:ss',
+                            )}.tsv`
+                          : `${type}_${filenameSafeLabel}.tsv`,
                     },
                   ];
                 }
@@ -468,18 +472,21 @@ const ManageSetsPage = ({
                                 <DownloadButton
                                   className="test-download-set-tsv"
                                   style={iconButton}
-                                  endpoint={`${type}s`}
+                                  endpoint="/tar_sets"
                                   activeText="" //intentionally blank
                                   inactiveText="" //intentionally blank
                                   altMessage={false}
                                   setParentState={() => {}}
                                   active={false}
-                                  filters={filters}
-                                  extraParams={{ format: 'tsv' }}
-                                  fields={downloadFields[type]}
-                                  filename={`${type}_set_${filenameSafeLabel}_${moment().format(
-                                    'YYYY-MM-DD:hh:mm:ss',
-                                  )}`}
+                                  sets={[
+                                    {
+                                      id,
+                                      type,
+                                      filename: `${type}_set_${filenameSafeLabel}_${moment().format(
+                                        'YYYY-MM-DD:hh:mm:ss',
+                                      )}.tsv`,
+                                    },
+                                  ]}
                                 />
                               </Tooltip>
                               {type === 'case' && (

--- a/src/packages/@ncigdc/utils/download/index.js
+++ b/src/packages/@ncigdc/utils/download/index.js
@@ -223,6 +223,8 @@ const arrayToStringFields = ['expand', 'fields', 'facets'];
 const arrayToStringOnFields = (key, value, fields) =>
   _.includes(fields, key) ? [].concat(value).join() : value;
 
+type TDownloadCallbacks = (inProgress: Function, done: Function) => {};
+
 const download = ({
   url,
   params,
@@ -233,7 +235,7 @@ const download = ({
   params: any,
   method: string,
   altMessage?: boolean,
-}) => {
+}): TDownloadCallbacks => {
   const downloadToken = _.uniqueId(`${+new Date()}-`);
   // a cookie value that the server will remove as a download-ready indicator
   const cookieKey = navigator.cookieEnabled


### PR DESCRIPTION
for large sets, sometimes the streamed tsv file cut off without all the ids, but the tar_set endpoint which skips the filter and downloads sets directly always worked. Changed the tar_set endpoint to not tar if only one set in payload https://github.com/NCI-GDC/gdcapi/pull/868

done in manage set page, analysis page pending