### PR TITLE
:lipstick: ImageViewer style tweaks

### DIFF
--- a/src/packages/@ncigdc/modern_components/ImageViewer/ImageViewerTab.js
+++ b/src/packages/@ncigdc/modern_components/ImageViewer/ImageViewerTab.js
@@ -60,10 +60,12 @@ export default compose(
   );
   return (
     <Row>
-      <Column
+      <div
         style={{
           width: '250px',
           padding: '1rem 1rem 1rem 1rem',
+          maxHeight: '550px',
+          overflow: 'auto',
         }}
       >
         {slides.map(({ file_id, submitter_id }) => (
@@ -90,7 +92,7 @@ export default compose(
             </ThumbnailLink>
           </Column>
         ))}
-      </Column>
+      </div>
       <Column style={{ width: '100%' }}>
         <Row>
           <ZoomableImage imageId={selectedOrFirstId} />

--- a/src/packages/@ncigdc/uikit/Tabs.js
+++ b/src/packages/@ncigdc/uikit/Tabs.js
@@ -114,7 +114,7 @@ const Tabs = ({
           style={{
             maxHeight: '550px',
             minWidth: '190px',
-            overflowY: 'scroll',
+            overflowY: 'auto',
             overflowX: 'hidden',
             msOverflowStyle: 'none',
             backgroundColor: 'white',


### PR DESCRIPTION
hide these vertical scroll bars in the tabs on linux
![screenshot-20180326165033-219x147](https://user-images.githubusercontent.com/1314446/37932185-d4abbab2-3115-11e8-855a-e0e32f8e4376.png)
constrain the thumbnails height to 550px like the tabs panel so it doesn't stretch the page if there's a lot of thumbnails, as for case id 68b86559-38b2-41f2-b66e-c3c2b628b14d
![screenshot-20180326165143-454x635](https://user-images.githubusercontent.com/1314446/37932241-fbc00d6a-3115-11e8-8607-8ddfce0763e0.png)
