### PR TITLE
change x-axis length from 8 to 10

### DIFF
--- a/src/packages/@ncigdc/components/Charts/BarChart.js
+++ b/src/packages/@ncigdc/components/Charts/BarChart.js
@@ -16,7 +16,7 @@ import { withTooltip } from '@ncigdc/uikit/Tooltip';
 import withSize from '@ncigdc/utils/withSize';
 import './style.css';
 
-export const DEFAULT_X_AXIS_LABEL_LENGTH = 8;
+export const DEFAULT_X_AXIS_LABEL_LENGTH = 10;
 
 const BarChart = ({
   data,


### PR DESCRIPTION
## Ticket Number

PRTL-2598

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

X-axis labels on the survival plot can now be 10 characters before they're truncated.