### PR TITLE
🐛 [PRTL-1933] - Fixes blank page when cancer-gene-census unchecked.

### DIFF
--- a/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.js
+++ b/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.js
@@ -70,7 +70,7 @@ export default compose(
                 filters: makeFilter([
                   {
                     field: 'genes.is_cancer_gene_census',
-                    value: [gene.is_cancer_gene_census],
+                    value: [gene.is_cancer_gene_census ? 'true' : 'false'],
                   },
                 ]),
               }}


### PR DESCRIPTION
Sets census value to string 'true'.