### PR TITLE
:bug:PRTL-1920. resets query so result dropdown disappears on blur.

### DIFF
--- a/src/packages/@ncigdc/components/QuickSearch/QuickSearch.js
+++ b/src/packages/@ncigdc/components/QuickSearch/QuickSearch.js
@@ -102,7 +102,10 @@ export default compose(
               currentTarget === triggerElement
             )
           ) {
-            setTimeout(() => setIsInSearchMode(false), 500);
+            setTimeout(() => {
+              setIsInSearchMode(false);
+              reset();
+            }, 500);
           }
         });
       }}


### PR DESCRIPTION
Wondering why I need to still call setIsInSearchMode(false); it looks like reset() should do this automatically?