### PR TITLE
:bug [PRTL-2083] Disable the GoLink Button when the input value is empty.

### DIFF
--- a/src/packages/@ncigdc/components/Aggregations/ExactMatchFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/ExactMatchFacet.js
@@ -84,16 +84,23 @@ const ExactMatchFacet = compose(
                     />
                     <GoLink
                       merge="toggle"
-                      query={{
-                        filters: makeFilter([
-                          {
-                            field: `${doctype}.${fieldNoDoctype}`,
-                            value: [inputValue],
-                          },
-                        ]),
-                      }}
+                      query={
+                        inputValue && {
+                          filters: makeFilter([
+                            {
+                              field: `${doctype}.${fieldNoDoctype}`,
+                              value: [inputValue],
+                            },
+                          ]),
+                        }
+                      }
                       dark={!!inputValue}
-                      onClick={() => setInputValue('')}
+                      onClick={inputValue ? () => setInputValue('') : null}
+                      style={
+                        inputValue
+                          ? null
+                          : { color: 'grey', cursor: 'not-allowed' }
+                      }
                     >
                       Go!
                     </GoLink>

--- a/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
@@ -260,7 +260,6 @@ const RangeFacet = (props: TProps) => {
     },
   };
   const { maxDisplayed, minDisplayed } = props.state;
-
   return (
     <Container style={{ ...props.style }} className="test-range-facet">
       {!props.collapsed &&
@@ -344,7 +343,8 @@ const RangeFacet = (props: TProps) => {
             <GoLink
               dark={!!innerContent.length}
               merge="replace"
-              query={innerContent.length && query}
+              query={innerContent.length ? query : null}
+              style={innerContent.length ? null : { color: 'grey' }}
             >
               Go!
             </GoLink>


### PR DESCRIPTION
To avoid empty search request, set query value to null when the input value for a GoLink component is empty in both RangeFacet and ExactMatchFacet.