### PR TITLE
🛠 [GDCDEVOPS-160] add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,19 @@
+# robots.txt
+#
+# Disallow access to subpages while still allowing access to the root path
+# and any static files.
+
+User-agent: *
+Disallow: /analysis
+Disallow: /annotations
+Disallow: /cart
+Disallow: /cases
+Disallow: /exploration
+Disallow: /files
+Disallow: /genes
+Disallow: /image-viewer
+Disallow: /manage-sets
+Disallow: /projects
+Disallow: /query
+Disallow: /repository
+Disallow: /ssms


### PR DESCRIPTION
Add a `robots.txt` file to stop search engines from crawling past the home page.

Googlebot recently crawled around the exploration page for a while and generated a bunch of increasingly complex Elasticsearch queries. This should stop legitimate search indexes from doing that.