### PR TITLE
resolves OPS-269 removing last references to gdc-api.nci.nih.gov ahea…

### DIFF
--- a/public/gdc-config.js
+++ b/public/gdc-config.js
@@ -4,7 +4,7 @@ angular.module("ngApp.config", [])
     "version": "1.4.1",
     "commitLink": "https://github.com/NCI-GDC/portal-ui/commit/1416c89",
     "commitHash": "1416c89",
-    "api": "https://gdc-api.nci.nih.gov/v0",
+    "api": "https://api.gdc.cancer.gov/v0",
     "auth":"https://gdc-portal.nci.nih.gov/auth",
     "auth_api": "https://gdc-portal.nci.nih.gov/auth/api",
     "supportedAPI": "1",


### PR DESCRIPTION
…d of SSL expiring on Jun 17 23:59:59 2018 GMT