### PR TITLE
2075 custom tsv slide count

### DIFF
--- a/src/packages/@ncigdc/modern_components/ExploreCasesTable/ExploreCasesTable.model.js
+++ b/src/packages/@ncigdc/modern_components/ExploreCasesTable/ExploreCasesTable.model.js
@@ -17,6 +17,7 @@ import ImageViewerLink from '@ncigdc/components/Links/ImageViewerLink';
 import { RepositorySlideCount } from '@ncigdc/modern_components/Counts';
 import { MicroscopeIcon } from '@ncigdc/theme/icons';
 import { DISPLAY_SLIDES } from '@ncigdc/utils/constants';
+import { ForTsvExport } from '@ncigdc/components/DownloadTableToTsvButton';
 
 import {
   createDataCategoryColumns,
@@ -263,7 +264,8 @@ const casesTableModel = [
               { field: 'cases.case_id', value: node.case_id },
             ])}
           >
-            {count =>
+            {count => [
+              <ForTsvExport>{count}</ForTsvExport>,
               count ? (
                 <Tooltip Component="View Slide Image">
                   <ImageViewerLink
@@ -279,7 +281,8 @@ const casesTableModel = [
                 </Tooltip>
               ) : (
                 <Tooltip Component="No slide images to view.">--</Tooltip>
-              )}
+              ),
+            ]}
           </RepositorySlideCount>
         </Td>
       ),

--- a/src/packages/@ncigdc/modern_components/RepoCasesTable/RepoCasesTable.model.js
+++ b/src/packages/@ncigdc/modern_components/RepoCasesTable/RepoCasesTable.model.js
@@ -23,6 +23,7 @@ import { RepositorySlideCount } from '@ncigdc/modern_components/Counts';
 import { MicroscopeIcon } from '@ncigdc/theme/icons';
 import { DISPLAY_SLIDES } from '@ncigdc/utils/constants';
 import { Tooltip } from '@ncigdc/uikit/Tooltip';
+import { ForTsvExport } from '@ncigdc/components/DownloadTableToTsvButton';
 
 const youngestDiagnosis = (
   p: { age_at_diagnosis: number },
@@ -244,7 +245,8 @@ const casesTableModel = [
               { field: 'cases.case_id', value: node.case_id },
             ])}
           >
-            {count =>
+            {count => [
+              <ForTsvExport>{count}</ForTsvExport>,
               count ? (
                 <Tooltip Component="View Slide Image">
                   <ImageViewerLink
@@ -260,7 +262,8 @@ const casesTableModel = [
                 </Tooltip>
               ) : (
                 <Tooltip Component="No slide images to view.">--</Tooltip>
-              )}
+              ),
+            ]}
           </RepositorySlideCount>
         </Td>
       ),


### PR DESCRIPTION
tsv export querySelects the dom nodes and then writes values to tsv, in the DOM the slide count is displayed with ()s but excel displays numbers with () as negative :sweat_drops:, the `ForTsvExport` component tells Tsv exporter what to write instead of DOM value.