### PR TITLE
PRTL-2517 remove unnecessary layout breaking scrollbars

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard.js
@@ -1062,7 +1062,6 @@ const ClinicalVariableCard: React.ComponentType<IVariableCardProps> = ({
             headings={getHeadings(variable.active_chart)}
             tableContainerStyle={{
               height: 175,
-              overflow: 'scroll',
             }}
           />
         </div>


### PR DESCRIPTION
Leaving it at `overflow: auto` seems to take care of the problem well enough.
Will amend if testing finds unforeseen side-effects.