### PR TITLE
🚧- No slides in json tooltip

### DIFF
--- a/src/packages/@ncigdc/modern_components/ExploreCasesTable/ExploreCasesTable.js
+++ b/src/packages/@ncigdc/modern_components/ExploreCasesTable/ExploreCasesTable.js
@@ -84,7 +84,7 @@ export default compose(
             arrangeColumnKey="exploreCases"
             total={cases.hits.total}
             endpoint="case_ssms"
-            downloadTooltip="Export All Except #Mutations and #Genes"
+            downloadTooltip="Export All Except #Mutations, #Genes and Slides"
             currentFilters={filters}
             score={score}
             sort={sort}


### PR DESCRIPTION
Show slides in excluded tooltip until slide file count can be added to json download