### PR TITLE
[PRTL-2534] add CIViC to gene and ssm entity views

### DIFF
--- a/data/getSchema.js
+++ b/data/getSchema.js
@@ -6,20 +6,21 @@ const {
   printSchema,
 } = require('graphql/utilities');
 const path = require('path');
+
 const schemaPath = path.join(__dirname, 'schema');
 
-const SERVER = 'http://localhost:5000/graphql';
+// Takes 'node /data/getSchema.js https://api.gdc.cancer.gov/v0/'
+const SERVER = `${process.argv[2] || 'http://localhost:5000/'}graphql`;
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
 fetch(SERVER, {
-  method: 'POST',
+  body: JSON.stringify({ query: introspectionQuery }),
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   },
-  body: JSON.stringify({ query: introspectionQuery }),
-})
-  .then(res => res.json())
+  method: 'POST',
+}).then(res => res.json())
   .then(schemaJSON => {
     fs.writeFileSync(`${schemaPath}.json`, JSON.stringify(schemaJSON, null, 2));
 

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -625,6 +625,9 @@ type Case implements Node {
   disease_type: String
 
   # keyword
+  diagnosis_ids: String
+
+  # keyword
   submitter_aliquot_ids: String
 
   # keyword
@@ -632,6 +635,9 @@ type Case implements Node {
 
   # keyword
   primary_site: String
+
+  # keyword
+  submitter_diagnosis_ids: String
 
   # keyword
   submitter_slide_ids: String
@@ -755,7 +761,7 @@ type CaseAggregations {
 
   # Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.
   #
-  samples__time_between_excision_and_freezing: Aggregations
+  samples__time_between_excision_and_freezing: NumericAggregations
 
   # Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.
   #
@@ -770,13 +776,13 @@ type CaseAggregations {
   # UUID for identifying or recalling a node.
   #
   samples__submitter_id: Aggregations
-  samples__intermediate_dimension: Aggregations
+  samples__intermediate_dimension: NumericAggregations
   samples__sample_id: Aggregations
 
   # Numeric representation of the elapsed time between the surgical clamping of
   # blood supply and freezing of the sample, measured in minutes.
   #
-  samples__time_between_clamping_and_freezing: Aggregations
+  samples__time_between_clamping_and_freezing: NumericAggregations
 
   # UUID of the related pathology report.
   samples__pathology_report_uuid: Aggregations
@@ -872,7 +878,7 @@ type CaseAggregations {
 
   # Numeric value that represents the shortest dimension of the sample, measured in millimeters.
   #
-  samples__shortest_dimension: Aggregations
+  samples__shortest_dimension: NumericAggregations
 
   # The method used to procure the sample used to extract analyte(s).
   #
@@ -1411,7 +1417,7 @@ type CaseAggregations {
   # Numeric value that represents the initial weight of the sample, measured in milligrams.
   #
   samples__initial_weight: NumericAggregations
-  samples__longest_dimension: Aggregations
+  samples__longest_dimension: NumericAggregations
   submitter_sample_ids: Aggregations
 
   # Status of the annotation.
@@ -1465,10 +1471,6 @@ type CaseAggregations {
   #
   exposures__cigarettes_per_day: NumericAggregations
 
-  # The year in which the participant quit smoking.
-  #
-  exposures__tobacco_smoking_quit_year: NumericAggregations
-
   # The weight of the patient measured in kilograms.
   #
   exposures__weight: NumericAggregations
@@ -1476,19 +1478,6 @@ type CaseAggregations {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   exposures__updated_datetime: Aggregations
-
-  # A response to a question that asks whether the participant has consumed at
-  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
-  #
-  exposures__alcohol_history: Aggregations
-
-  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
-  #
-  exposures__alcohol_intensity: Aggregations
-
-  # A calculated numerical quantity that represents an individual's weight to height ratio.
-  #
-  exposures__bmi: NumericAggregations
 
   # Numeric value (or unknown) to represent the number of years a person has been smoking.
   #
@@ -1498,45 +1487,106 @@ type CaseAggregations {
   #
   exposures__height: NumericAggregations
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # smoke that is emitted from burning tobacco, including cigarettes, pipes, and
+  # cigars. This includes tobacco smoke exhaled by smokers.
   #
-  exposures__created_datetime: Aggregations
-
-  # The current state of the object.
-  #
-  exposures__state: Aggregations
+  exposures__environmental_tobacco_smoke_exposure: Aggregations
 
   # Category describing current smoking status and smoking history as self-reported by a patient.
   #
   exposures__tobacco_smoking_status: Aggregations
 
+  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  #
+  exposures__alcohol_days_per_week: NumericAggregations
+
+  # Numeric computed value to represent lifetime tobacco exposure defined as
+  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  #
+  exposures__pack_years_smoked: NumericAggregations
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposured
+  # to respirable crystalline silica, a widespread, naturally occurring,
+  # crystalline metal oxide that consists of different forms including quartz,
+  # cristobalite, tridymite, tripoli, ganister, chert and novaculite.
+  #
+  exposures__respirable_crystalline_silica_exposure: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # fine powder derived by the crushing of coal.
+  #
+  exposures__coal_dust_exposure: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  exposures__created_datetime: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.
+  #
+  exposures__asbestos_exposure: Aggregations
+
+  # The current state of the object.
+  #
+  exposures__state: Aggregations
+
+  # The text term used to describe the specific type of tobacco used by the patient.
+  #
+  exposures__type_of_tobacco_used: Aggregations
+
   # The year in which the participant began smoking.
   #
   exposures__tobacco_smoking_onset_year: NumericAggregations
+
+  # A response to a question that asks whether the participant has consumed at
+  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
+  #
+  exposures__alcohol_history: Aggregations
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  exposures__bmi: NumericAggregations
+
+  # The text term used to generally decribe how often the patient smokes.
+  #
+  exposures__smoking_frequency: Aggregations
 
   # Numeric value used to describe the average number of alcoholic beverages  a person consumes per day.
   #
   exposures__alcohol_drinks_per_day: NumericAggregations
 
-  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  # The text term used to describe the patient's specific type of smoke exposure.
   #
-  exposures__alcohol_days_per_week: NumericAggregations
+  exposures__type_of_smoke_exposure: Aggregations
+  exposures__exposure_id: Aggregations
 
   # A project-specific identifier for a node. This property is the calling
   # card/nickname/alias for a unit of submission. It can be used in place of the
   # UUID for identifying or recalling a node.
   #
   exposures__submitter_id: Aggregations
-  exposures__exposure_id: Aggregations
 
-  # Numeric computed value to represent lifetime tobacco exposure defined as
-  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
   #
-  exposures__pack_years_smoked: NumericAggregations
+  exposures__alcohol_intensity: Aggregations
+
+  # The text term used to describe the approximate amount of time elapsed between
+  # the time the patient wakes up in the morning to the time they smoke their
+  # first cigarette.
+  #
+  exposures__time_between_waking_and_first_smoke: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to radon.
+  #
+  exposures__radon_exposure: Aggregations
+
+  # The year in which the participant quit smoking.
+  #
+  exposures__tobacco_smoking_quit_year: NumericAggregations
   files__origin: Aggregations
-  files__proportion_base_mismatch: NumericAggregations
+  files__chip_id: Aggregations
+  files__index_files__chip_id: Aggregations
   files__index_files__proportion_base_mismatch: NumericAggregations
-  files__index_files__updated_datetime: Aggregations
   files__index_files__file_name: Aggregations
   files__index_files__submitter_id: Aggregations
   files__index_files__read_pair_number: Aggregations
@@ -1553,14 +1603,21 @@ type CaseAggregations {
   files__index_files__magnification: NumericAggregations
   files__index_files__mean_coverage: NumericAggregations
   files__index_files__average_read_length: NumericAggregations
+  files__index_files__contamination_error: NumericAggregations
+  files__index_files__channel: Aggregations
   files__index_files__experimental_strategy: Aggregations
+  files__index_files__updated_datetime: Aggregations
   files__index_files__data_type: Aggregations
+  files__index_files__chip_position: Aggregations
   files__index_files__proportion_coverage_10X: NumericAggregations
   files__index_files__file_id: Aggregations
+  files__index_files__contamination: NumericAggregations
   files__index_files__proportion_reads_duplicated: NumericAggregations
   files__index_files__total_reads: NumericAggregations
   files__index_files__state_comment: Aggregations
+  files__index_files__plate_well: Aggregations
   files__index_files__md5sum: Aggregations
+  files__index_files__plate_name: Aggregations
   files__index_files__data_format: Aggregations
   files__index_files__proportion_reads_mapped: NumericAggregations
   files__index_files__proportion_targets_no_coverage: NumericAggregations
@@ -1582,8 +1639,8 @@ type CaseAggregations {
   files__downstream_analyses__workflow_type: Aggregations
   files__downstream_analyses__workflow_start_datetime: Aggregations
   files__downstream_analyses__workflow_version: Aggregations
+  files__downstream_analyses__output_files__chip_id: Aggregations
   files__downstream_analyses__output_files__proportion_base_mismatch: NumericAggregations
-  files__downstream_analyses__output_files__updated_datetime: Aggregations
   files__downstream_analyses__output_files__file_name: Aggregations
   files__downstream_analyses__output_files__submitter_id: Aggregations
   files__downstream_analyses__output_files__read_pair_number: Aggregations
@@ -1600,14 +1657,21 @@ type CaseAggregations {
   files__downstream_analyses__output_files__magnification: NumericAggregations
   files__downstream_analyses__output_files__mean_coverage: NumericAggregations
   files__downstream_analyses__output_files__average_read_length: NumericAggregations
+  files__downstream_analyses__output_files__contamination_error: NumericAggregations
+  files__downstream_analyses__output_files__channel: Aggregations
   files__downstream_analyses__output_files__experimental_strategy: Aggregations
+  files__downstream_analyses__output_files__updated_datetime: Aggregations
   files__downstream_analyses__output_files__data_type: Aggregations
+  files__downstream_analyses__output_files__chip_position: Aggregations
   files__downstream_analyses__output_files__proportion_coverage_10X: NumericAggregations
   files__downstream_analyses__output_files__file_id: Aggregations
+  files__downstream_analyses__output_files__contamination: NumericAggregations
   files__downstream_analyses__output_files__proportion_reads_duplicated: NumericAggregations
   files__downstream_analyses__output_files__total_reads: NumericAggregations
   files__downstream_analyses__output_files__state_comment: Aggregations
+  files__downstream_analyses__output_files__plate_well: Aggregations
   files__downstream_analyses__output_files__md5sum: Aggregations
+  files__downstream_analyses__output_files__plate_name: Aggregations
   files__downstream_analyses__output_files__data_format: Aggregations
   files__downstream_analyses__output_files__proportion_reads_mapped: NumericAggregations
   files__downstream_analyses__output_files__proportion_targets_no_coverage: NumericAggregations
@@ -1655,11 +1719,9 @@ type CaseAggregations {
   # The current state of the object.
   #
   files__state: Aggregations
-  files__release_number: Aggregations
   files__access: Aggregations
   files__platform: Aggregations
   files__magnification: NumericAggregations
-  files__version: Aggregations
   files__metadata_files__md5sum: Aggregations
   files__metadata_files__type: Aggregations
   files__metadata_files__data_type: Aggregations
@@ -1676,18 +1738,28 @@ type CaseAggregations {
   files__metadata_files__file_size: NumericAggregations
   files__metadata_files__state_comment: Aggregations
   files__average_read_length: NumericAggregations
+  files__contamination_error: NumericAggregations
   files__type: Aggregations
+  files__channel: Aggregations
   files__revision: NumericAggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  files__updated_datetime: Aggregations
   files__data_type: Aggregations
   files__tags: Aggregations
+  files__chip_position: Aggregations
   files__proportion_coverage_10X: NumericAggregations
   files__file_id: Aggregations
+  files__contamination: NumericAggregations
+  files__proportion_base_mismatch: NumericAggregations
   files__proportion_reads_duplicated: NumericAggregations
   files__total_reads: NumericAggregations
 
   # Optional comment about why the file is in the current state, mainly for invalid state.
   #
   files__state_comment: Aggregations
+  files__plate_well: Aggregations
   files__data_format: Aggregations
   files__center__code: Aggregations
   files__center__name: Aggregations
@@ -1695,21 +1767,17 @@ type CaseAggregations {
   files__center__namespace: Aggregations
   files__center__center_id: Aggregations
   files__center__center_type: Aggregations
-  files__baseid: Aggregations
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
   files__md5sum: Aggregations
-
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-  #
-  files__updated_datetime: Aggregations
+  files__plate_name: Aggregations
   files__mean_coverage: NumericAggregations
   files__analysis__analysis_id: Aggregations
   files__analysis__updated_datetime: Aggregations
   files__analysis__created_datetime: Aggregations
+  files__analysis__input_files__chip_id: Aggregations
   files__analysis__input_files__proportion_base_mismatch: NumericAggregations
-  files__analysis__input_files__updated_datetime: Aggregations
   files__analysis__input_files__file_name: Aggregations
   files__analysis__input_files__submitter_id: Aggregations
   files__analysis__input_files__read_pair_number: Aggregations
@@ -1726,14 +1794,21 @@ type CaseAggregations {
   files__analysis__input_files__magnification: NumericAggregations
   files__analysis__input_files__mean_coverage: NumericAggregations
   files__analysis__input_files__average_read_length: NumericAggregations
+  files__analysis__input_files__contamination_error: NumericAggregations
+  files__analysis__input_files__channel: Aggregations
   files__analysis__input_files__experimental_strategy: Aggregations
+  files__analysis__input_files__updated_datetime: Aggregations
   files__analysis__input_files__data_type: Aggregations
+  files__analysis__input_files__chip_position: Aggregations
   files__analysis__input_files__proportion_coverage_10X: NumericAggregations
   files__analysis__input_files__file_id: Aggregations
+  files__analysis__input_files__contamination: NumericAggregations
   files__analysis__input_files__proportion_reads_duplicated: NumericAggregations
   files__analysis__input_files__total_reads: NumericAggregations
   files__analysis__input_files__state_comment: Aggregations
+  files__analysis__input_files__plate_well: Aggregations
   files__analysis__input_files__md5sum: Aggregations
+  files__analysis__input_files__plate_name: Aggregations
   files__analysis__input_files__data_format: Aggregations
   files__analysis__input_files__proportion_reads_mapped: NumericAggregations
   files__analysis__input_files__proportion_targets_no_coverage: NumericAggregations
@@ -1825,6 +1900,345 @@ type CaseAggregations {
   files__data_category: Aggregations
   files__experimental_strategy: Aggregations
   files__average_insert_size: NumericAggregations
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # post-bronchodilator.
+  #
+  follow_ups__fev1_ref_post_bronch_percent: NumericAggregations
+
+  # The weight of the patient measured in kilograms.
+  #
+  follow_ups__weight: NumericAggregations
+
+  # Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).
+  #
+  follow_ups__reflux_treatment_type: Aggregations
+
+  # The text term used to describe the type of progressive or recurrent disease or relapsed disease.
+  #
+  follow_ups__progression_or_recurrence_type: Aggregations
+
+  # The height of the patient in centimeters.
+  #
+  follow_ups__height: NumericAggregations
+
+  # Number of days between the date used for index and the date of the patient's adverse event.
+  #
+  follow_ups__days_to_adverse_event: NumericAggregations
+
+  # The text term used to describe the suspected cause or reason for the patient disease response.
+  #
+  follow_ups__cause_of_response: Aggregations
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.
+  #
+  follow_ups__fev1_fvc_pre_bronch_percent: NumericAggregations
+
+  # The ECOG functional performance status of the patient/participant.
+  #
+  follow_ups__ecog_performance_status: Aggregations
+
+  # Text classification to represent the strain or type of human papillomavirus identified in an individual.
+  #
+  follow_ups__hpv_positive_type: Aggregations
+
+  # Number of days between the date used for index and the date the patient's
+  # disease was formally confirmed as progression-free.
+  #
+  follow_ups__days_to_progression_free: NumericAggregations
+
+  # Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.
+  #
+  follow_ups__days_to_follow_up: NumericAggregations
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.
+  #
+  follow_ups__fev1_fvc_post_bronch_percent: NumericAggregations
+
+  # The text term used to describe the method used to diagnose the patient's comorbidity disease.
+  #
+  follow_ups__comorbidity_method_of_diagnosis: Aggregations
+
+  # The value, as a percentage of predicted lung volume, measuring the amount of
+  # carbon monoxide detected in a patient's lungs.
+  #
+  follow_ups__dlco_ref_predictive_percent: NumericAggregations
+
+  # The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.
+  #
+  follow_ups__comorbidity: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__updated_datetime: Aggregations
+
+  # The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__risk_factor: Aggregations
+
+  # The current state of the object.
+  #
+  follow_ups__state: Aggregations
+
+  # Number of days between the date used for index and the date the patient's disease progressed.
+  #
+  follow_ups__days_to_progression: NumericAggregations
+
+  # Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.
+  #
+  follow_ups__adverse_event: Aggregations
+
+  # Number of days between the date used for index and the date the patient's disease recurred.
+  #
+  follow_ups__days_to_recurrence: NumericAggregations
+
+  # The yes/no/unknown indicator used to describe whether the mutation included in
+  # molecular testing was known to have an affect on the mismatch repair process.
+  #
+  follow_ups__molecular_tests__mismatch_repair_mutation: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__molecular_tests__updated_datetime: Aggregations
+
+  # The text term used to describe an antigen included in molecular testing.
+  #
+  follow_ups__molecular_tests__antigen: Aggregations
+
+  # The text term used to describe the biological origin of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__variant_origin: Aggregations
+
+  # Numeric value used to describe the lower limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  follow_ups__molecular_tests__blood_test_normal_range_lower: NumericAggregations
+
+  # Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.
+  #
+  follow_ups__molecular_tests__locus: Aggregations
+
+  # The text term or numeric value used to describe a sepcific result of a molecular test.
+  #
+  follow_ups__molecular_tests__test_value: NumericAggregations
+
+  # The text term used to describe a secondary gene targeted or included in
+  # molecular analysis. For rearrangements, this is should represent the location
+  # of the variant.
+  #
+  follow_ups__molecular_tests__second_gene_symbol: Aggregations
+
+  # Text term used to describe the number of sets of homologous chromosomes.
+  #
+  follow_ups__molecular_tests__ploidy: Aggregations
+
+  # The text term used to describe a chromosome targeted or included in molecular
+  # testing. If a specific genetic variant is being reported, this property can be
+  # used to capture the chromosome where that variant is located.
+  #
+  follow_ups__molecular_tests__chromosome: Aggregations
+
+  # Text term used to describe a specific test that is not covered in the list of molecular analysis methods.
+  #
+  follow_ups__molecular_tests__specialized_molecular_test: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__molecular_tests__created_datetime: Aggregations
+
+  # Intron number targeted or included in molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # intron where that variant is located.
+  #
+  follow_ups__molecular_tests__intron: Aggregations
+
+  # The text term used to describe a gene targeted or included in molecular
+  # analysis. For rearrangements, this is shold be used to represent the reference gene.
+  #
+  follow_ups__molecular_tests__gene_symbol: Aggregations
+
+  # The current state of the object.
+  #
+  follow_ups__molecular_tests__state: Aggregations
+
+  # The text term used to describe a specific histone variants, which are proteins
+  # that substitute for the core canonical histones.
+  #
+  follow_ups__molecular_tests__histone_variant: Aggregations
+
+  # Numeric value used to describe the number of cells used for molecular testing.
+  #
+  follow_ups__molecular_tests__cell_count: NumericAggregations
+
+  # The text term used to describe the family, or classification of a group of
+  # basic proteins found in chromatin, called histones.
+  #
+  follow_ups__molecular_tests__histone_family: Aggregations
+
+  # Numeric value used to describe the number of times a section of the genome is
+  # repeated or copied within an insertion, duplication or deletion variant.
+  #
+  follow_ups__molecular_tests__copy_number: NumericAggregations
+
+  # The text term used to describe the type of analyte used for molecular testing.
+  #
+  follow_ups__molecular_tests__test_analyte_type: Aggregations
+
+  # Exon number targeted or included in a molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # exon where that variant is located.
+  #
+  follow_ups__molecular_tests__exon: Aggregations
+
+  # The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.
+  #
+  follow_ups__molecular_tests__laboratory_test: Aggregations
+
+  # The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.
+  #
+  follow_ups__molecular_tests__test_result: Aggregations
+
+  # Alphanumeric value used to describe the transcript of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__transcript: Aggregations
+
+  # Numeric value used to describe the upper limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  follow_ups__molecular_tests__blood_test_normal_range_upper: NumericAggregations
+
+  # The text term used to describe the units of the test value for a molecular
+  # test. This property is used in conjunction with test_value.
+  #
+  follow_ups__molecular_tests__test_units: Aggregations
+
+  # The text term used to describe the zygosity of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__zygosity: Aggregations
+
+  # Alphanumeric value used to describe the cytoband or chromosomal location
+  # targeted or included in molecular analysis. If a specific genetic variant is
+  # being reported, this property can be used to capture the cytoband where the
+  # variant is located. Format: [chromosome][chromosome arm].[band+sub-bands].
+  # Example: 17p13.1.
+  #
+  follow_ups__molecular_tests__cytoband: Aggregations
+
+  # The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.
+  follow_ups__molecular_tests__biospecimen_type: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  follow_ups__molecular_tests__submitter_id: Aggregations
+
+  # The second exon number involved in molecular variation. If a specific genetic
+  # variant is being reported, this property can be used to capture the second
+  # exon where that variant is located. This property is typically used for a
+  # translocation where two different locations are involved in the variation.
+  #
+  follow_ups__molecular_tests__second_exon: Aggregations
+  follow_ups__molecular_tests__molecular_test_id: Aggregations
+
+  # The text term used to describe the method used for molecular analysis.
+  #
+  follow_ups__molecular_tests__molecular_analysis_method: Aggregations
+
+  # The text term used to describe the molecular consequence of genetic variation.
+  #
+  follow_ups__molecular_tests__molecular_consequence: Aggregations
+
+  # The text term used to describe the type of genetic variation.
+  #
+  follow_ups__molecular_tests__variant_type: Aggregations
+
+  # Numeric value used to describe the number of loci determined to be abnormal.
+  #
+  follow_ups__molecular_tests__loci_abnormal_count: NumericAggregations
+
+  # Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.
+  #
+  follow_ups__molecular_tests__aa_change: Aggregations
+
+  # Numeric value used to describe the number of loci tested.
+  #
+  follow_ups__molecular_tests__loci_count: NumericAggregations
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  follow_ups__bmi: NumericAggregations
+
+  # Text term used to describe the patient's menopause status.
+  #
+  follow_ups__menopause_status: Aggregations
+
+  # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
+  #
+  follow_ups__progression_or_recurrence: Aggregations
+
+  # Text term used to describe the types of treatment used to manage diabetes.
+  #
+  follow_ups__diabetes_treatment_type: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__risk_factor_treatment: Aggregations
+
+  # The text term used to describe the anatomic site of the progressive or recurrent disease.
+  #
+  follow_ups__progression_or_recurrence_anatomic_site: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  follow_ups__submitter_id: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether goblet cells were
+  # determined to be present in a patient diagnosed with Barrett's esophagus.
+  #
+  follow_ups__barretts_esophagus_goblet_cells_present: Aggregations
+
+  # Code assigned to describe the patient's response or outcome to the disease.
+  #
+  follow_ups__disease_response: Aggregations
+  follow_ups__follow_up_id: Aggregations
+
+  # Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.
+  #
+  follow_ups__pancreatitis_onset_year: NumericAggregations
+
+  # Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.
+  #
+  follow_ups__viral_hepatitis_serologies: Aggregations
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # pre-bronchodilator.
+  #
+  follow_ups__fev1_ref_pre_bronch_percent: NumericAggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__created_datetime: Aggregations
+
+  # Text term used to describe the classification used of the functional capabilities of a person.
+  #
+  follow_ups__karnofsky_performance_status: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__hepatitis_sustained_virological_response: Aggregations
+
+  # Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.
+  #
+  follow_ups__days_to_comorbidity: NumericAggregations
   index_date: Aggregations
   case_autocomplete: Aggregations
 
@@ -1868,6 +2282,7 @@ type CaseAggregations {
   #
   family_histories__relationship_age_at_diagnosis: NumericAggregations
   submitter_id: Aggregations
+  disease_type: Aggregations
 
   # Text term that represents the type of vascular tumor invasion.
   #
@@ -1897,9 +2312,9 @@ type CaseAggregations {
   #
   diagnoses__submitter_id: Aggregations
 
-  # The survival state of the person registered on the protocol.
+  # The text term used to describe the extent of metastatic disease present at diagnosis.
   #
-  diagnoses__vital_status: Aggregations
+  diagnoses__metastasis_at_diagnosis: Aggregations
 
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
@@ -1911,7 +2326,6 @@ type CaseAggregations {
   # immunocytochemical stains. A system of numbered categories for representation of data.
   #
   diagnoses__morphology: Aggregations
-  diagnoses__days_to_death: NumericAggregations
 
   # Time interval from the date of last follow up to the date of initial
   # pathologic diagnosis, represented as a calculated number of days.
@@ -1921,7 +2335,6 @@ type CaseAggregations {
   # Text term used to describe the classification of rhabdomyosarcoma, as defined by the Children's Oncology Group (COG).
   #
   diagnoses__cog_rhabdomyosarcoma_risk_group: Aggregations
-  diagnoses__days_to_hiv_diagnosis: NumericAggregations
 
   # Code of pathological T (primary tumor) to define the size or contiguous
   # extension of the primary tumor (T), using staging criteria from the American
@@ -1952,6 +2365,16 @@ type CaseAggregations {
   #
   diagnoses__ajcc_pathologic_n: Aggregations
 
+  # The text term used to describe the overall Weiss assessment score, a commonly
+  # used assessment describing the malignancy of adrenocortical tumors. The Weiss
+  # score is determined based on nine histological criteria including the
+  # following: high nuclear grade, mitotic rate greater than five per 50 high
+  # power fields (HPF), atypical mitotic figures, eosinophilic tumor cell
+  # cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than
+  # 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.
+  #
+  diagnoses__weiss_assessment_score: Aggregations
+
   # Text term and code that represents the metastatic stage of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
@@ -1961,6 +2384,11 @@ type CaseAggregations {
   # Text term to describe the amount of dysplasia found within the benign esophageal columnar mucosa.
   #
   diagnoses__esophageal_columnar_dysplasia_degree: Aggregations
+
+  # The number of lymph nodes tested to determine whether lymph nodes were 
+  # involved with disease as determined by a pathologic examination.
+  #
+  diagnoses__lymph_nodes_tested: NumericAggregations
 
   # The text term used to describe the classification of the histopathologic degree of liver damage.
   #
@@ -1973,6 +2401,12 @@ type CaseAggregations {
   # Text term to specify the location of the supratentorial tumor.
   #
   diagnoses__supratentorial_localization: Aggregations
+
+  # The text term used to describe the International Germ Cell Cancer
+  # Collaborative Group (IGCCCG), a grouping used to further classify metastatic
+  # testicular tumors.
+  #
+  diagnoses__igcccg_stage: Aggregations
 
   # The yes/no/unknown/not reported indicator used to describe whether the tumor
   # is located across the gastroesophageal junction.
@@ -1987,13 +2421,17 @@ type CaseAggregations {
   # The multiple myeloma disease stage at diagnosis.
   #
   diagnoses__iss_stage: Aggregations
-  diagnoses__cause_of_death: Aggregations
 
   # Text term and code that represents the tumor site of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
   #
   diagnoses__enneking_msts_tumor_site: Aggregations
+
+  # A numeric value used to measure therapeutic response of the primary tumor and
+  # predict patient outcomes based on a three-point tumor regression grading system.
+  #
+  diagnoses__tumor_regression_grade: Aggregations
 
   # Numeric value used to describe the gross pathologic tumor weight, measured in grams.
   #
@@ -2003,7 +2441,6 @@ type CaseAggregations {
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
   #
   diagnoses__ajcc_clinical_stage: Aggregations
-  diagnoses__hiv_positive: Aggregations
 
   # Text term to signify whether lymphoma B-symptoms are present as noted in the patient's medical record.
   #
@@ -2018,10 +2455,6 @@ type CaseAggregations {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   diagnoses__updated_datetime: Aggregations
-
-  # The text term used to describe the extent of metastatic disease present at diagnosis.
-  #
-  diagnoses__metastasis_at_diagnosis: Aggregations
 
   # Number of days between the date used for index and the date of the patient was
   # thought to have the best overall response to their disease.
@@ -2039,7 +2472,6 @@ type CaseAggregations {
   # Age at the time of diagnosis expressed in number of days since birth.
   #
   diagnoses__age_at_diagnosis: NumericAggregations
-  diagnoses__hpv_positive_type: Aggregations
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
@@ -2095,7 +2527,6 @@ type CaseAggregations {
   # The yes/no/unknown indicator used to describe the patient's history of prior cancer diagnosis.
   #
   diagnoses__prior_malignancy: Aggregations
-  diagnoses__days_to_new_event: NumericAggregations
 
   # Numeric value used to describe the non-peritonealised bare area of rectum,
   # comprising anterior and posterior segments, when submitted as a surgical
@@ -2128,7 +2559,15 @@ type CaseAggregations {
   # Numeric value to represent the year of an individual's initial pathologic diagnosis of cancer.
   #
   diagnoses__year_of_diagnosis: NumericAggregations
-  diagnoses__progression_free_survival: NumericAggregations
+
+  # The text term used to describe the secondary Gleason score, which describes
+  # the pattern of cells making up the second largest area of the tumor. The
+  # primary and secondary Gleason pattern grades are combined to determine the
+  # patient's Gleason grade group, which is used to determine the aggresiveness of
+  # prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  diagnoses__secondary_gleason_grade: Aggregations
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -2153,6 +2592,10 @@ type CaseAggregations {
   #
   diagnoses__perineural_invasion_present: Aggregations
 
+  # The text term used to describe whether the patient's disease originated in a single location or multiple locations.
+  #
+  diagnoses__tumor_focality: Aggregations
+
   # The text term used to describe the classification of Wilms tumors
   # distinguishing between favorable and unfavorable histologic groups.
   #
@@ -2161,7 +2604,6 @@ type CaseAggregations {
   # Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.
   #
   diagnoses__ajcc_clinical_t: Aggregations
-  diagnoses__colon_polyps_history: Aggregations
 
   # Extent of the regional lymph node involvement for the cancer based on evidence
   # obtained from clinical assessment parameters determined prior to treatment.
@@ -2188,7 +2630,53 @@ type CaseAggregations {
   # specifically describes the extent of the primary tumor prior to treatment.
   #
   diagnoses__cog_liver_stage: Aggregations
-  diagnoses__progression_free_survival_event: Aggregations
+
+  # Status of the annotation.
+  diagnoses__annotations__status: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__legacy_updated_datetime: Aggregations
+  diagnoses__annotations__entity_id: Aggregations
+
+  # Top level classification of the annotation.
+  diagnoses__annotations__classification: Aggregations
+
+  # Name of the person or entity responsible for the creation of the annotation.
+  diagnoses__annotations__creator: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__created_datetime: Aggregations
+  diagnoses__annotations__entity_submitter_id: Aggregations
+
+  # Open entry for any further description or characterization of the data.
+  diagnoses__annotations__notes: Aggregations
+  diagnoses__annotations__entity_type: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__updated_datetime: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__legacy_created_datetime: Aggregations
+
+  # The current state of the object.
+  #
+  diagnoses__annotations__state: Aggregations
+  diagnoses__annotations__case_id: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  diagnoses__annotations__submitter_id: Aggregations
+  diagnoses__annotations__annotation_id: Aggregations
+  diagnoses__annotations__case_submitter_id: Aggregations
+
+  # Top level characterization of the annotation.
+  diagnoses__annotations__category: Aggregations
 
   # Text term used to describe the stage of the musculoskeletal sarcoma, using the
   # Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).
@@ -2226,7 +2714,11 @@ type CaseAggregations {
   # The total number of peripancreatic lymph nodes tested for the presence of pancreatic cancer cells.
   #
   diagnoses__peripancreatic_lymph_nodes_tested: NumericAggregations
-  diagnoses__overall_survival: NumericAggregations
+
+  # The text term used to describe the Masaoka staging system, a classification
+  # that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.
+  #
+  diagnoses__masaoka_stage: Aggregations
 
   # Text term that represents the component of the International Neuroblastoma
   # Pathology Classification (INPC) for mitosis-karyorrhexis index (MKI).
@@ -2250,7 +2742,6 @@ type CaseAggregations {
   # The yes/no/unknown indicator used to describe whether esophageal columnar metaplasia was determined to be present.
   #
   diagnoses__esophageal_columnar_metaplasia_present: Aggregations
-  diagnoses__new_event_anatomic_site: Aggregations
 
   # The best improvement achieved throughout the entire course of protocol treatment.
   #
@@ -2267,6 +2758,15 @@ type CaseAggregations {
   # Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.
   #
   diagnoses__tumor_grade: Aggregations
+
+  # The text term used to describe the primary Gleason score, which describes the
+  # pattern of cells making up the largest area of the tumor. The primary and
+  # secondary Gleason pattern grades are combined to determine the patient's
+  # Gleason grade group, which is used to determine the aggresiveness of prostate
+  # cancer. Note that this grade describes the entire prostatectomy specimen and
+  # is not specific to the sample used for sequencing.
+  #
+  diagnoses__primary_gleason_grade: Aggregations
 
   # Number of days between the date used for index and the date the treatment started.
   #
@@ -2294,6 +2794,10 @@ type CaseAggregations {
   #
   diagnoses__treatments__submitter_id: Aggregations
   diagnoses__treatments__treatment_id: Aggregations
+
+  # The text term used to describe the pathologic effect a treatment(s) had on the tumor.
+  #
+  diagnoses__treatments__treatment_effect: Aggregations
 
   # The current state of the object.
   #
@@ -2330,8 +2834,6 @@ type CaseAggregations {
   # Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.
   #
   diagnoses__days_to_diagnosis: NumericAggregations
-  diagnoses__days_to_birth: NumericAggregations
-  diagnoses__hpv_status: Aggregations
 
   # The text term used to describe the version or edition of the American Joint
   # Committee on Cancer Staging Handbooks, a publication by the group formed for
@@ -2340,12 +2842,10 @@ type CaseAggregations {
   # classifications.
   #
   diagnoses__ajcc_staging_system_edition: Aggregations
-  diagnoses__new_event_type: Aggregations
 
   # The text term used to describe the classification of medulloblastoma tumors based on molecular features.
   #
   diagnoses__medulloblastoma_molecular_classification: Aggregations
-  diagnoses__ldh_normal_range_upper: NumericAggregations
 
   # The text term used to describe the staging classification of renal tumors, as
   # defined by the Children's Oncology Group (COG).
@@ -2368,7 +2868,14 @@ type CaseAggregations {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__site_of_resection_or_biopsy: Aggregations
-  disease_type: Aggregations
+
+  # The text term used to describe the overall grouping of grades defined by the
+  # Gleason grading classification, which is used to determine the aggressiveness
+  # of prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  diagnoses__gleason_grade_group: Aggregations
+  diagnosis_ids: Aggregations
   submitter_aliquot_ids: Aggregations
   summary__data_categories__file_count: NumericAggregations
   summary__data_categories__data_category: Aggregations
@@ -2413,6 +2920,7 @@ type CaseAggregations {
   project__name: Aggregations
   aliquot_ids: Aggregations
   primary_site: Aggregations
+  submitter_diagnosis_ids: Aggregations
 
   # Study name of the project.
   tissue_source_site__project: Aggregations
@@ -2543,8 +3051,8 @@ type CaseFile implements Node {
   # keyword
   origin: String
 
-  # long
-  proportion_base_mismatch: Float
+  # keyword
+  chip_id: String
 
   # The name (or part of a name) of a file (of any type).
   #
@@ -2588,9 +3096,6 @@ type CaseFile implements Node {
   state: String
 
   # keyword
-  release_number: String
-
-  # keyword
   access: String
 
   # keyword
@@ -2599,26 +3104,42 @@ type CaseFile implements Node {
   # long
   magnification: Float
 
-  # keyword
-  version: String
-
   # long
   average_read_length: Float
+
+  # long
+  contamination_error: Float
 
   # keyword
   type: String
 
+  # keyword
+  channel: String
+
   # long
   revision: Float
 
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  updated_datetime: String
+
   # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
+
+  # long
+  proportion_base_mismatch: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -2631,18 +3152,17 @@ type CaseFile implements Node {
   state_comment: String
 
   # keyword
-  data_format: String
+  plate_well: String
 
   # keyword
-  baseid: String
+  data_format: String
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
   md5sum: String
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-  #
-  updated_datetime: String
+  # keyword
+  plate_name: String
 
   # long
   mean_coverage: Float
@@ -2685,6 +3205,20 @@ type CaseFileEdge {
 
 type CaseFiles {
   hits(offset: Int, sort: [Sort], filters: FiltersArgument, before: String, after: String, first: Int, last: Int): CaseFileConnection
+}
+
+type CivicAnnotation {
+  # keyword
+  gene_id: String
+
+  # keyword
+  variant_id: String
+  id: String
+}
+
+type ClinicalAnnotations {
+  civic: CivicAnnotation
+  id: String
 }
 
 type CNV implements Node {
@@ -2761,9 +3295,8 @@ type CNVAggregations {
   occurrence__case__diagnoses__tumor_stage: Aggregations
   occurrence__case__diagnoses__age_at_diagnosis: NumericAggregations
   occurrence__case__diagnoses__hpv_positive_type: Aggregations
-  occurrence__case__diagnoses__vital_status: Aggregations
   occurrence__case__diagnoses__morphology: Aggregations
-  occurrence__case__diagnoses__days_to_death: NumericAggregations
+  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__new_event_anatomic_site: Aggregations
   occurrence__case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   occurrence__case__diagnoses__perineural_invasion_present: Aggregations
@@ -2778,7 +3311,7 @@ type CNVAggregations {
   occurrence__case__diagnoses__ajcc_pathologic_n: Aggregations
   occurrence__case__diagnoses__vascular_invasion_present: Aggregations
   occurrence__case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
+  occurrence__case__diagnoses__created_datetime: Aggregations
   occurrence__case__diagnoses__residual_disease: Aggregations
   occurrence__case__diagnoses__days_to_recurrence: NumericAggregations
   occurrence__case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -2801,7 +3334,6 @@ type CNVAggregations {
   occurrence__case__diagnoses__treatments__treatment_or_therapy: Aggregations
   occurrence__case__diagnoses__lymphatic_invasion_present: Aggregations
   occurrence__case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  occurrence__case__diagnoses__days_to_birth: NumericAggregations
   occurrence__case__diagnoses__progression_or_recurrence: Aggregations
   occurrence__case__diagnoses__hpv_status: Aggregations
   occurrence__case__diagnoses__prior_malignancy: Aggregations
@@ -2814,9 +3346,8 @@ type CNVAggregations {
   occurrence__case__diagnoses__ldh_normal_range_upper: NumericAggregations
   occurrence__case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   occurrence__case__diagnoses__lymph_nodes_positive: NumericAggregations
-  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  occurrence__case__diagnoses__created_datetime: Aggregations
+  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
   occurrence__case__diagnoses__ajcc_clinical_stage: Aggregations
   occurrence__case__diagnoses__days_to_new_event: NumericAggregations
   occurrence__case__diagnoses__hiv_positive: Aggregations
@@ -2832,6 +3363,9 @@ type CNVAggregations {
   occurrence__case__demographic__demographic_id: Aggregations
   occurrence__case__demographic__state: Aggregations
   occurrence__case__demographic__race: Aggregations
+  occurrence__case__demographic__days_to_birth: NumericAggregations
+  occurrence__case__demographic__vital_status: Aggregations
+  occurrence__case__demographic__days_to_death: NumericAggregations
   occurrence__case__demographic__submitter_id: Aggregations
   occurrence__case__demographic__ethnicity: Aggregations
   occurrence__case__demographic__year_of_death: NumericAggregations
@@ -3308,9 +3842,9 @@ type Diagnosis implements Node {
   #
   submitter_id: String
 
-  # The survival state of the person registered on the protocol.
+  # The text term used to describe the extent of metastatic disease present at diagnosis.
   #
-  vital_status: String
+  metastasis_at_diagnosis: String
 
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
@@ -3323,9 +3857,6 @@ type Diagnosis implements Node {
   #
   morphology: String
 
-  # long
-  days_to_death: Float
-
   # Time interval from the date of last follow up to the date of initial
   # pathologic diagnosis, represented as a calculated number of days.
   #
@@ -3334,9 +3865,6 @@ type Diagnosis implements Node {
   # Text term used to describe the classification of rhabdomyosarcoma, as defined by the Children's Oncology Group (COG).
   #
   cog_rhabdomyosarcoma_risk_group: String
-
-  # long
-  days_to_hiv_diagnosis: Float
 
   # Code of pathological T (primary tumor) to define the size or contiguous
   # extension of the primary tumor (T), using staging criteria from the American
@@ -3367,6 +3895,16 @@ type Diagnosis implements Node {
   #
   ajcc_pathologic_n: String
 
+  # The text term used to describe the overall Weiss assessment score, a commonly
+  # used assessment describing the malignancy of adrenocortical tumors. The Weiss
+  # score is determined based on nine histological criteria including the
+  # following: high nuclear grade, mitotic rate greater than five per 50 high
+  # power fields (HPF), atypical mitotic figures, eosinophilic tumor cell
+  # cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than
+  # 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.
+  #
+  weiss_assessment_score: String
+
   # Text term and code that represents the metastatic stage of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
@@ -3376,6 +3914,11 @@ type Diagnosis implements Node {
   # Text term to describe the amount of dysplasia found within the benign esophageal columnar mucosa.
   #
   esophageal_columnar_dysplasia_degree: String
+
+  # The number of lymph nodes tested to determine whether lymph nodes were 
+  # involved with disease as determined by a pathologic examination.
+  #
+  lymph_nodes_tested: Float
 
   # The text term used to describe the classification of the histopathologic degree of liver damage.
   #
@@ -3388,6 +3931,12 @@ type Diagnosis implements Node {
   # Text term to specify the location of the supratentorial tumor.
   #
   supratentorial_localization: String
+
+  # The text term used to describe the International Germ Cell Cancer
+  # Collaborative Group (IGCCCG), a grouping used to further classify metastatic
+  # testicular tumors.
+  #
+  igcccg_stage: String
 
   # The yes/no/unknown/not reported indicator used to describe whether the tumor
   # is located across the gastroesophageal junction.
@@ -3403,14 +3952,16 @@ type Diagnosis implements Node {
   #
   iss_stage: String
 
-  # keyword
-  cause_of_death: String
-
   # Text term and code that represents the tumor site of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
   #
   enneking_msts_tumor_site: String
+
+  # A numeric value used to measure therapeutic response of the primary tumor and
+  # predict patient outcomes based on a three-point tumor regression grading system.
+  #
+  tumor_regression_grade: String
 
   # Numeric value used to describe the gross pathologic tumor weight, measured in grams.
   #
@@ -3420,9 +3971,6 @@ type Diagnosis implements Node {
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
   #
   ajcc_clinical_stage: String
-
-  # keyword
-  hiv_positive: String
 
   # Text term to signify whether lymphoma B-symptoms are present as noted in the patient's medical record.
   #
@@ -3437,10 +3985,6 @@ type Diagnosis implements Node {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   updated_datetime: String
-
-  # The text term used to describe the extent of metastatic disease present at diagnosis.
-  #
-  metastasis_at_diagnosis: String
 
   # Number of days between the date used for index and the date of the patient was
   # thought to have the best overall response to their disease.
@@ -3458,9 +4002,6 @@ type Diagnosis implements Node {
   # Age at the time of diagnosis expressed in number of days since birth.
   #
   age_at_diagnosis: Float
-
-  # keyword
-  hpv_positive_type: String
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
@@ -3519,9 +4060,6 @@ type Diagnosis implements Node {
   #
   prior_malignancy: String
 
-  # long
-  days_to_new_event: Float
-
   # Numeric value used to describe the non-peritonealised bare area of rectum,
   # comprising anterior and posterior segments, when submitted as a surgical
   # specimen resulting from excision of cancer of the rectum.
@@ -3554,8 +4092,14 @@ type Diagnosis implements Node {
   #
   year_of_diagnosis: Float
 
-  # long
-  progression_free_survival: Float
+  # The text term used to describe the secondary Gleason score, which describes
+  # the pattern of cells making up the second largest area of the tumor. The
+  # primary and secondary Gleason pattern grades are combined to determine the
+  # patient's Gleason grade group, which is used to determine the aggresiveness of
+  # prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  secondary_gleason_grade: String
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -3580,6 +4124,10 @@ type Diagnosis implements Node {
   #
   perineural_invasion_present: String
 
+  # The text term used to describe whether the patient's disease originated in a single location or multiple locations.
+  #
+  tumor_focality: String
+
   # The text term used to describe the classification of Wilms tumors
   # distinguishing between favorable and unfavorable histologic groups.
   #
@@ -3588,9 +4136,6 @@ type Diagnosis implements Node {
   # Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.
   #
   ajcc_clinical_t: String
-
-  # keyword
-  colon_polyps_history: String
 
   # Extent of the regional lymph node involvement for the cancer based on evidence
   # obtained from clinical assessment parameters determined prior to treatment.
@@ -3617,9 +4162,6 @@ type Diagnosis implements Node {
   # specifically describes the extent of the primary tumor prior to treatment.
   #
   cog_liver_stage: String
-
-  # keyword
-  progression_free_survival_event: String
 
   # Text term used to describe the stage of the musculoskeletal sarcoma, using the
   # Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).
@@ -3658,8 +4200,10 @@ type Diagnosis implements Node {
   #
   peripancreatic_lymph_nodes_tested: Float
 
-  # long
-  overall_survival: Float
+  # The text term used to describe the Masaoka staging system, a classification
+  # that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.
+  #
+  masaoka_stage: String
 
   # Text term that represents the component of the International Neuroblastoma
   # Pathology Classification (INPC) for mitosis-karyorrhexis index (MKI).
@@ -3684,9 +4228,6 @@ type Diagnosis implements Node {
   #
   esophageal_columnar_metaplasia_present: String
 
-  # keyword
-  new_event_anatomic_site: String
-
   # The best improvement achieved throughout the entire course of protocol treatment.
   #
   best_overall_response: String
@@ -3703,15 +4244,18 @@ type Diagnosis implements Node {
   #
   tumor_grade: String
 
+  # The text term used to describe the primary Gleason score, which describes the
+  # pattern of cells making up the largest area of the tumor. The primary and
+  # secondary Gleason pattern grades are combined to determine the patient's
+  # Gleason grade group, which is used to determine the aggresiveness of prostate
+  # cancer. Note that this grade describes the entire prostatectomy specimen and
+  # is not specific to the sample used for sequencing.
+  #
+  primary_gleason_grade: String
+
   # Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.
   #
   days_to_diagnosis: Float
-
-  # long
-  days_to_birth: Float
-
-  # keyword
-  hpv_status: String
 
   # The text term used to describe the version or edition of the American Joint
   # Committee on Cancer Staging Handbooks, a publication by the group formed for
@@ -3721,15 +4265,9 @@ type Diagnosis implements Node {
   #
   ajcc_staging_system_edition: String
 
-  # keyword
-  new_event_type: String
-
   # The text term used to describe the classification of medulloblastoma tumors based on molecular features.
   #
   medulloblastoma_molecular_classification: String
-
-  # long
-  ldh_normal_range_upper: Float
 
   # The text term used to describe the staging classification of renal tumors, as
   # defined by the Children's Oncology Group (COG).
@@ -3752,6 +4290,13 @@ type Diagnosis implements Node {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   site_of_resection_or_biopsy: String
+
+  # The text term used to describe the overall grouping of grades defined by the
+  # Gleason grading classification, which is used to determine the aggressiveness
+  # of prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  gleason_grade_group: String
   score: Int
 }
 
@@ -4024,10 +4569,6 @@ type ECaseAggregations {
   diagnoses__age_at_diagnosis: NumericAggregations
   diagnoses__hpv_positive_type: Aggregations
 
-  # The survival state of the person registered on the protocol.
-  #
-  diagnoses__vital_status: Aggregations
-
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
   # for coding the site (topography) and the histology (morphology) of neoplasms.
@@ -4038,7 +4579,11 @@ type ECaseAggregations {
   # immunocytochemical stains. A system of numbered categories for representation of data.
   #
   diagnoses__morphology: Aggregations
-  diagnoses__days_to_death: NumericAggregations
+
+  # The text term used to describe the clinical classification of lymphoma, as
+  # defined by the Ann Arbor Lymphoma Staging System.
+  #
+  diagnoses__ann_arbor_clinical_stage: Aggregations
   diagnoses__new_event_anatomic_site: Aggregations
 
   # Time interval from the date of last follow up to the date of initial
@@ -4095,10 +4640,9 @@ type ECaseAggregations {
   diagnoses__vascular_invasion_present: Aggregations
   diagnoses__ldh_level_at_diagnosis: NumericAggregations
 
-  # Time interval from the date of last follow up to the date of initial
-  # pathologic diagnosis, represented as a calculated number of days.
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
-  diagnoses__days_to_last_follow_up: NumericAggregations
+  diagnoses__created_datetime: Aggregations
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -4188,7 +4732,6 @@ type ECaseAggregations {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__tissue_or_organ_of_origin: Aggregations
-  diagnoses__days_to_birth: NumericAggregations
 
   # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
   #
@@ -4233,20 +4776,16 @@ type ECaseAggregations {
   #
   diagnoses__lymph_nodes_positive: NumericAggregations
 
-  # The text term used to describe the clinical classification of lymphoma, as
-  # defined by the Ann Arbor Lymphoma Staging System.
-  #
-  diagnoses__ann_arbor_clinical_stage: Aggregations
-
   # The text term used to describe the anatomic site of origin, of the patient's
   # malignant disease, as described by the World Health Organization's (WHO)
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__site_of_resection_or_biopsy: Aggregations
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # Time interval from the date of last follow up to the date of initial
+  # pathologic diagnosis, represented as a calculated number of days.
   #
-  diagnoses__created_datetime: Aggregations
+  diagnoses__days_to_last_follow_up: NumericAggregations
 
   # Stage group determined from clinical information on the tumor (T), regional
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
@@ -4275,6 +4814,8 @@ type ECaseAggregations {
   gene__symbol: Aggregations
   gene__gene_id: Aggregations
   gene__ssm__ncbi_build: Aggregations
+  gene__ssm__clinical_annotations__civic__gene_id: Aggregations
+  gene__ssm__clinical_annotations__civic__variant_id: Aggregations
   gene__ssm__observation__src_vcf_id: Aggregations
   gene__ssm__observation__mutation_status: Aggregations
   gene__ssm__observation__tumor_genotype__tumor_seq_allele1: Aggregations
@@ -4683,10 +5224,6 @@ type EDiagnosis implements Node {
   # keyword
   hpv_positive_type: String
 
-  # The survival state of the person registered on the protocol.
-  #
-  vital_status: String
-
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
   # for coding the site (topography) and the histology (morphology) of neoplasms.
@@ -4698,8 +5235,10 @@ type EDiagnosis implements Node {
   #
   morphology: String
 
-  # long
-  days_to_death: Float
+  # The text term used to describe the clinical classification of lymphoma, as
+  # defined by the Ann Arbor Lymphoma Staging System.
+  #
+  ann_arbor_clinical_stage: String
 
   # keyword
   new_event_anatomic_site: String
@@ -4764,10 +5303,9 @@ type EDiagnosis implements Node {
   # long
   ldh_level_at_diagnosis: Float
 
-  # Time interval from the date of last follow up to the date of initial
-  # pathologic diagnosis, represented as a calculated number of days.
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
-  days_to_last_follow_up: Float
+  created_datetime: String
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -4808,9 +5346,6 @@ type EDiagnosis implements Node {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   tissue_or_organ_of_origin: String
-
-  # long
-  days_to_birth: Float
 
   # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
   #
@@ -4863,20 +5398,16 @@ type EDiagnosis implements Node {
   #
   lymph_nodes_positive: Float
 
-  # The text term used to describe the clinical classification of lymphoma, as
-  # defined by the Ann Arbor Lymphoma Staging System.
-  #
-  ann_arbor_clinical_stage: String
-
   # The text term used to describe the anatomic site of origin, of the patient's
   # malignant disease, as described by the World Health Organization's (WHO)
   # International Classification of Diseases for Oncology (ICD-O).
   #
   site_of_resection_or_biopsy: String
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # Time interval from the date of last follow up to the date of initial
+  # pathologic diagnosis, represented as a calculated number of days.
   #
-  created_datetime: String
+  days_to_last_follow_up: Float
 
   # Stage group determined from clinical information on the tumor (T), regional
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
@@ -5247,10 +5778,6 @@ type Exposure implements Node {
   #
   cigarettes_per_day: Float
 
-  # The year in which the participant quit smoking.
-  #
-  tobacco_smoking_quit_year: Float
-
   # The weight of the patient measured in kilograms.
   #
   weight: Float
@@ -5258,19 +5785,6 @@ type Exposure implements Node {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   updated_datetime: String
-
-  # A response to a question that asks whether the participant has consumed at
-  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
-  #
-  alcohol_history: String
-
-  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
-  #
-  alcohol_intensity: String
-
-  # A calculated numerical quantity that represents an individual's weight to height ratio.
-  #
-  bmi: Float
 
   # Numeric value (or unknown) to represent the number of years a person has been smoking.
   #
@@ -5280,29 +5794,80 @@ type Exposure implements Node {
   #
   height: Float
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # smoke that is emitted from burning tobacco, including cigarettes, pipes, and
+  # cigars. This includes tobacco smoke exhaled by smokers.
   #
-  created_datetime: String
-
-  # The current state of the object.
-  #
-  state: String
+  environmental_tobacco_smoke_exposure: String
 
   # Category describing current smoking status and smoking history as self-reported by a patient.
   #
   tobacco_smoking_status: String
 
+  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  #
+  alcohol_days_per_week: Float
+
+  # Numeric computed value to represent lifetime tobacco exposure defined as
+  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  #
+  pack_years_smoked: Float
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposured
+  # to respirable crystalline silica, a widespread, naturally occurring,
+  # crystalline metal oxide that consists of different forms including quartz,
+  # cristobalite, tridymite, tripoli, ganister, chert and novaculite.
+  #
+  respirable_crystalline_silica_exposure: String
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # fine powder derived by the crushing of coal.
+  #
+  coal_dust_exposure: String
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  created_datetime: String
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.
+  #
+  asbestos_exposure: String
+
+  # The current state of the object.
+  #
+  state: String
+
+  # The text term used to describe the specific type of tobacco used by the patient.
+  #
+  type_of_tobacco_used: String
+
   # The year in which the participant began smoking.
   #
   tobacco_smoking_onset_year: Float
+
+  # A response to a question that asks whether the participant has consumed at
+  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
+  #
+  alcohol_history: String
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  bmi: Float
+
+  # The text term used to generally decribe how often the patient smokes.
+  #
+  smoking_frequency: String
 
   # Numeric value used to describe the average number of alcoholic beverages  a person consumes per day.
   #
   alcohol_drinks_per_day: Float
 
-  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  # The text term used to describe the patient's specific type of smoke exposure.
   #
-  alcohol_days_per_week: Float
+  type_of_smoke_exposure: String
+
+  # keyword
+  exposure_id: String
 
   # A project-specific identifier for a node. This property is the calling
   # card/nickname/alias for a unit of submission. It can be used in place of the
@@ -5310,13 +5875,23 @@ type Exposure implements Node {
   #
   submitter_id: String
 
-  # keyword
-  exposure_id: String
-
-  # Numeric computed value to represent lifetime tobacco exposure defined as
-  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
   #
-  pack_years_smoked: Float
+  alcohol_intensity: String
+
+  # The text term used to describe the approximate amount of time elapsed between
+  # the time the patient wakes up in the morning to the time they smoke their
+  # first cigarette.
+  #
+  time_between_waking_and_first_smoke: String
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to radon.
+  #
+  radon_exposure: String
+
+  # The year in which the participant quit smoking.
+  #
+  tobacco_smoking_quit_year: Float
   score: Int
 }
 
@@ -5427,8 +6002,8 @@ type File implements Node {
   # keyword
   origin: String
 
-  # long
-  proportion_base_mismatch: Float
+  # keyword
+  chip_id: String
 
   # keyword
   file_name: String
@@ -5464,9 +6039,6 @@ type File implements Node {
   state: String
 
   # keyword
-  release_number: String
-
-  # keyword
   access: String
 
   # keyword
@@ -5475,26 +6047,41 @@ type File implements Node {
   # long
   magnification: Float
 
-  # keyword
-  version: String
-
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
   # keyword
   type: String
+
+  # keyword
+  channel: String
 
   # long
   revision: Float
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
+
+  # long
+  proportion_base_mismatch: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -5506,16 +6093,16 @@ type File implements Node {
   state_comment: String
 
   # keyword
-  data_format: String
+  plate_well: String
 
   # keyword
-  baseid: String
+  data_format: String
 
   # keyword
   md5sum: String
 
   # keyword
-  updated_datetime: String
+  plate_name: String
 
   # long
   mean_coverage: Float
@@ -5553,9 +6140,9 @@ type File implements Node {
 
 type FileAggregations {
   origin: Aggregations
-  proportion_base_mismatch: NumericAggregations
+  chip_id: Aggregations
+  index_files__chip_id: Aggregations
   index_files__proportion_base_mismatch: NumericAggregations
-  index_files__updated_datetime: Aggregations
   index_files__file_name: Aggregations
   index_files__submitter_id: Aggregations
   index_files__read_pair_number: Aggregations
@@ -5572,14 +6159,21 @@ type FileAggregations {
   index_files__magnification: NumericAggregations
   index_files__mean_coverage: NumericAggregations
   index_files__average_read_length: NumericAggregations
+  index_files__contamination_error: NumericAggregations
+  index_files__channel: Aggregations
   index_files__experimental_strategy: Aggregations
+  index_files__updated_datetime: Aggregations
   index_files__data_type: Aggregations
+  index_files__chip_position: Aggregations
   index_files__proportion_coverage_10X: NumericAggregations
   index_files__file_id: Aggregations
+  index_files__contamination: NumericAggregations
   index_files__proportion_reads_duplicated: NumericAggregations
   index_files__total_reads: NumericAggregations
   index_files__state_comment: Aggregations
+  index_files__plate_well: Aggregations
   index_files__md5sum: Aggregations
+  index_files__plate_name: Aggregations
   index_files__data_format: Aggregations
   index_files__proportion_reads_mapped: NumericAggregations
   index_files__proportion_targets_no_coverage: NumericAggregations
@@ -5598,8 +6192,8 @@ type FileAggregations {
   downstream_analyses__workflow_type: Aggregations
   downstream_analyses__workflow_start_datetime: Aggregations
   downstream_analyses__workflow_version: Aggregations
+  downstream_analyses__output_files__chip_id: Aggregations
   downstream_analyses__output_files__proportion_base_mismatch: NumericAggregations
-  downstream_analyses__output_files__updated_datetime: Aggregations
   downstream_analyses__output_files__file_name: Aggregations
   downstream_analyses__output_files__submitter_id: Aggregations
   downstream_analyses__output_files__read_pair_number: Aggregations
@@ -5616,14 +6210,21 @@ type FileAggregations {
   downstream_analyses__output_files__magnification: NumericAggregations
   downstream_analyses__output_files__mean_coverage: NumericAggregations
   downstream_analyses__output_files__average_read_length: NumericAggregations
+  downstream_analyses__output_files__contamination_error: NumericAggregations
+  downstream_analyses__output_files__channel: Aggregations
   downstream_analyses__output_files__experimental_strategy: Aggregations
+  downstream_analyses__output_files__updated_datetime: Aggregations
   downstream_analyses__output_files__data_type: Aggregations
+  downstream_analyses__output_files__chip_position: Aggregations
   downstream_analyses__output_files__proportion_coverage_10X: NumericAggregations
   downstream_analyses__output_files__file_id: Aggregations
+  downstream_analyses__output_files__contamination: NumericAggregations
   downstream_analyses__output_files__proportion_reads_duplicated: NumericAggregations
   downstream_analyses__output_files__total_reads: NumericAggregations
   downstream_analyses__output_files__state_comment: Aggregations
+  downstream_analyses__output_files__plate_well: Aggregations
   downstream_analyses__output_files__md5sum: Aggregations
+  downstream_analyses__output_files__plate_name: Aggregations
   downstream_analyses__output_files__data_format: Aggregations
   downstream_analyses__output_files__proportion_reads_mapped: NumericAggregations
   downstream_analyses__output_files__proportion_targets_no_coverage: NumericAggregations
@@ -5694,11 +6295,9 @@ type FileAggregations {
   imaging_date: Aggregations
   error_type: Aggregations
   state: Aggregations
-  release_number: Aggregations
   access: Aggregations
   platform: Aggregations
   magnification: NumericAggregations
-  version: Aggregations
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
@@ -5744,6 +6343,7 @@ type FileAggregations {
   #
   metadata_files__state_comment: Aggregations
   average_read_length: NumericAggregations
+  contamination_error: NumericAggregations
   type: Aggregations
 
   # Status of the annotation.
@@ -5792,11 +6392,16 @@ type FileAggregations {
 
   # Top level characterization of the annotation.
   annotations__category: Aggregations
+  channel: Aggregations
   revision: NumericAggregations
+  updated_datetime: Aggregations
   data_type: Aggregations
   tags: Aggregations
+  chip_position: Aggregations
   proportion_coverage_10X: NumericAggregations
   file_id: Aggregations
+  contamination: NumericAggregations
+  proportion_base_mismatch: NumericAggregations
   proportion_reads_duplicated: NumericAggregations
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
@@ -5846,13 +6451,13 @@ type FileAggregations {
   cases__case_id: Aggregations
   cases__samples__sample_type_id: Aggregations
   cases__samples__updated_datetime: Aggregations
-  cases__samples__time_between_excision_and_freezing: Aggregations
+  cases__samples__time_between_excision_and_freezing: NumericAggregations
   cases__samples__oct_embedded: Aggregations
   cases__samples__tumor_code_id: Aggregations
   cases__samples__submitter_id: Aggregations
-  cases__samples__intermediate_dimension: Aggregations
+  cases__samples__intermediate_dimension: NumericAggregations
   cases__samples__sample_id: Aggregations
-  cases__samples__time_between_clamping_and_freezing: Aggregations
+  cases__samples__time_between_clamping_and_freezing: NumericAggregations
   cases__samples__pathology_report_uuid: Aggregations
   cases__samples__created_datetime: Aggregations
   cases__samples__tumor_descriptor: Aggregations
@@ -5882,7 +6487,7 @@ type FileAggregations {
   cases__samples__annotations__category: Aggregations
   cases__samples__is_ffpe: Aggregations
   cases__samples__distributor_reference: Aggregations
-  cases__samples__shortest_dimension: Aggregations
+  cases__samples__shortest_dimension: NumericAggregations
   cases__samples__method_of_sample_procurement: Aggregations
   cases__samples__tumor_code: Aggregations
   cases__samples__passage_count: NumericAggregations
@@ -6038,7 +6643,7 @@ type FileAggregations {
   cases__samples__days_to_collection: NumericAggregations
   cases__samples__catalog_reference: Aggregations
   cases__samples__initial_weight: NumericAggregations
-  cases__samples__longest_dimension: Aggregations
+  cases__samples__longest_dimension: NumericAggregations
   cases__submitter_sample_ids: Aggregations
   cases__annotations__status: Aggregations
   cases__annotations__legacy_updated_datetime: Aggregations
@@ -6058,23 +6663,109 @@ type FileAggregations {
   cases__annotations__case_submitter_id: Aggregations
   cases__annotations__category: Aggregations
   cases__exposures__cigarettes_per_day: NumericAggregations
-  cases__exposures__tobacco_smoking_quit_year: NumericAggregations
   cases__exposures__weight: NumericAggregations
   cases__exposures__updated_datetime: Aggregations
-  cases__exposures__alcohol_history: Aggregations
-  cases__exposures__alcohol_intensity: Aggregations
-  cases__exposures__bmi: NumericAggregations
   cases__exposures__years_smoked: NumericAggregations
   cases__exposures__height: NumericAggregations
-  cases__exposures__created_datetime: Aggregations
-  cases__exposures__state: Aggregations
+  cases__exposures__environmental_tobacco_smoke_exposure: Aggregations
   cases__exposures__tobacco_smoking_status: Aggregations
-  cases__exposures__tobacco_smoking_onset_year: NumericAggregations
-  cases__exposures__alcohol_drinks_per_day: NumericAggregations
   cases__exposures__alcohol_days_per_week: NumericAggregations
-  cases__exposures__submitter_id: Aggregations
-  cases__exposures__exposure_id: Aggregations
   cases__exposures__pack_years_smoked: NumericAggregations
+  cases__exposures__respirable_crystalline_silica_exposure: Aggregations
+  cases__exposures__coal_dust_exposure: Aggregations
+  cases__exposures__created_datetime: Aggregations
+  cases__exposures__asbestos_exposure: Aggregations
+  cases__exposures__state: Aggregations
+  cases__exposures__type_of_tobacco_used: Aggregations
+  cases__exposures__tobacco_smoking_onset_year: NumericAggregations
+  cases__exposures__alcohol_history: Aggregations
+  cases__exposures__bmi: NumericAggregations
+  cases__exposures__smoking_frequency: Aggregations
+  cases__exposures__alcohol_drinks_per_day: NumericAggregations
+  cases__exposures__type_of_smoke_exposure: Aggregations
+  cases__exposures__exposure_id: Aggregations
+  cases__exposures__submitter_id: Aggregations
+  cases__exposures__alcohol_intensity: Aggregations
+  cases__exposures__time_between_waking_and_first_smoke: Aggregations
+  cases__exposures__radon_exposure: Aggregations
+  cases__exposures__tobacco_smoking_quit_year: NumericAggregations
+  cases__follow_ups__fev1_ref_post_bronch_percent: NumericAggregations
+  cases__follow_ups__weight: NumericAggregations
+  cases__follow_ups__reflux_treatment_type: Aggregations
+  cases__follow_ups__progression_or_recurrence_type: Aggregations
+  cases__follow_ups__height: NumericAggregations
+  cases__follow_ups__days_to_adverse_event: NumericAggregations
+  cases__follow_ups__cause_of_response: Aggregations
+  cases__follow_ups__fev1_fvc_pre_bronch_percent: NumericAggregations
+  cases__follow_ups__ecog_performance_status: Aggregations
+  cases__follow_ups__hpv_positive_type: Aggregations
+  cases__follow_ups__days_to_progression_free: NumericAggregations
+  cases__follow_ups__days_to_follow_up: NumericAggregations
+  cases__follow_ups__fev1_fvc_post_bronch_percent: NumericAggregations
+  cases__follow_ups__comorbidity_method_of_diagnosis: Aggregations
+  cases__follow_ups__dlco_ref_predictive_percent: NumericAggregations
+  cases__follow_ups__comorbidity: Aggregations
+  cases__follow_ups__updated_datetime: Aggregations
+  cases__follow_ups__risk_factor: Aggregations
+  cases__follow_ups__state: Aggregations
+  cases__follow_ups__days_to_progression: NumericAggregations
+  cases__follow_ups__adverse_event: Aggregations
+  cases__follow_ups__days_to_recurrence: NumericAggregations
+  cases__follow_ups__molecular_tests__mismatch_repair_mutation: Aggregations
+  cases__follow_ups__molecular_tests__updated_datetime: Aggregations
+  cases__follow_ups__molecular_tests__antigen: Aggregations
+  cases__follow_ups__molecular_tests__variant_origin: Aggregations
+  cases__follow_ups__molecular_tests__blood_test_normal_range_lower: NumericAggregations
+  cases__follow_ups__molecular_tests__locus: Aggregations
+  cases__follow_ups__molecular_tests__test_value: NumericAggregations
+  cases__follow_ups__molecular_tests__second_gene_symbol: Aggregations
+  cases__follow_ups__molecular_tests__ploidy: Aggregations
+  cases__follow_ups__molecular_tests__chromosome: Aggregations
+  cases__follow_ups__molecular_tests__specialized_molecular_test: Aggregations
+  cases__follow_ups__molecular_tests__created_datetime: Aggregations
+  cases__follow_ups__molecular_tests__intron: Aggregations
+  cases__follow_ups__molecular_tests__gene_symbol: Aggregations
+  cases__follow_ups__molecular_tests__state: Aggregations
+  cases__follow_ups__molecular_tests__histone_variant: Aggregations
+  cases__follow_ups__molecular_tests__cell_count: NumericAggregations
+  cases__follow_ups__molecular_tests__histone_family: Aggregations
+  cases__follow_ups__molecular_tests__copy_number: NumericAggregations
+  cases__follow_ups__molecular_tests__test_analyte_type: Aggregations
+  cases__follow_ups__molecular_tests__exon: Aggregations
+  cases__follow_ups__molecular_tests__laboratory_test: Aggregations
+  cases__follow_ups__molecular_tests__test_result: Aggregations
+  cases__follow_ups__molecular_tests__transcript: Aggregations
+  cases__follow_ups__molecular_tests__blood_test_normal_range_upper: NumericAggregations
+  cases__follow_ups__molecular_tests__test_units: Aggregations
+  cases__follow_ups__molecular_tests__zygosity: Aggregations
+  cases__follow_ups__molecular_tests__cytoband: Aggregations
+  cases__follow_ups__molecular_tests__biospecimen_type: Aggregations
+  cases__follow_ups__molecular_tests__submitter_id: Aggregations
+  cases__follow_ups__molecular_tests__second_exon: Aggregations
+  cases__follow_ups__molecular_tests__molecular_test_id: Aggregations
+  cases__follow_ups__molecular_tests__molecular_analysis_method: Aggregations
+  cases__follow_ups__molecular_tests__molecular_consequence: Aggregations
+  cases__follow_ups__molecular_tests__variant_type: Aggregations
+  cases__follow_ups__molecular_tests__loci_abnormal_count: NumericAggregations
+  cases__follow_ups__molecular_tests__aa_change: Aggregations
+  cases__follow_ups__molecular_tests__loci_count: NumericAggregations
+  cases__follow_ups__bmi: NumericAggregations
+  cases__follow_ups__menopause_status: Aggregations
+  cases__follow_ups__progression_or_recurrence: Aggregations
+  cases__follow_ups__diabetes_treatment_type: Aggregations
+  cases__follow_ups__risk_factor_treatment: Aggregations
+  cases__follow_ups__progression_or_recurrence_anatomic_site: Aggregations
+  cases__follow_ups__submitter_id: Aggregations
+  cases__follow_ups__barretts_esophagus_goblet_cells_present: Aggregations
+  cases__follow_ups__disease_response: Aggregations
+  cases__follow_ups__follow_up_id: Aggregations
+  cases__follow_ups__pancreatitis_onset_year: NumericAggregations
+  cases__follow_ups__viral_hepatitis_serologies: Aggregations
+  cases__follow_ups__fev1_ref_pre_bronch_percent: NumericAggregations
+  cases__follow_ups__created_datetime: Aggregations
+  cases__follow_ups__karnofsky_performance_status: Aggregations
+  cases__follow_ups__hepatitis_sustained_virological_response: Aggregations
+  cases__follow_ups__days_to_comorbidity: NumericAggregations
 
   # The text term used to describe the reference or anchor date used when for date
   # obfuscation, where a single date is obscurred by creating one or more date
@@ -6097,44 +6788,48 @@ type FileAggregations {
   # UUID for identifying or recalling a node.
   #
   cases__submitter_id: Aggregations
+
+  # The text term used to describe the type of malignant disease, as categorized
+  # by the World Health Organization's (WHO) International Classification of
+  # Diseases for Oncology (ICD-O).
+  #
+  cases__disease_type: Aggregations
   cases__diagnoses__vascular_invasion_type: Aggregations
   cases__diagnoses__method_of_diagnosis: Aggregations
   cases__diagnoses__laterality: Aggregations
   cases__diagnoses__ann_arbor_pathologic_stage: Aggregations
   cases__diagnoses__inrg_stage: Aggregations
   cases__diagnoses__submitter_id: Aggregations
-  cases__diagnoses__vital_status: Aggregations
+  cases__diagnoses__metastasis_at_diagnosis: Aggregations
   cases__diagnoses__morphology: Aggregations
-  cases__diagnoses__days_to_death: NumericAggregations
   cases__diagnoses__days_to_last_known_disease_status: NumericAggregations
   cases__diagnoses__cog_rhabdomyosarcoma_risk_group: Aggregations
-  cases__diagnoses__days_to_hiv_diagnosis: NumericAggregations
   cases__diagnoses__ajcc_pathologic_t: Aggregations
   cases__diagnoses__prior_treatment: Aggregations
   cases__diagnoses__irs_group: Aggregations
   cases__diagnoses__ajcc_pathologic_m: Aggregations
   cases__diagnoses__ajcc_pathologic_n: Aggregations
+  cases__diagnoses__weiss_assessment_score: Aggregations
   cases__diagnoses__enneking_msts_metastasis: Aggregations
   cases__diagnoses__esophageal_columnar_dysplasia_degree: Aggregations
+  cases__diagnoses__lymph_nodes_tested: NumericAggregations
   cases__diagnoses__ishak_fibrosis_score: Aggregations
   cases__diagnoses__lymphatic_invasion_present: Aggregations
   cases__diagnoses__supratentorial_localization: Aggregations
+  cases__diagnoses__igcccg_stage: Aggregations
   cases__diagnoses__gastric_esophageal_junction_involvement: Aggregations
   cases__diagnoses__goblet_cells_columnar_mucosa_present: Aggregations
   cases__diagnoses__iss_stage: Aggregations
-  cases__diagnoses__cause_of_death: Aggregations
   cases__diagnoses__enneking_msts_tumor_site: Aggregations
+  cases__diagnoses__tumor_regression_grade: Aggregations
   cases__diagnoses__gross_tumor_weight: NumericAggregations
   cases__diagnoses__ajcc_clinical_stage: Aggregations
-  cases__diagnoses__hiv_positive: Aggregations
   cases__diagnoses__ann_arbor_b_symptoms: Aggregations
   cases__diagnoses__cog_neuroblastoma_risk_group: Aggregations
   cases__diagnoses__updated_datetime: Aggregations
-  cases__diagnoses__metastasis_at_diagnosis: Aggregations
   cases__diagnoses__days_to_best_overall_response: NumericAggregations
   cases__diagnoses__tumor_stage: Aggregations
   cases__diagnoses__age_at_diagnosis: NumericAggregations
-  cases__diagnoses__hpv_positive_type: Aggregations
   cases__diagnoses__created_datetime: Aggregations
   cases__diagnoses__enneking_msts_grade: Aggregations
   cases__diagnoses__state: Aggregations
@@ -6147,28 +6842,43 @@ type FileAggregations {
   cases__diagnoses__tissue_or_organ_of_origin: Aggregations
   cases__diagnoses__peripancreatic_lymph_nodes_positive: Aggregations
   cases__diagnoses__prior_malignancy: Aggregations
-  cases__diagnoses__days_to_new_event: NumericAggregations
   cases__diagnoses__circumferential_resection_margin: NumericAggregations
   cases__diagnoses__lymph_nodes_positive: NumericAggregations
   cases__diagnoses__days_to_last_follow_up: NumericAggregations
   cases__diagnoses__inss_stage: Aggregations
   cases__diagnoses__inpc_histologic_group: Aggregations
   cases__diagnoses__year_of_diagnosis: NumericAggregations
-  cases__diagnoses__progression_free_survival: NumericAggregations
+  cases__diagnoses__secondary_gleason_grade: Aggregations
   cases__diagnoses__residual_disease: Aggregations
   cases__diagnoses__anaplasia_present: Aggregations
   cases__diagnoses__ann_arbor_clinical_stage: Aggregations
   cases__diagnoses__tumor_confined_to_organ_of_origin: Aggregations
   cases__diagnoses__perineural_invasion_present: Aggregations
+  cases__diagnoses__tumor_focality: Aggregations
   cases__diagnoses__wilms_tumor_histologic_subtype: Aggregations
   cases__diagnoses__ajcc_clinical_t: Aggregations
-  cases__diagnoses__colon_polyps_history: Aggregations
   cases__diagnoses__ajcc_clinical_n: Aggregations
   cases__diagnoses__ajcc_clinical_m: Aggregations
   cases__diagnoses__irs_stage: Aggregations
   cases__diagnoses__first_symptom_prior_to_diagnosis: Aggregations
   cases__diagnoses__cog_liver_stage: Aggregations
-  cases__diagnoses__progression_free_survival_event: Aggregations
+  cases__diagnoses__annotations__status: Aggregations
+  cases__diagnoses__annotations__legacy_updated_datetime: Aggregations
+  cases__diagnoses__annotations__entity_id: Aggregations
+  cases__diagnoses__annotations__classification: Aggregations
+  cases__diagnoses__annotations__creator: Aggregations
+  cases__diagnoses__annotations__created_datetime: Aggregations
+  cases__diagnoses__annotations__entity_submitter_id: Aggregations
+  cases__diagnoses__annotations__notes: Aggregations
+  cases__diagnoses__annotations__entity_type: Aggregations
+  cases__diagnoses__annotations__updated_datetime: Aggregations
+  cases__diagnoses__annotations__legacy_created_datetime: Aggregations
+  cases__diagnoses__annotations__state: Aggregations
+  cases__diagnoses__annotations__case_id: Aggregations
+  cases__diagnoses__annotations__submitter_id: Aggregations
+  cases__diagnoses__annotations__annotation_id: Aggregations
+  cases__diagnoses__annotations__case_submitter_id: Aggregations
+  cases__diagnoses__annotations__category: Aggregations
   cases__diagnoses__enneking_msts_stage: Aggregations
   cases__diagnoses__icd_10_code: Aggregations
   cases__diagnoses__inpc_grade: Aggregations
@@ -6177,17 +6887,17 @@ type FileAggregations {
   cases__diagnoses__burkitt_lymphoma_clinical_variant: Aggregations
   cases__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   cases__diagnoses__peripancreatic_lymph_nodes_tested: NumericAggregations
-  cases__diagnoses__overall_survival: NumericAggregations
+  cases__diagnoses__masaoka_stage: Aggregations
   cases__diagnoses__mitosis_karyorrhexis_index: Aggregations
   cases__diagnoses__classification_of_tumor: Aggregations
   cases__diagnoses__last_known_disease_status: Aggregations
   cases__diagnoses__primary_diagnosis: Aggregations
   cases__diagnoses__esophageal_columnar_metaplasia_present: Aggregations
-  cases__diagnoses__new_event_anatomic_site: Aggregations
   cases__diagnoses__best_overall_response: Aggregations
   cases__diagnoses__vascular_invasion_present: Aggregations
   cases__diagnoses__micropapillary_features: Aggregations
   cases__diagnoses__tumor_grade: Aggregations
+  cases__diagnoses__primary_gleason_grade: Aggregations
   cases__diagnoses__treatments__days_to_treatment_start: NumericAggregations
   cases__diagnoses__treatments__updated_datetime: Aggregations
   cases__diagnoses__treatments__created_datetime: Aggregations
@@ -6195,6 +6905,7 @@ type FileAggregations {
   cases__diagnoses__treatments__treatment_type: Aggregations
   cases__diagnoses__treatments__submitter_id: Aggregations
   cases__diagnoses__treatments__treatment_id: Aggregations
+  cases__diagnoses__treatments__treatment_effect: Aggregations
   cases__diagnoses__treatments__state: Aggregations
   cases__diagnoses__treatments__therapeutic_agents: Aggregations
   cases__diagnoses__treatments__regimen_or_line_of_therapy: Aggregations
@@ -6204,22 +6915,14 @@ type FileAggregations {
   cases__diagnoses__treatments__days_to_treatment_end: NumericAggregations
   cases__diagnoses__treatments__treatment_or_therapy: Aggregations
   cases__diagnoses__days_to_diagnosis: NumericAggregations
-  cases__diagnoses__days_to_birth: NumericAggregations
-  cases__diagnoses__hpv_status: Aggregations
   cases__diagnoses__ajcc_staging_system_edition: Aggregations
-  cases__diagnoses__new_event_type: Aggregations
   cases__diagnoses__medulloblastoma_molecular_classification: Aggregations
-  cases__diagnoses__ldh_normal_range_upper: NumericAggregations
   cases__diagnoses__cog_renal_stage: Aggregations
   cases__diagnoses__synchronous_malignancy: Aggregations
   cases__diagnoses__metastasis_at_diagnosis_site: Aggregations
   cases__diagnoses__site_of_resection_or_biopsy: Aggregations
-
-  # The text term used to describe the type of malignant disease, as categorized
-  # by the World Health Organization's (WHO) International Classification of
-  # Diseases for Oncology (ICD-O).
-  #
-  cases__disease_type: Aggregations
+  cases__diagnoses__gleason_grade_group: Aggregations
+  cases__diagnosis_ids: Aggregations
   cases__submitter_aliquot_ids: Aggregations
   cases__summary__data_categories__file_count: NumericAggregations
   cases__summary__data_categories__data_category: Aggregations
@@ -6248,6 +6951,7 @@ type FileAggregations {
   # specific primary sites of disease.
   #
   cases__primary_site: Aggregations
+  cases__submitter_diagnosis_ids: Aggregations
   cases__tissue_source_site__project: Aggregations
   cases__tissue_source_site__bcr_id: Aggregations
   cases__tissue_source_site__code: Aggregations
@@ -6256,6 +6960,7 @@ type FileAggregations {
   cases__submitter_slide_ids: Aggregations
   total_reads: NumericAggregations
   state_comment: Aggregations
+  plate_well: Aggregations
   data_format: Aggregations
 
   # Numeric code for the center.
@@ -6273,15 +6978,14 @@ type FileAggregations {
 
   # Type classification of the center (e.g. CGCC).
   center__center_type: Aggregations
-  baseid: Aggregations
   md5sum: Aggregations
-  updated_datetime: Aggregations
+  plate_name: Aggregations
   mean_coverage: NumericAggregations
   analysis__analysis_id: Aggregations
   analysis__updated_datetime: Aggregations
   analysis__created_datetime: Aggregations
+  analysis__input_files__chip_id: Aggregations
   analysis__input_files__proportion_base_mismatch: NumericAggregations
-  analysis__input_files__updated_datetime: Aggregations
   analysis__input_files__file_name: Aggregations
   analysis__input_files__submitter_id: Aggregations
   analysis__input_files__read_pair_number: Aggregations
@@ -6298,14 +7002,21 @@ type FileAggregations {
   analysis__input_files__magnification: NumericAggregations
   analysis__input_files__mean_coverage: NumericAggregations
   analysis__input_files__average_read_length: NumericAggregations
+  analysis__input_files__contamination_error: NumericAggregations
+  analysis__input_files__channel: Aggregations
   analysis__input_files__experimental_strategy: Aggregations
+  analysis__input_files__updated_datetime: Aggregations
   analysis__input_files__data_type: Aggregations
+  analysis__input_files__chip_position: Aggregations
   analysis__input_files__proportion_coverage_10X: NumericAggregations
   analysis__input_files__file_id: Aggregations
+  analysis__input_files__contamination: NumericAggregations
   analysis__input_files__proportion_reads_duplicated: NumericAggregations
   analysis__input_files__total_reads: NumericAggregations
   analysis__input_files__state_comment: Aggregations
+  analysis__input_files__plate_well: Aggregations
   analysis__input_files__md5sum: Aggregations
+  analysis__input_files__plate_name: Aggregations
   analysis__input_files__data_format: Aggregations
   analysis__input_files__proportion_reads_mapped: NumericAggregations
   analysis__input_files__proportion_targets_no_coverage: NumericAggregations
@@ -6601,6 +7312,9 @@ type FileCase implements Node {
   disease_type: String
 
   # keyword
+  diagnosis_ids: String
+
+  # keyword
   submitter_aliquot_ids: String
 
   # keyword
@@ -6613,6 +7327,9 @@ type FileCase implements Node {
   # specific primary sites of disease.
   #
   primary_site: String
+
+  # keyword
+  submitter_diagnosis_ids: String
 
   # keyword
   submitter_slide_ids: String
@@ -6801,9 +7518,8 @@ type GeneAggregations {
   case__diagnoses__tumor_stage: Aggregations
   case__diagnoses__age_at_diagnosis: NumericAggregations
   case__diagnoses__hpv_positive_type: Aggregations
-  case__diagnoses__vital_status: Aggregations
   case__diagnoses__morphology: Aggregations
-  case__diagnoses__days_to_death: NumericAggregations
+  case__diagnoses__ann_arbor_clinical_stage: Aggregations
   case__diagnoses__new_event_anatomic_site: Aggregations
   case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   case__diagnoses__perineural_invasion_present: Aggregations
@@ -6818,7 +7534,7 @@ type GeneAggregations {
   case__diagnoses__ajcc_pathologic_n: Aggregations
   case__diagnoses__vascular_invasion_present: Aggregations
   case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  case__diagnoses__days_to_last_follow_up: NumericAggregations
+  case__diagnoses__created_datetime: Aggregations
   case__diagnoses__residual_disease: Aggregations
   case__diagnoses__days_to_recurrence: NumericAggregations
   case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -6841,7 +7557,6 @@ type GeneAggregations {
   case__diagnoses__treatments__treatment_or_therapy: Aggregations
   case__diagnoses__lymphatic_invasion_present: Aggregations
   case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  case__diagnoses__days_to_birth: NumericAggregations
   case__diagnoses__progression_or_recurrence: Aggregations
   case__diagnoses__hpv_status: Aggregations
   case__diagnoses__prior_malignancy: Aggregations
@@ -6854,9 +7569,8 @@ type GeneAggregations {
   case__diagnoses__ldh_normal_range_upper: NumericAggregations
   case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   case__diagnoses__lymph_nodes_positive: NumericAggregations
-  case__diagnoses__ann_arbor_clinical_stage: Aggregations
   case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  case__diagnoses__created_datetime: Aggregations
+  case__diagnoses__days_to_last_follow_up: NumericAggregations
   case__diagnoses__ajcc_clinical_stage: Aggregations
   case__diagnoses__days_to_new_event: NumericAggregations
   case__diagnoses__hiv_positive: Aggregations
@@ -6872,11 +7586,16 @@ type GeneAggregations {
   case__demographic__demographic_id: Aggregations
   case__demographic__state: Aggregations
   case__demographic__race: Aggregations
+  case__demographic__days_to_birth: NumericAggregations
+  case__demographic__vital_status: Aggregations
+  case__demographic__days_to_death: NumericAggregations
   case__demographic__submitter_id: Aggregations
   case__demographic__ethnicity: Aggregations
   case__demographic__year_of_death: NumericAggregations
   case__submitter_id: Aggregations
   case__ssm__ncbi_build: Aggregations
+  case__ssm__clinical_annotations__civic__gene_id: Aggregations
+  case__ssm__clinical_annotations__civic__variant_id: Aggregations
   case__ssm__observation__src_vcf_id: Aggregations
   case__ssm__observation__mutation_status: Aggregations
   case__ssm__observation__tumor_genotype__tumor_seq_allele1: Aggregations
@@ -7139,11 +7858,11 @@ type Genes {
 type IndexFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7193,17 +7912,32 @@ type IndexFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7215,7 +7949,13 @@ type IndexFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7272,11 +8012,11 @@ type InputBamFile {
 type InputFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7326,17 +8066,32 @@ type InputFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7348,7 +8103,13 @@ type InputFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7509,6 +8270,8 @@ interface Node {
 type NumericAggregations {
   stats: Stats
   histogram(interval: Float): Aggregations
+  percentiles: Percentiles
+  range(ranges: FiltersArgument): Aggregations
 }
 
 enum Order {
@@ -7519,11 +8282,11 @@ enum Order {
 type OutputFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7573,17 +8336,32 @@ type OutputFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7595,7 +8373,13 @@ type OutputFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7652,6 +8436,13 @@ type PageInfo {
 
   # When paginating forwards, the cursor to continue.
   endCursor: String
+}
+
+type Percentiles {
+  quartile_1: Float
+  quartile_3: Float
+  median: Float
+  iqr: Float
 }
 
 type Portion implements Node {
@@ -8229,7 +9020,7 @@ type Sample implements Node {
 
   # Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.
   #
-  time_between_excision_and_freezing: String
+  time_between_excision_and_freezing: Float
 
   # Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.
   #
@@ -8244,7 +9035,7 @@ type Sample implements Node {
   # UUID for identifying or recalling a node.
   #
   submitter_id: String
-  intermediate_dimension: String
+  intermediate_dimension: Float
 
   # keyword
   sample_id: String
@@ -8252,7 +9043,7 @@ type Sample implements Node {
   # Numeric representation of the elapsed time between the surgical clamping of
   # blood supply and freezing of the sample, measured in minutes.
   #
-  time_between_clamping_and_freezing: String
+  time_between_clamping_and_freezing: Float
 
   # UUID of the related pathology report.
   pathology_report_uuid: String
@@ -8301,7 +9092,7 @@ type Sample implements Node {
 
   # Numeric value that represents the shortest dimension of the sample, measured in millimeters.
   #
-  shortest_dimension: String
+  shortest_dimension: Float
 
   # The method used to procure the sample used to extract analyte(s).
   #
@@ -8352,7 +9143,7 @@ type Sample implements Node {
   # Numeric value that represents the initial weight of the sample, measured in milligrams.
   #
   initial_weight: Float
-  longest_dimension: String
+  longest_dimension: Float
   score: Int
 }
 
@@ -8506,9 +9297,6 @@ type Ssm implements Node {
   ncbi_build: String
 
   # keyword
-  mutation_type: String
-
-  # keyword
   mutation_subtype: String
 
   # long
@@ -8530,21 +9318,26 @@ type Ssm implements Node {
   tumor_allele: String
 
   # keyword
+  mutation_type: String
+
+  # keyword
   chromosome: String
 
   # keyword
   genomic_dna_change: String
-  external_db_ids: SsmGeneExternalDbIds
+  clinical_annotations: ClinicalAnnotations
   consequence: SSMConsequences
-  occurrence: SSMOccurrences
   cosmic_id: [String]
+  external_db_ids: SsmGeneExternalDbIds
   gene_aa_change: [String]
+  occurrence: SSMOccurrences
   score: Int
 }
 
 type SsmAggregations {
   ncbi_build: Aggregations
-  mutation_type: Aggregations
+  clinical_annotations__civic__gene_id: Aggregations
+  clinical_annotations__civic__variant_id: Aggregations
   occurrence__case__exposures__cigarettes_per_day: NumericAggregations
   occurrence__case__exposures__weight: NumericAggregations
   occurrence__case__exposures__updated_datetime: Aggregations
@@ -8574,9 +9367,8 @@ type SsmAggregations {
   occurrence__case__diagnoses__tumor_stage: Aggregations
   occurrence__case__diagnoses__age_at_diagnosis: NumericAggregations
   occurrence__case__diagnoses__hpv_positive_type: Aggregations
-  occurrence__case__diagnoses__vital_status: Aggregations
   occurrence__case__diagnoses__morphology: Aggregations
-  occurrence__case__diagnoses__days_to_death: NumericAggregations
+  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__new_event_anatomic_site: Aggregations
   occurrence__case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   occurrence__case__diagnoses__perineural_invasion_present: Aggregations
@@ -8591,7 +9383,7 @@ type SsmAggregations {
   occurrence__case__diagnoses__ajcc_pathologic_n: Aggregations
   occurrence__case__diagnoses__vascular_invasion_present: Aggregations
   occurrence__case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
+  occurrence__case__diagnoses__created_datetime: Aggregations
   occurrence__case__diagnoses__residual_disease: Aggregations
   occurrence__case__diagnoses__days_to_recurrence: NumericAggregations
   occurrence__case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -8614,7 +9406,6 @@ type SsmAggregations {
   occurrence__case__diagnoses__treatments__treatment_or_therapy: Aggregations
   occurrence__case__diagnoses__lymphatic_invasion_present: Aggregations
   occurrence__case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  occurrence__case__diagnoses__days_to_birth: NumericAggregations
   occurrence__case__diagnoses__progression_or_recurrence: Aggregations
   occurrence__case__diagnoses__hpv_status: Aggregations
   occurrence__case__diagnoses__prior_malignancy: Aggregations
@@ -8627,9 +9418,8 @@ type SsmAggregations {
   occurrence__case__diagnoses__ldh_normal_range_upper: NumericAggregations
   occurrence__case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   occurrence__case__diagnoses__lymph_nodes_positive: NumericAggregations
-  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  occurrence__case__diagnoses__created_datetime: Aggregations
+  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
   occurrence__case__diagnoses__ajcc_clinical_stage: Aggregations
   occurrence__case__diagnoses__days_to_new_event: NumericAggregations
   occurrence__case__diagnoses__hiv_positive: Aggregations
@@ -8645,6 +9435,9 @@ type SsmAggregations {
   occurrence__case__demographic__demographic_id: Aggregations
   occurrence__case__demographic__state: Aggregations
   occurrence__case__demographic__race: Aggregations
+  occurrence__case__demographic__days_to_birth: NumericAggregations
+  occurrence__case__demographic__vital_status: Aggregations
+  occurrence__case__demographic__days_to_death: NumericAggregations
   occurrence__case__demographic__submitter_id: Aggregations
   occurrence__case__demographic__ethnicity: Aggregations
   occurrence__case__demographic__year_of_death: NumericAggregations
@@ -8713,6 +9506,7 @@ type SsmAggregations {
   occurrence__case__available_variation_data: Aggregations
   occurrence__case__disease_type: Aggregations
   occurrence__occurrence_id: Aggregations
+  gene_aa_change: Aggregations
   mutation_subtype: Aggregations
   end_position: NumericAggregations
   reference_allele: Aggregations
@@ -8772,7 +9566,7 @@ type SsmAggregations {
   consequence__transcript__annotation__hgvsp_short: Aggregations
   consequence__transcript__ref_seq_accession: Aggregations
   tumor_allele: Aggregations
-  gene_aa_change: Aggregations
+  mutation_type: Aggregations
   chromosome: Aggregations
   genomic_dna_change: Aggregations
 }
@@ -9047,6 +9841,15 @@ type Stats {
   count: Int
   avg: Float
   sum: Float
+  std_deviation: Float
+  sum_of_squares: Float
+  variance: Float
+  std_deviation_bounds: StdDeviationBounds
+}
+
+type StdDeviationBounds {
+  upper: Float
+  lower: Float
 }
 
 type Summary {
@@ -9295,6 +10098,10 @@ type Treatment implements Node {
 
   # keyword
   treatment_id: String
+
+  # The text term used to describe the pathologic effect a treatment(s) had on the tumor.
+  #
+  treatment_effect: String
 
   # The current state of the object.
   #

--- a/data/schema.json
+++ b/data/schema.json
@@ -1226,7 +1226,7 @@
               "name": "samples__time_between_excision_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1274,7 +1274,7 @@
               "name": "samples__intermediate_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1298,7 +1298,7 @@
               "name": "samples__time_between_clamping_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1658,7 +1658,7 @@
               "name": "samples__shortest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3530,7 +3530,7 @@
               "name": "samples__longest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3765,18 +3765,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The year in which the participant quit smoking.\n",
-              "isDeprecated": false,
-              "name": "exposures__tobacco_smoking_quit_year",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The weight of the patient measured in kilograms.\n",
               "isDeprecated": false,
               "name": "exposures__weight",
@@ -3795,42 +3783,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
-              "isDeprecated": false,
-              "name": "exposures__alcohol_history",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
-              "isDeprecated": false,
-              "name": "exposures__alcohol_intensity",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
-              "isDeprecated": false,
-              "name": "exposures__bmi",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3861,21 +3813,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to smoke that is emitted from burning tobacco, including cigarettes, pipes, and cigars. This includes tobacco smoke exhaled by smokers.\n",
               "isDeprecated": false,
-              "name": "exposures__created_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "exposures__state",
+              "name": "exposures__environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -3897,12 +3837,144 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_days_per_week",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "isDeprecated": false,
+              "name": "exposures__pack_years_smoked",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposured to respirable crystalline silica, a widespread, naturally occurring, crystalline metal oxide that consists of different forms including quartz, cristobalite, tridymite, tripoli, ganister, chert and novaculite.\n",
+              "isDeprecated": false,
+              "name": "exposures__respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to fine powder derived by the crushing of coal.\n",
+              "isDeprecated": false,
+              "name": "exposures__coal_dust_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "exposures__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.\n",
+              "isDeprecated": false,
+              "name": "exposures__asbestos_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "exposures__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the specific type of tobacco used by the patient.\n",
+              "isDeprecated": false,
+              "name": "exposures__type_of_tobacco_used",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The year in which the participant began smoking.\n",
               "isDeprecated": false,
               "name": "exposures__tobacco_smoking_onset_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_history",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "exposures__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to generally decribe how often the patient smokes.\n",
+              "isDeprecated": false,
+              "name": "exposures__smoking_frequency",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -3921,21 +3993,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "description": "The text term used to describe the patient's specific type of smoke exposure.\n",
               "isDeprecated": false,
-              "name": "exposures__alcohol_days_per_week",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "exposures__submitter_id",
+              "name": "exposures__type_of_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -3957,9 +4017,57 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
               "isDeprecated": false,
-              "name": "exposures__pack_years_smoked",
+              "name": "exposures__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_intensity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the approximate amount of time elapsed between the time the patient wakes up in the morning to the time they smoke their first cigarette.\n",
+              "isDeprecated": false,
+              "name": "exposures__time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to radon.\n",
+              "isDeprecated": false,
+              "name": "exposures__radon_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year in which the participant quit smoking.\n",
+              "isDeprecated": false,
+              "name": "exposures__tobacco_smoking_quit_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -3983,10 +4091,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__proportion_base_mismatch",
+              "name": "files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__chip_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -3999,18 +4119,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__index_files__updated_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -4211,6 +4319,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -4223,7 +4355,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4251,6 +4407,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4295,7 +4463,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4523,10 +4715,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__downstream_analyses__output_files__proportion_base_mismatch",
+              "name": "files__downstream_analyses__output_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -4535,10 +4727,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__downstream_analyses__output_files__updated_datetime",
+              "name": "files__downstream_analyses__output_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4739,6 +4931,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -4751,7 +4967,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4779,6 +5019,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4823,7 +5075,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5195,18 +5471,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__release_number",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "files__access",
               "type": {
                 "kind": "OBJECT",
@@ -5235,18 +5499,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__version",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -5447,7 +5699,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__channel",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5469,6 +5745,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "files__data_type",
@@ -5484,6 +5772,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "files__tags",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5519,6 +5819,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__proportion_base_mismatch",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__proportion_reads_duplicated",
               "type": {
                 "kind": "OBJECT",
@@ -5544,6 +5868,18 @@
               "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
               "isDeprecated": false,
               "name": "files__state_comment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__plate_well",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5637,18 +5973,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__baseid",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.\n",
               "isDeprecated": false,
               "name": "files__md5sum",
@@ -5661,9 +5985,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": null,
               "isDeprecated": false,
-              "name": "files__updated_datetime",
+              "name": "files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5723,10 +6047,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__analysis__input_files__proportion_base_mismatch",
+              "name": "files__analysis__input_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -5735,10 +6059,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__analysis__input_files__updated_datetime",
+              "name": "files__analysis__input_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -5939,6 +6263,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -5951,7 +6299,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5979,6 +6351,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -6023,7 +6407,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7125,6 +7533,930 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The weight of the patient measured in kilograms.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__weight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).\n",
+              "isDeprecated": false,
+              "name": "follow_ups__reflux_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of progressive or recurrent disease or relapsed disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The height of the patient in centimeters.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__height",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's adverse event.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the suspected cause or reason for the patient disease response.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__cause_of_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The ECOG functional performance status of the patient/participant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__ecog_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__hpv_positive_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease was formally confirmed as progression-free.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_progression_free",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_follow_up",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used to diagnose the patient's comorbidity disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__dlco_ref_predictive_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__risk_factor",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease progressed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_progression",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease recurred.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the mutation included in molecular testing was known to have an affect on the mismatch repair process.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__mismatch_repair_mutation",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe an antigen included in molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__antigen",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological origin of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__variant_origin",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the lower limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__blood_test_normal_range_lower",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__locus",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term or numeric value used to describe a sepcific result of a molecular test.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_value",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a secondary gene targeted or included in molecular analysis. For rearrangements, this is should represent the location of the variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__second_gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the number of sets of homologous chromosomes.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__ploidy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a chromosome targeted or included in molecular testing. If a specific genetic variant is being reported, this property can be used to capture the chromosome where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__chromosome",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe a specific test that is not covered in the list of molecular analysis methods.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__specialized_molecular_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Intron number targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the intron where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__intron",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a gene targeted or included in molecular analysis. For rearrangements, this is shold be used to represent the reference gene.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a specific histone variants, which are proteins that substitute for the core canonical histones.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__histone_variant",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of cells used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__cell_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the family, or classification of a group of basic proteins found in chromatin, called histones.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__histone_family",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of times a section of the genome is repeated or copied within an insertion, duplication or deletion variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__copy_number",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of analyte used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_analyte_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Exon number targeted or included in a molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the exon where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__laboratory_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_result",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the transcript of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__transcript",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the upper limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__blood_test_normal_range_upper",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the units of the test value for a molecular test. This property is used in conjunction with test_value.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_units",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the zygosity of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__zygosity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the cytoband or chromosomal location targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the cytoband where the variant is located. Format: [chromosome][chromosome arm].[band+sub-bands]. Example: 17p13.1.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__cytoband",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__biospecimen_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The second exon number involved in molecular variation. If a specific genetic variant is being reported, this property can be used to capture the second exon where that variant is located. This property is typically used for a translocation where two different locations are involved in the variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__second_exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_test_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used for molecular analysis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_analysis_method",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the molecular consequence of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_consequence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__variant_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci determined to be abnormal.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__loci_abnormal_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci tested.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__loci_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the patient's menopause status.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__menopause_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage diabetes.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__diabetes_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__risk_factor_treatment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the anatomic site of the progressive or recurrent disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether goblet cells were determined to be present in a patient diagnosed with Barrett's esophagus.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Code assigned to describe the patient's response or outcome to the disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__disease_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups__follow_up_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__pancreatitis_onset_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__viral_hepatitis_serologies",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the classification used of the functional capabilities of a person.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__karnofsky_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "index_date",
@@ -7281,6 +8613,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "disease_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term that represents the type of vascular tumor invasion.\n",
               "isDeprecated": false,
               "name": "diagnoses__vascular_invasion_type",
@@ -7353,9 +8697,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
+              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
               "isDeprecated": false,
-              "name": "diagnoses__vital_status",
+              "name": "diagnoses__metastasis_at_diagnosis",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7371,18 +8715,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_death",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7407,18 +8739,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_hiv_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7485,6 +8805,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall Weiss assessment score, a commonly used assessment describing the malignancy of adrenocortical tumors. The Weiss score is determined based on nine histological criteria including the following: high nuclear grade, mitotic rate greater than five per 50 high power fields (HPF), atypical mitotic figures, eosinophilic tumor cell cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__weiss_assessment_score",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term and code that represents the metastatic stage of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
               "name": "diagnoses__enneking_msts_metastasis",
@@ -7503,6 +8835,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of lymph nodes tested to determine whether lymph nodes were  involved with disease as determined by a pathologic examination.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__lymph_nodes_tested",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7536,6 +8880,18 @@
               "description": "Text term to specify the location of the supratentorial tumor.\n",
               "isDeprecated": false,
               "name": "diagnoses__supratentorial_localization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the International Germ Cell Cancer Collaborative Group (IGCCCG), a grouping used to further classify metastatic testicular tumors.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__igcccg_stage",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7581,9 +8937,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
-              "name": "diagnoses__cause_of_death",
+              "name": "diagnoses__enneking_msts_tumor_site",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7593,9 +8949,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
+              "description": "A numeric value used to measure therapeutic response of the primary tumor and predict patient outcomes based on a three-point tumor regression grading system.\n",
               "isDeprecated": false,
-              "name": "diagnoses__enneking_msts_tumor_site",
+              "name": "diagnoses__tumor_regression_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7620,18 +8976,6 @@
               "description": "Stage group determined from clinical information on the tumor (T), regional node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hiv_positive",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7677,18 +9021,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__metastasis_at_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date of the patient was thought to have the best overall response to their disease.\n",
               "isDeprecated": false,
               "name": "diagnoses__days_to_best_overall_response",
@@ -7719,18 +9051,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hpv_positive_type",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -7881,18 +9201,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_new_event",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Numeric value used to describe the non-peritonealised bare area of rectum, comprising anterior and posterior segments, when submitted as a surgical specimen resulting from excision of cancer of the rectum.\n",
               "isDeprecated": false,
               "name": "diagnoses__circumferential_resection_margin",
@@ -7965,12 +9273,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the secondary Gleason score, which describes the pattern of cells making up the second largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
               "isDeprecated": false,
-              "name": "diagnoses__progression_free_survival",
+              "name": "diagnoses__secondary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -8037,6 +9345,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe whether the patient's disease originated in a single location or multiple locations.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__tumor_focality",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The text term used to describe the classification of Wilms tumors distinguishing between favorable and unfavorable histologic groups.\n",
               "isDeprecated": false,
               "name": "diagnoses__wilms_tumor_histologic_subtype",
@@ -8052,18 +9372,6 @@
               "description": "Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_clinical_t",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__colon_polyps_history",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8133,9 +9441,201 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Status of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__legacy_updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "diagnoses__progression_free_survival_event",
+              "name": "diagnoses__annotations__entity_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Top level classification of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__classification",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Name of the person or entity responsible for the creation of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__creator",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__entity_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Open entry for any further description or characterization of the data.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__notes",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__entity_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__legacy_created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__case_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__annotation_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__case_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Top level characterization of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__category",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8241,12 +9741,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the Masaoka staging system, a classification that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.\n",
               "isDeprecated": false,
-              "name": "diagnoses__overall_survival",
+              "name": "diagnoses__masaoka_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -8313,18 +9813,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__new_event_anatomic_site",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The best improvement achieved throughout the entire course of protocol treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__best_overall_response",
@@ -8364,6 +9852,18 @@
               "description": "Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.\n",
               "isDeprecated": false,
               "name": "diagnoses__tumor_grade",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the primary Gleason score, which describes the pattern of cells making up the largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__primary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8448,6 +9948,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "diagnoses__treatments__treatment_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the pathologic effect a treatment(s) had on the tumor.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__treatments__treatment_effect",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8565,45 +10077,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hpv_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the version or edition of the American Joint Committee on Cancer Staging Handbooks, a publication by the group formed for the purpose of developing a system of staging for cancer that is acceptable to the American medical profession and is compatible with other accepted classifications.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_staging_system_edition",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__new_event_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8619,18 +10095,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__ldh_normal_range_upper",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -8685,9 +10149,21 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall grouping of grades defined by the Gleason grading classification, which is used to determine the aggressiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__gleason_grade_group",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "disease_type",
+              "name": "diagnosis_ids",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8949,6 +10425,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Study name of the project.",
               "isDeprecated": false,
               "name": "tissue_source_site__project",
@@ -9137,6 +10625,41 @@
                 "name": "Aggregations",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "percentiles",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Percentiles",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "ranges",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "range",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -9208,6 +10731,54 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "std_deviation",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sum_of_squares",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "variance",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "std_deviation_bounds",
+              "type": {
+                "kind": "OBJECT",
+                "name": "StdDeviationBounds",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -9224,6 +10795,100 @@
           "interfaces": null,
           "kind": "SCALAR",
           "name": "Float",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "upper",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "lower",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "StdDeviationBounds",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "quartile_1",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "quartile_3",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "median",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "iqr",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Percentiles",
           "possibleTypes": null
         },
         {
@@ -9768,6 +11433,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "diagnosis_ids",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "submitter_aliquot_ids",
               "type": {
                 "kind": "SCALAR",
@@ -9793,6 +11470,18 @@
               "description": "keyword",
               "isDeprecated": false,
               "name": "primary_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10931,9 +12620,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
+              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
               "isDeprecated": false,
-              "name": "vital_status",
+              "name": "metastasis_at_diagnosis",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10949,18 +12638,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_death",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -10985,18 +12662,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_hiv_diagnosis",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -11063,6 +12728,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall Weiss assessment score, a commonly used assessment describing the malignancy of adrenocortical tumors. The Weiss score is determined based on nine histological criteria including the following: high nuclear grade, mitotic rate greater than five per 50 high power fields (HPF), atypical mitotic figures, eosinophilic tumor cell cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.\n",
+              "isDeprecated": false,
+              "name": "weiss_assessment_score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term and code that represents the metastatic stage of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
               "name": "enneking_msts_metastasis",
@@ -11081,6 +12758,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of lymph nodes tested to determine whether lymph nodes were  involved with disease as determined by a pathologic examination.\n",
+              "isDeprecated": false,
+              "name": "lymph_nodes_tested",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -11114,6 +12803,18 @@
               "description": "Text term to specify the location of the supratentorial tumor.\n",
               "isDeprecated": false,
               "name": "supratentorial_localization",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the International Germ Cell Cancer Collaborative Group (IGCCCG), a grouping used to further classify metastatic testicular tumors.\n",
+              "isDeprecated": false,
+              "name": "igcccg_stage",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11159,9 +12860,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
-              "name": "cause_of_death",
+              "name": "enneking_msts_tumor_site",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11171,9 +12872,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
+              "description": "A numeric value used to measure therapeutic response of the primary tumor and predict patient outcomes based on a three-point tumor regression grading system.\n",
               "isDeprecated": false,
-              "name": "enneking_msts_tumor_site",
+              "name": "tumor_regression_grade",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11198,18 +12899,6 @@
               "description": "Stage group determined from clinical information on the tumor (T), regional node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.\n",
               "isDeprecated": false,
               "name": "ajcc_clinical_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hiv_positive",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11255,18 +12944,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
-              "isDeprecated": false,
-              "name": "metastasis_at_diagnosis",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date of the patient was thought to have the best overall response to their disease.\n",
               "isDeprecated": false,
               "name": "days_to_best_overall_response",
@@ -11297,18 +12974,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hpv_positive_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -11459,18 +13124,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_new_event",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Numeric value used to describe the non-peritonealised bare area of rectum, comprising anterior and posterior segments, when submitted as a surgical specimen resulting from excision of cancer of the rectum.\n",
               "isDeprecated": false,
               "name": "circumferential_resection_margin",
@@ -11543,12 +13196,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the secondary Gleason score, which describes the pattern of cells making up the second largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
               "isDeprecated": false,
-              "name": "progression_free_survival",
+              "name": "secondary_gleason_grade",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -11615,6 +13268,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe whether the patient's disease originated in a single location or multiple locations.\n",
+              "isDeprecated": false,
+              "name": "tumor_focality",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The text term used to describe the classification of Wilms tumors distinguishing between favorable and unfavorable histologic groups.\n",
               "isDeprecated": false,
               "name": "wilms_tumor_histologic_subtype",
@@ -11630,18 +13295,6 @@
               "description": "Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
               "isDeprecated": false,
               "name": "ajcc_clinical_t",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "colon_polyps_history",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11702,18 +13355,6 @@
               "description": "The text term used to describe the staging classification of liver tumors, as defined by the Children's Oncology Group (COG). This staging system specifically describes the extent of the primary tumor prior to treatment.\n",
               "isDeprecated": false,
               "name": "cog_liver_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "progression_free_survival_event",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11819,12 +13460,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the Masaoka staging system, a classification that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.\n",
               "isDeprecated": false,
-              "name": "overall_survival",
+              "name": "masaoka_stage",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -11891,18 +13532,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "new_event_anatomic_site",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The best improvement achieved throughout the entire course of protocol treatment.\n",
               "isDeprecated": false,
               "name": "best_overall_response",
@@ -11951,36 +13580,24 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the primary Gleason score, which describes the pattern of cells making up the largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "primary_gleason_grade",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.\n",
               "isDeprecated": false,
               "name": "days_to_diagnosis",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_birth",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hpv_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -11999,36 +13616,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "new_event_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the classification of medulloblastoma tumors based on molecular features.\n",
               "isDeprecated": false,
               "name": "medulloblastoma_molecular_classification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "ldh_normal_range_upper",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -12074,6 +13667,18 @@
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "site_of_resection_or_biopsy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the overall grouping of grades defined by the Gleason grading classification, which is used to determine the aggressiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "gleason_grade_group",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12399,6 +14004,18 @@
               "description": "keyword",
               "isDeprecated": false,
               "name": "treatment_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the pathologic effect a treatment(s) had on the tumor.\n",
+              "isDeprecated": false,
+              "name": "treatment_effect",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12789,12 +14406,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -12935,18 +14552,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "SCALAR",
@@ -12981,12 +14586,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "version",
+              "name": "average_read_length",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -12995,7 +14600,7 @@
               "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
-              "name": "average_read_length",
+              "name": "contamination_error",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -13017,6 +14622,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
               "name": "revision",
@@ -13029,9 +14646,33 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13059,6 +14700,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -13103,7 +14768,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "data_format",
+              "name": "plate_well",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13115,7 +14780,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "baseid",
+              "name": "data_format",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13137,9 +14802,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13474,18 +15139,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The year in which the participant quit smoking.\n",
-              "isDeprecated": false,
-              "name": "tobacco_smoking_quit_year",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The weight of the patient measured in kilograms.\n",
               "isDeprecated": false,
               "name": "weight",
@@ -13504,42 +15157,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
-              "isDeprecated": false,
-              "name": "alcohol_history",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
-              "isDeprecated": false,
-              "name": "alcohol_intensity",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
-              "isDeprecated": false,
-              "name": "bmi",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -13570,21 +15187,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to smoke that is emitted from burning tobacco, including cigarettes, pipes, and cigars. This includes tobacco smoke exhaled by smokers.\n",
               "isDeprecated": false,
-              "name": "created_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "state",
+              "name": "environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13606,12 +15211,144 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "isDeprecated": false,
+              "name": "alcohol_days_per_week",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "isDeprecated": false,
+              "name": "pack_years_smoked",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposured to respirable crystalline silica, a widespread, naturally occurring, crystalline metal oxide that consists of different forms including quartz, cristobalite, tridymite, tripoli, ganister, chert and novaculite.\n",
+              "isDeprecated": false,
+              "name": "respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to fine powder derived by the crushing of coal.\n",
+              "isDeprecated": false,
+              "name": "coal_dust_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.\n",
+              "isDeprecated": false,
+              "name": "asbestos_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the specific type of tobacco used by the patient.\n",
+              "isDeprecated": false,
+              "name": "type_of_tobacco_used",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The year in which the participant began smoking.\n",
               "isDeprecated": false,
               "name": "tobacco_smoking_onset_year",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
+              "isDeprecated": false,
+              "name": "alcohol_history",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "bmi",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to generally decribe how often the patient smokes.\n",
+              "isDeprecated": false,
+              "name": "smoking_frequency",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -13630,21 +15367,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "description": "The text term used to describe the patient's specific type of smoke exposure.\n",
               "isDeprecated": false,
-              "name": "alcohol_days_per_week",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "submitter_id",
+              "name": "type_of_smoke_exposure",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13666,9 +15391,57 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
               "isDeprecated": false,
-              "name": "pack_years_smoked",
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
+              "isDeprecated": false,
+              "name": "alcohol_intensity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the approximate amount of time elapsed between the time the patient wakes up in the morning to the time they smoke their first cigarette.\n",
+              "isDeprecated": false,
+              "name": "time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to radon.\n",
+              "isDeprecated": false,
+              "name": "radon_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year in which the participant quit smoking.\n",
+              "isDeprecated": false,
+              "name": "tobacco_smoking_quit_year",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -14798,7 +16571,7 @@
               "name": "time_between_excision_and_freezing",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -14846,7 +16619,7 @@
               "name": "intermediate_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -14870,7 +16643,7 @@
               "name": "time_between_clamping_and_freezing",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -15026,7 +16799,7 @@
               "name": "shortest_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -15182,7 +16955,7 @@
               "name": "longest_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -17430,10 +19203,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__chip_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17446,18 +19231,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "index_files__updated_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17658,6 +19431,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -17670,7 +19467,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -17698,6 +19519,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -17742,7 +19575,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -17970,10 +19827,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "downstream_analyses__output_files__proportion_base_mismatch",
+              "name": "downstream_analyses__output_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17982,10 +19839,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "downstream_analyses__output_files__updated_datetime",
+              "name": "downstream_analyses__output_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -18186,6 +20043,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -18198,7 +20079,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -18226,6 +20131,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -18270,7 +20187,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -18642,18 +20583,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "OBJECT",
@@ -18682,18 +20611,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "version",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -18883,6 +20800,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "average_read_length",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contamination_error",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -19110,10 +21039,34 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "revision",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -19146,6 +21099,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "chip_position",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "proportion_coverage_10X",
               "type": {
                 "kind": "OBJECT",
@@ -19162,6 +21127,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19569,7 +21558,7 @@
               "name": "cases__samples__time_between_excision_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19617,7 +21606,7 @@
               "name": "cases__samples__intermediate_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19641,7 +21630,7 @@
               "name": "cases__samples__time_between_clamping_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -20001,7 +21990,7 @@
               "name": "cases__samples__shortest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -21873,7 +23862,7 @@
               "name": "cases__samples__longest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22110,18 +24099,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__tobacco_smoking_quit_year",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__exposures__weight",
               "type": {
                 "kind": "OBJECT",
@@ -22138,42 +24115,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__alcohol_history",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__alcohol_intensity",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__bmi",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22206,19 +24147,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__created_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__state",
+              "name": "cases__exposures__environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22242,10 +24171,142 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__exposures__alcohol_days_per_week",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__pack_years_smoked",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__coal_dust_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__asbestos_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__type_of_tobacco_used",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__exposures__tobacco_smoking_onset_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__alcohol_history",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__smoking_frequency",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -22266,19 +24327,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__alcohol_days_per_week",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__submitter_id",
+              "name": "cases__exposures__type_of_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22302,7 +24351,979 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__pack_years_smoked",
+              "name": "cases__exposures__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__alcohol_intensity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__radon_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__tobacco_smoking_quit_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__weight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__reflux_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__height",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__cause_of_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__ecog_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__hpv_positive_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_progression_free",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_follow_up",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__dlco_ref_predictive_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__risk_factor",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_progression",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__mismatch_repair_mutation",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__antigen",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__variant_origin",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__blood_test_normal_range_lower",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__locus",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_value",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__second_gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__ploidy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__chromosome",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__specialized_molecular_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__intron",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__histone_variant",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__cell_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__histone_family",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__copy_number",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_analyte_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__laboratory_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_result",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__transcript",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__blood_test_normal_range_upper",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_units",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__zygosity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__cytoband",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__biospecimen_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__second_exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_test_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_analysis_method",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_consequence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__variant_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__loci_abnormal_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__loci_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__menopause_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__diabetes_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__risk_factor_treatment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__disease_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__follow_up_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__pancreatitis_onset_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__viral_hepatitis_serologies",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__karnofsky_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_comorbidity",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -22456,6 +25477,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
+              "isDeprecated": false,
+              "name": "cases__disease_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__vascular_invasion_type",
@@ -22530,7 +25563,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__vital_status",
+              "name": "cases__diagnoses__metastasis_at_diagnosis",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22546,18 +25579,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_death",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22582,18 +25603,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_hiv_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22662,6 +25671,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__diagnoses__weiss_assessment_score",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__diagnoses__enneking_msts_metastasis",
               "type": {
                 "kind": "OBJECT",
@@ -22678,6 +25699,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__lymph_nodes_tested",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22711,6 +25744,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__supratentorial_localization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__igcccg_stage",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22758,7 +25803,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__cause_of_death",
+              "name": "cases__diagnoses__enneking_msts_tumor_site",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22770,7 +25815,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__enneking_msts_tumor_site",
+              "name": "cases__diagnoses__tumor_regression_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22795,18 +25840,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hiv_positive",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22854,18 +25887,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__metastasis_at_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__days_to_best_overall_response",
               "type": {
                 "kind": "OBJECT",
@@ -22894,18 +25915,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hpv_positive_type",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23058,18 +26067,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_new_event",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__circumferential_resection_margin",
               "type": {
                 "kind": "OBJECT",
@@ -23142,10 +26139,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__progression_free_survival",
+              "name": "cases__diagnoses__secondary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23214,6 +26211,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__diagnoses__tumor_focality",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__diagnoses__wilms_tumor_histologic_subtype",
               "type": {
                 "kind": "OBJECT",
@@ -23227,18 +26236,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_clinical_t",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__colon_polyps_history",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23310,7 +26307,199 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__progression_free_survival_event",
+              "name": "cases__diagnoses__annotations__status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__legacy_updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__classification",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__creator",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__notes",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__legacy_created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__case_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__annotation_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__case_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__category",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23418,10 +26607,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__overall_survival",
+              "name": "cases__diagnoses__masaoka_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23490,18 +26679,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__new_event_anatomic_site",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__best_overall_response",
               "type": {
                 "kind": "OBJECT",
@@ -23539,6 +26716,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__tumor_grade",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__primary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23623,6 +26812,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__treatments__treatment_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__treatments__treatment_effect",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23742,43 +26943,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hpv_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_staging_system_edition",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__new_event_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23794,18 +26959,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__ldh_normal_range_upper",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -23860,9 +27013,21 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
+              "description": null,
               "isDeprecated": false,
-              "name": "cases__disease_type",
+              "name": "cases__diagnoses__gleason_grade_group",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnosis_ids",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24126,6 +27291,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__submitter_diagnosis_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__tissue_source_site__project",
               "type": {
                 "kind": "OBJECT",
@@ -24222,6 +27399,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "data_format",
               "type": {
                 "kind": "OBJECT",
@@ -24306,18 +27495,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "baseid",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "md5sum",
               "type": {
                 "kind": "OBJECT",
@@ -24330,7 +27507,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24390,10 +27567,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "analysis__input_files__proportion_base_mismatch",
+              "name": "analysis__input_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -24402,10 +27579,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "analysis__input_files__updated_datetime",
+              "name": "analysis__input_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -24606,6 +27783,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -24618,7 +27819,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24646,6 +27871,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -24690,7 +27927,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -25989,12 +29250,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -26135,18 +29396,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "SCALAR",
@@ -26181,18 +29430,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "version",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
               "name": "average_read_length",
@@ -26205,9 +29442,33 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26231,7 +29492,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26259,6 +29544,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -26303,7 +29612,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "data_format",
+              "name": "plate_well",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26315,7 +29624,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "baseid",
+              "name": "data_format",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26339,7 +29648,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26993,24 +30302,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -27209,6 +30518,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -27223,7 +30556,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27251,6 +30608,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -27295,7 +30664,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -29853,6 +33246,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "diagnosis_ids",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "submitter_aliquot_ids",
               "type": {
                 "kind": "SCALAR",
@@ -29878,6 +33283,18 @@
               "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories. Reference tissue_or_organ_of_origin on the diagnosis node for more specific primary sites of disease.\n",
               "isDeprecated": false,
               "name": "primary_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -30814,24 +34231,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31030,6 +34447,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -31044,7 +34485,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31072,6 +34537,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31116,7 +34593,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31439,24 +34940,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31655,6 +35156,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -31669,7 +35194,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31697,6 +35246,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31741,7 +35302,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -32872,18 +36457,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
               "isDeprecated": false,
               "name": "diagnoses__morphology",
@@ -32896,12 +36469,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
               "isDeprecated": false,
-              "name": "diagnoses__days_to_death",
+              "name": "diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -33076,12 +36649,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
               "isDeprecated": false,
-              "name": "diagnoses__days_to_last_follow_up",
+              "name": "diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -33352,18 +36925,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__progression_or_recurrence",
@@ -33508,18 +37069,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "diagnoses__site_of_resection_or_biopsy",
@@ -33532,12 +37081,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
               "isDeprecated": false,
-              "name": "diagnoses__created_datetime",
+              "name": "diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -33823,6 +37372,30 @@
               "description": null,
               "isDeprecated": false,
               "name": "gene__ssm__ncbi_build",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "gene__ssm__clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "gene__ssm__clinical_annotations__civic__variant_id",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -36313,18 +39886,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
-              "isDeprecated": false,
-              "name": "vital_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
               "isDeprecated": false,
               "name": "morphology",
@@ -36337,12 +39898,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
               "isDeprecated": false,
-              "name": "days_to_death",
+              "name": "ann_arbor_clinical_stage",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -36517,12 +40078,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
               "isDeprecated": false,
-              "name": "days_to_last_follow_up",
+              "name": "created_datetime",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -36631,18 +40192,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_birth",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -36793,18 +40342,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
-              "isDeprecated": false,
-              "name": "ann_arbor_clinical_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "site_of_resection_or_biopsy",
@@ -36817,12 +40354,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
               "isDeprecated": false,
-              "name": "created_datetime",
+              "name": "days_to_last_follow_up",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -38878,18 +42415,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -38902,10 +42427,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_death",
+              "name": "case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -39082,10 +42607,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_last_follow_up",
+              "name": "case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -39358,18 +42883,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -39514,18 +43027,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -39538,10 +43039,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__created_datetime",
+              "name": "case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -39730,6 +43231,42 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "case__demographic__submitter_id",
               "type": {
                 "kind": "OBJECT",
@@ -39779,6 +43316,30 @@
               "description": null,
               "isDeprecated": false,
               "name": "case__ssm__ncbi_build",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__ssm__clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__ssm__clinical_annotations__civic__variant_id",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -43575,7 +47136,19 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "mutation_type",
+              "name": "clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clinical_annotations__civic__variant_id",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -43935,18 +47508,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -43959,10 +47520,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_death",
+              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -44139,10 +47700,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
+              "name": "occurrence__case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -44415,18 +47976,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -44571,18 +48120,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -44595,10 +48132,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__created_datetime",
+              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -44779,6 +48316,42 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -45603,6 +49176,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "gene_aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "mutation_subtype",
               "type": {
                 "kind": "OBJECT",
@@ -46311,7 +49896,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "gene_aa_change",
+              "name": "mutation_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -46484,18 +50069,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "mutation_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "mutation_subtype",
               "type": {
                 "kind": "SCALAR",
@@ -46580,6 +50153,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "mutation_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "chromosome",
               "type": {
                 "kind": "SCALAR",
@@ -46604,10 +50189,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "external_db_ids",
+              "name": "clinical_annotations",
               "type": {
                 "kind": "OBJECT",
-                "name": "SsmGeneExternalDbIds",
+                "name": "ClinicalAnnotations",
                 "ofType": null
               }
             },
@@ -46620,18 +50205,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "SSMConsequences",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "occurrence",
-              "type": {
-                "kind": "OBJECT",
-                "name": "SSMOccurrences",
                 "ofType": null
               }
             },
@@ -46656,6 +50229,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "external_db_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SsmGeneExternalDbIds",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "gene_aa_change",
               "type": {
                 "kind": "LIST",
@@ -46665,6 +50250,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SSMOccurrences",
+                "ofType": null
               }
             },
             {
@@ -46701,15 +50298,11 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "entrez_ssm",
+              "name": "civic",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "CivicAnnotation",
+                "ofType": null
               }
             },
             {
@@ -46717,55 +50310,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "hgnc",
+              "name": "id",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "omim_ssm",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "uniprotkb_swissprot",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ClinicalAnnotations",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
             {
               "args": [],
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "entrez_gene",
+              "name": "gene_id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -46777,7 +50345,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "omim_gene",
+              "name": "variant_id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -46800,7 +50368,7 @@
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "SsmGeneExternalDbIds",
+          "name": "CivicAnnotation",
           "possibleTypes": null
         },
         {
@@ -47723,6 +51291,117 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "SsmGene",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "entrez_ssm",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hgnc",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "omim_ssm",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "uniprotkb_swissprot",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "entrez_gene",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "omim_gene",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SsmGeneExternalDbIds",
           "possibleTypes": null
         },
         {
@@ -49649,18 +53328,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -49673,10 +53340,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_death",
+              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -49853,10 +53520,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
+              "name": "occurrence__case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -50129,18 +53796,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -50285,18 +53940,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -50309,10 +53952,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__created_datetime",
+              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -50493,6 +54136,42 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },

--- a/src/packages/@ncigdc/components/EntityPageVerticalTable.js
+++ b/src/packages/@ncigdc/components/EntityPageVerticalTable.js
@@ -5,7 +5,9 @@ import PropTypes from 'prop-types';
 
 import { Column } from '@ncigdc/uikit/Flex';
 import { withTheme } from '@ncigdc/theme';
-import Table, { Tr, Td, Th, CollapsibleTd } from '@ncigdc/uikit/Table';
+import Table, {
+  Tr, Td, Th, CollapsibleTd,
+} from '@ncigdc/uikit/Table';
 
 // th are vertical
 const EntityPageVerticalTable = ({
@@ -21,29 +23,29 @@ const EntityPageVerticalTable = ({
 }) => {
   const styles = {
     table: {
+      backgroundColor: '#fff',
       borderCollapse: 'collapse',
       borderSpacing: 0,
       overflow: 'auto',
-      backgroundColor: '#fff',
     },
-    tr: {
+    td: {
       border: 'none !important',
       color: theme.greyScale2,
     },
-    td: {
+    tr: {
       border: 'none !important',
       color: theme.greyScale2,
     },
   };
   return (
     <Column
+      className={`${className} test-entity-table-wrapper`}
       id={id}
-      className={className + ' test-entity-table-wrapper'}
       style={{
         flexWrap: 'wrap',
         ...style,
       }}
-    >
+      >
       {title && (
         <h1
           style={{
@@ -58,48 +60,47 @@ const EntityPageVerticalTable = ({
             backgroundColor: '#fff',
             ...titleStyle,
           }}
-        >
+          >
           {title}
         </h1>
       )}
       {description}
       <Table
-        style={styles.table}
-        body={
+        body={(
           <tbody>
             {thToTd.map((d, i) => (
-              <Tr key={d.th}>
+              <Tr key={typeof d.th === 'string' ? d.th : `unkeyed-${i}`}>
                 <Th
                   style={{
                     ...styles.tr,
-                    width: '30%',
                     backgroundColor: i % 2 === 0 ? theme.tableStripe : '#fff',
                     textTransform: 'capitalize',
                     verticalAlign: 'top',
+                    width: '30%',
                   }}
-                >
+                  >
                   {d.th}
                 </Th>
                 {!!d.collapsibleTd && (
-                  <CollapsibleTd
+                <CollapsibleTd
                     style={{
                       ...styles.td,
                       backgroundColor: i % 2 === 0 ? theme.tableStripe : '#fff',
                       ...d.style,
                     }}
                     text={d.collapsibleTd}
-                  />
+                    />
                 )}
                 {!!d.td && (
-                  <Td
+                <Td
                     style={{
                       ...styles.td,
                       backgroundColor: i % 2 === 0 ? theme.tableStripe : '#fff',
                       ...d.style,
                     }}
-                  >
-                    {d.td}
-                  </Td>
+                    >
+                  {d.td}
+                </Td>
                 )}
                 {!d.td &&
                   !d.collapsibleTd && (
@@ -110,24 +111,25 @@ const EntityPageVerticalTable = ({
                           i % 2 === 0 ? theme.tableStripe : '#fff',
                         ...d.style,
                       }}
-                    >
+                      >
                       --
                     </Td>
-                  )}
+                )}
               </Tr>
             ))}
           </tbody>
-        }
-      />
+        )}
+        style={styles.table}
+        />
     </Column>
   );
 };
 
 EntityPageVerticalTable.propTypes = {
-  title: PropTypes.node,
-  style: PropTypes.object,
   props: PropTypes.any,
+  style: PropTypes.object,
   thToTd: PropTypes.array,
+  title: PropTypes.node,
 };
 
 export default withTheme(EntityPageVerticalTable);

--- a/src/packages/@ncigdc/modern_components/GeneExternalReferences/GeneExternalReferences.js
+++ b/src/packages/@ncigdc/modern_components/GeneExternalReferences/GeneExternalReferences.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { compose, withProps, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withProps,
+} from 'recompose';
 import { omit } from 'lodash';
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
 import externalReferenceLinks, {
@@ -13,38 +19,51 @@ type TProps = {
   externalLinks: Object,
 };
 
+const GeneExternalReferences = ({ externalLinks }: TProps = {}) => (
+  <EntityPageVerticalTable
+    style={{ flex: 1 }}
+    thToTd={Object.keys(externalLinks).map(db => ({
+      td: externalLinks[db].length
+        ? (
+          <ExternalLink href={externalReferenceLinks[db](externalLinks[db][0])}>
+            {externalLinks[db]}
+          </ExternalLink>
+        ) : '--',
+      th: externalLinkNames[db] || db.replace(/_/, ' '),
+    }))}
+    title={(
+      <span>
+        <BookIcon style={{ marginRight: '1rem' }} />
+        {' '}
+        External References
+      </span>
+    )}
+    />
+);
+
 export default compose(
+  setDisplayName('EnhancedGeneExternalReferences'),
   branch(
     ({ viewer }) => !viewer.explore.genes.hits.edges[0],
     renderComponent(() => <div>No gene found.</div>)
   ),
-  withProps(({ viewer: { explore: { genes: { hits: { edges } } } } } = {}) => {
+  withProps(({
+    viewer: {
+      explore: {
+        genes: { hits: { edges } },
+        ssms: { aggregations: { clinical_annotations__civic__gene_id: { buckets } } },
+      },
+    },
+  } = {}) => {
     const gene = edges[0].node;
+    const civic = buckets[0] ? [buckets[0].key] : [];
 
     return {
       externalLinks: {
         ...omit(gene.external_db_ids, '__dataID__'),
         ensembl: [gene.gene_id],
+        civic, // non-alphabetical order, to match the requirement.
       },
     };
   })
-)(({ externalLinks }: TProps = {}) => (
-  <EntityPageVerticalTable
-    title={
-      <span>
-        <BookIcon style={{ marginRight: '1rem' }} /> External References
-      </span>
-    }
-    thToTd={Object.keys(externalLinks).map(db => ({
-      th: externalLinkNames[db] || db.replace(/_/, ' '),
-      td: externalLinks[db].length ? (
-        <ExternalLink href={externalReferenceLinks[db](externalLinks[db][0])}>
-          {externalLinks[db]}
-        </ExternalLink>
-      ) : (
-        '--'
-      ),
-    }))}
-    style={{ flex: 1 }}
-  />
-));
+)(GeneExternalReferences);

--- a/src/packages/@ncigdc/modern_components/GeneExternalReferences/GeneExternalReferences.relay.js
+++ b/src/packages/@ncigdc/modern_components/GeneExternalReferences/GeneExternalReferences.relay.js
@@ -3,61 +3,77 @@
 import React from 'react';
 import { graphql } from 'react-relay';
 import { makeFilter } from '@ncigdc/utils/filters';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import Query from '@ncigdc/modern_components/Query';
 
-export default (Component: ReactClass<*>) =>
-  compose(
-    branch(
-      ({ geneId }) => !geneId,
-      renderComponent(() => (
-        <div>
-          <pre>geneId</pre> must be provided
-        </div>
-      )),
-    ),
-    withPropsOnChange(['geneId'], ({ geneId }) => {
-      return {
-        variables: {
-          filters: makeFilter([
-            {
-              field: 'genes.gene_id',
-              value: [geneId],
-            },
-          ]),
-        },
-      };
-    }),
-  )((props: Object) => {
-    return (
-      <Query
-        parentProps={props}
-        minHeight={278}
-        variables={props.variables}
-        Component={Component}
-        query={graphql`
-          query GeneExternalReferences_relayQuery($filters: FiltersArgument) {
-            viewer {
-              explore {
-                genes {
-                  hits(first: 1, filters: $filters) {
-                    edges {
-                      node {
-                        gene_id
-                        external_db_ids {
-                          entrez_gene
-                          uniprotkb_swissprot
-                          hgnc
-                          omim_gene
-                        }
-                      }
+export default (Component: ReactClass<*>) => compose(
+  setDisplayName('EnhancedGeneExternalReferences_Relay'),
+  branch(
+    ({ geneId }) => !geneId,
+    renderComponent(() => (
+      <div>
+        <pre>geneId</pre>
+        {' '}
+must be provided
+      </div>
+    )),
+  ),
+  withPropsOnChange(['geneId'], ({ geneId }) => {
+    return {
+      variables: {
+        filters: makeFilter([
+          {
+            field: 'genes.gene_id',
+            value: [geneId],
+          },
+        ]),
+      },
+    };
+  }),
+)((props: Object) => (
+  <Query
+    Component={Component}
+    minHeight={278}
+    parentProps={props}
+    query={graphql`
+      query GeneExternalReferences_relayQuery($filters: FiltersArgument) {
+        viewer {
+          explore {
+            genes {
+              hits(first: 1, filters: $filters) {
+                edges {
+                  node {
+                    gene_id
+                    external_db_ids {
+                      entrez_gene
+                      uniprotkb_swissprot
+                      hgnc
+                      omim_gene
                     }
                   }
                 }
               }
             }
+            ssms{
+              aggregations(filters: $filters) {
+                clinical_annotations__civic__gene_id{
+                  buckets {
+                    doc_count
+                    key
+                  }
+                }
+              }
+            }
           }
-        `}
-      />
-    );
-  });
+        }
+      }
+    `}
+    variables={props.variables}
+    />
+));

--- a/src/packages/@ncigdc/modern_components/GeneExternalReferences/index.js
+++ b/src/packages/@ncigdc/modern_components/GeneExternalReferences/index.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import Component from './GeneExternalReferences';
 import createRenderer from './GeneExternalReferences.relay';
+
 const GeneExternalReferences = createRenderer(Component);
+
 GeneExternalReferences.propTypes = {
   geneId: PropTypes.string,
 };
+
 export default GeneExternalReferences;

--- a/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.js
+++ b/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.js
@@ -1,7 +1,10 @@
-// @flow
-
 import React from 'react';
-import { compose, branch, renderComponent } from 'recompose';
+import {
+  compose,
+  branch,
+  renderComponent,
+  setDisplayName,
+} from 'recompose';
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
 import TableIcon from '@ncigdc/theme/icons/Table';
 import MinusIcon from '@ncigdc/theme/icons/Minus';
@@ -9,29 +12,31 @@ import PlusIcon from '@ncigdc/theme/icons/Plus';
 import ExploreLink from '@ncigdc/components/Links/ExploreLink';
 import { makeFilter } from '@ncigdc/utils/filters';
 
-const strandIconMap = {
-  '-1': <MinusIcon />,
-  1: <PlusIcon />,
-};
-
-export default compose(
-  branch(
-    ({ viewer }) => !viewer.explore.genes.hits.edges[0],
-    renderComponent(() => <div>No gene found.</div>),
-  ),
-)(({ viewer: { explore: { genes: { hits: { edges } } } } } = {}) => {
+const GeneSummary = ({ viewer: { explore: { genes: { hits: { edges } } } } } = {}) => {
   const gene = edges[0].node;
   return (
     <EntityPageVerticalTable
       id="summary"
-      title={
-        <span>
-          <TableIcon style={{ marginRight: '1rem' }} />Summary
-        </span>
-      }
+      style={{
+        summary: {
+          marginBottom: '2rem',
+        },
+        column: {
+          width: '100%',
+          minWidth: 450,
+        },
+        alignSelf: 'flex-start',
+        width: '100%',
+      }}
       thToTd={[
-        { th: 'Symbol', td: gene.symbol },
-        { th: 'Name', td: gene.name },
+        {
+          th: 'Symbol',
+          td: gene.symbol,
+        },
+        {
+          th: 'Name',
+          td: gene.name,
+        },
         {
           th: 'Synonyms',
           td:
@@ -42,7 +47,10 @@ export default compose(
             wordBreak: 'breakWord',
           },
         },
-        { th: 'Type', td: gene.biotype },
+        {
+          th: 'Type',
+          td: gene.biotype,
+        },
         {
           th: 'Location',
           td: `chr${gene.gene_chromosome}:${gene.gene_start}-${gene.gene_end} (GRCh38)`,
@@ -74,7 +82,7 @@ export default compose(
                   },
                 ]),
               }}
-            >
+              >
               Cancer Gene Census
             </ExploreLink>
           ) : (
@@ -82,17 +90,25 @@ export default compose(
           ),
         },
       ]}
-      style={{
-        summary: {
-          marginBottom: '2rem',
-        },
-        column: {
-          width: '100%',
-          minWidth: 450,
-        },
-        alignSelf: 'flex-start',
-        width: '100%',
-      }}
-    />
+      title={(
+        <span>
+          <TableIcon style={{ marginRight: '1rem' }} />
+Summary
+        </span>
+      )}
+      />
   );
-});
+};
+
+const strandIconMap = {
+  '-1': <MinusIcon />,
+  1: <PlusIcon />,
+};
+
+export default compose(
+  setDisplayName('EnhancedGeneSummary'),
+  branch(
+    ({ viewer }) => !viewer.explore.genes.hits.edges[0],
+    renderComponent(() => <div>No gene found.</div>),
+  ),
+)(GeneSummary);

--- a/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.relay.js
+++ b/src/packages/@ncigdc/modern_components/GeneSummary/GeneSummary.relay.js
@@ -3,65 +3,69 @@
 import React from 'react';
 import { graphql } from 'react-relay';
 import { makeFilter } from '@ncigdc/utils/filters';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import Query from '@ncigdc/modern_components/Query';
 
-export default (Component: ReactClass<*>) =>
-  compose(
-    branch(
-      ({ geneId }) => !geneId,
-      renderComponent(() => (
-        <div>
-          <pre>geneId</pre> must be provided
-        </div>
-      )),
-    ),
-    withPropsOnChange(['geneId'], ({ geneId }) => {
-      return {
-        variables: {
-          filters: makeFilter([
-            {
-              field: 'genes.gene_id',
-              value: [geneId],
-            },
-          ]),
+export default (Component: ReactClass<*>) => compose(
+  setDisplayName('EnhancedGeneSummary_Relay'),
+  branch(
+    ({ geneId }) => !geneId,
+    renderComponent(() => (
+      <div>
+        <pre>geneId</pre>
+        {' '}
+        must be provided
+      </div>
+    )),
+  ),
+  withPropsOnChange(['geneId'], ({ geneId }) => ({
+    variables: {
+      filters: makeFilter([
+        {
+          field: 'genes.gene_id',
+          value: [geneId],
         },
-      };
-    }),
-  )((props: Object) => {
-    return (
-      <Query
-        parentProps={props}
-        minHeight={278}
-        variables={props.variables}
-        Component={Component}
-        query={graphql`
-          query GeneSummary_relayQuery($filters: FiltersArgument) {
-            viewer {
-              explore {
-                genes {
-                  hits(first: 1, filters: $filters) {
-                    edges {
-                      node {
-                        description
-                        gene_id
-                        symbol
-                        name
-                        synonyms
-                        biotype
-                        gene_chromosome
-                        gene_start
-                        gene_end
-                        gene_strand
-                        is_cancer_gene_census
-                      }
-                    }
+      ]),
+    },
+  })),
+)((props: Object) => (
+  <Query
+    Component={Component}
+    minHeight={278}
+    parentProps={props}
+    query={graphql`
+      query GeneSummary_relayQuery($filters: FiltersArgument) {
+        viewer {
+          explore {
+            genes {
+              hits(first: 1, filters: $filters) {
+                edges {
+                  node {
+                    description
+                    gene_id
+                    symbol
+                    name
+                    synonyms
+                    biotype
+                    gene_chromosome
+                    gene_start
+                    gene_end
+                    gene_strand
+                    is_cancer_gene_census
                   }
                 }
               }
             }
           }
-        `}
-      />
-    );
-  });
+        }
+      }
+    `}
+    variables={props.variables}
+    />
+));

--- a/src/packages/@ncigdc/modern_components/GeneSummary/index.js
+++ b/src/packages/@ncigdc/modern_components/GeneSummary/index.js
@@ -1,3 +1,4 @@
 import Component from './GeneSummary';
 import createRenderer from './GeneSummary.relay';
+
 export default createRenderer(Component);

--- a/src/packages/@ncigdc/modern_components/SsmExternalReferences/SsmExternalReferences.js
+++ b/src/packages/@ncigdc/modern_components/SsmExternalReferences/SsmExternalReferences.js
@@ -1,7 +1,11 @@
-// @flow
-
 import React from 'react';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import externalReferenceLinks from '@ncigdc/utils/externalReferenceLinks';
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
 import BookIcon from '@ncigdc/theme/icons/Book';
@@ -9,17 +13,86 @@ import { ExternalLink } from '@ncigdc/uikit/Links';
 import CollapsibleList from '@ncigdc/uikit/CollapsibleList';
 
 const styles = {
+  column: {
+    minWidth: 450,
+    width: '100%',
+  },
   summary: {
     marginBottom: '2rem',
     minWidth: '450px',
   },
-  column: {
-    width: '100%',
-    minWidth: 450,
-  },
 };
 
+const SSMExternalReferences = ({
+  dbSNP,
+  node: {
+    clinical_annotations: {
+      civic: {
+        gene_id,
+        variant_id,
+      },
+    },
+    cosmic_id,
+  },
+} = {}) => (
+  <EntityPageVerticalTable
+    style={{
+      ...styles.summary,
+      ...styles.column,
+      alignSelf: 'flex-start',
+    }}
+    thToTd={[
+      {
+        td:
+          dbSNP && /rs(\d+)$/g.test(dbSNP)
+            ? (
+              <ExternalLink href={externalReferenceLinks.dbsnp(dbSNP)}>
+                {dbSNP}
+              </ExternalLink>
+            ) : '--',
+        th: <span style={{ textTransform: 'none' }}>dbSNP</span>,
+      },
+      {
+        td: (cosmic_id || []).length ? (
+          <CollapsibleList
+            data={(cosmic_id || []).map(c => (
+              <ExternalLink
+                href={externalReferenceLinks[c.substring(0, 4).toLowerCase()](
+                  c.match(/(\d+)$/g),
+                )}
+                key={c}
+                >
+                {c}
+              </ExternalLink>
+            ))}
+            style={{ minWidth: '300px' }}
+            />
+        ) : '--',
+        th: 'COSMIC',
+      },
+      {
+        td:
+          (gene_id && variant_id)
+            ? (
+              <ExternalLink href={externalReferenceLinks.civic(gene_id, variant_id)}>
+                {variant_id}
+              </ExternalLink>
+            ) : '--',
+        th: 'CIViC',
+      },
+    ]}
+    title={(
+      <span>
+        <BookIcon style={{ marginRight: '1rem' }} />
+        {' '}
+        External References
+      </span>
+    )}
+    />
+);
+
 export default compose(
+  setDisplayName('SSMExternalReferences'),
   branch(
     ({ viewer }) => !viewer.explore.ssms.hits.edges[0],
     renderComponent(() => <div>No ssm found.</div>),
@@ -27,58 +100,16 @@ export default compose(
   withPropsOnChange(
     ['viewer'],
     ({ viewer: { explore: { ssms: { hits: { edges } } } } }) => {
-      const node = edges[0].node;
+      const { node } = edges[0];
       return {
         dbSNP: node.consequence.hits.edges.reduce(
-          (acc, c) =>
-            c.node.transcript.annotation.dbsnp_rs
+          (acc, c) => (c.node.transcript.annotation.dbsnp_rs
               ? c.node.transcript.annotation.dbsnp_rs
-              : acc,
+              : acc),
           '',
         ),
         node,
       };
     },
   ),
-)(({ node, dbSNP } = {}) => (
-  <EntityPageVerticalTable
-    title={
-      <span>
-        <BookIcon style={{ marginRight: '1rem' }} /> External References
-      </span>
-    }
-    thToTd={[
-      {
-        th: <span style={{ textTransform: 'none' }}>dbSNP</span>,
-        td:
-          dbSNP && /rs(\d+)$/g.test(dbSNP) ? (
-            <ExternalLink href={externalReferenceLinks.dbsnp(dbSNP)}>
-              {dbSNP}
-            </ExternalLink>
-          ) : (
-            '--'
-          ),
-      },
-      {
-        th: 'COSMIC',
-        td: (node.cosmic_id || []).length ? (
-          <CollapsibleList
-            style={{ minWidth: '300px' }}
-            data={(node.cosmic_id || []).map(c => (
-              <ExternalLink
-                href={externalReferenceLinks[c.substring(0, 4).toLowerCase()](
-                  c.match(/(\d+)$/g),
-                )}
-              >
-                {c}
-              </ExternalLink>
-            ))}
-          />
-        ) : (
-          '--'
-        ),
-      },
-    ]}
-    style={{ ...styles.summary, ...styles.column, alignSelf: 'flex-start' }}
-  />
-));
+)(SSMExternalReferences);

--- a/src/packages/@ncigdc/modern_components/SsmExternalReferences/SsmExternalReferences.relay.js
+++ b/src/packages/@ncigdc/modern_components/SsmExternalReferences/SsmExternalReferences.relay.js
@@ -1,73 +1,79 @@
-// @flow
-
 import React from 'react';
 import { graphql } from 'react-relay';
 import { makeFilter } from '@ncigdc/utils/filters';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import Query from '@ncigdc/modern_components/Query';
 
-export default (Component: ReactClass<*>) =>
-  compose(
-    branch(
-      ({ ssmId }) => !ssmId,
-      renderComponent(() => (
-        <div>
-          <pre>ssmId</pre> must be provided
-        </div>
-      )),
-    ),
-    withPropsOnChange(['ssmId'], ({ ssmId }) => {
-      return {
-        variables: {
-          filters: makeFilter([
-            {
-              field: 'ssms.ssm_id',
-              value: [ssmId],
-            },
-          ]),
-          withDbsnp_rs: {
-            op: 'AND',
-            content: [
-              {
-                op: 'NOT',
-                content: {
-                  field: 'consequence.transcript.annotation.dbsnp_rs',
-                  value: 'MISSING',
-                },
-              },
-            ],
-          },
+export default (Component: ReactClass<*>) => compose(
+  setDisplayName('EnhancedSSMExternalReferences_Relay'),
+  branch(
+    ({ ssmId }) => !ssmId,
+    renderComponent(() => (
+      <div>
+        <pre>ssmId</pre>
+        {' '}
+        must be provided
+      </div>
+    )),
+  ),
+  withPropsOnChange(['ssmId'], ({ ssmId }) => ({
+    variables: {
+      filters: makeFilter([
+        {
+          field: 'ssms.ssm_id',
+          value: [ssmId],
         },
-      };
-    }),
-  )((props: Object) => {
-    return (
-      <Query
-        parentProps={props}
-        minHeight={200}
-        variables={props.variables}
-        Component={Component}
-        query={graphql`
-          query SsmExternalReferences_relayQuery(
-            $filters: FiltersArgument
-            $withDbsnp_rs: FiltersArgument
-          ) {
-            viewer {
-              explore {
-                ssms {
-                  hits(first: 1, filters: $filters) {
-                    edges {
-                      node {
-                        cosmic_id
-                        consequence {
-                          hits(first: 1, filters: $withDbsnp_rs) {
-                            edges {
-                              node {
-                                transcript {
-                                  annotation {
-                                    dbsnp_rs
-                                  }
-                                }
+      ]),
+      withDbsnp_rs: {
+        content: [
+          {
+            content: {
+              field: 'consequence.transcript.annotation.dbsnp_rs',
+              value: 'MISSING',
+            },
+            op: 'NOT',
+          },
+        ],
+        op: 'AND',
+      },
+    },
+  })),
+)((props: Object) => (
+  <Query
+    Component={Component}
+    minHeight={200}
+    parentProps={props}
+    query={graphql`
+      query SsmExternalReferences_relayQuery(
+        $filters: FiltersArgument
+        $withDbsnp_rs: FiltersArgument
+      ) {
+        viewer {
+          explore {
+            ssms {
+              hits(first: 1, filters: $filters) {
+                edges {
+                  node {
+                    clinical_annotations {
+                      civic {
+                        gene_id
+                        variant_id
+                      }
+                    }
+                    cosmic_id
+                    consequence {
+                      hits(first: 1, filters: $withDbsnp_rs) {
+                        edges {
+                          node {
+                            transcript {
+                              annotation {
+                                dbsnp_rs
                               }
                             }
                           }
@@ -79,7 +85,9 @@ export default (Component: ReactClass<*>) =>
               }
             }
           }
-        `}
-      />
-    );
-  });
+        }
+      }
+    `}
+    variables={props.variables}
+    />
+));

--- a/src/packages/@ncigdc/modern_components/SsmExternalReferences/index.js
+++ b/src/packages/@ncigdc/modern_components/SsmExternalReferences/index.js
@@ -1,3 +1,4 @@
 import Component from './SsmExternalReferences';
 import createRenderer from './SsmExternalReferences.relay';
+
 export default createRenderer(Component);

--- a/src/packages/@ncigdc/modern_components/SsmSummary/SsmSummary.js
+++ b/src/packages/@ncigdc/modern_components/SsmSummary/SsmSummary.js
@@ -1,7 +1,13 @@
 // @flow
 
 import React from 'react';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import { get } from 'lodash';
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
 import TableIcon from '@ncigdc/theme/icons/Table';
@@ -12,17 +18,140 @@ import { Row } from '@ncigdc/uikit/Flex';
 import BubbleIcon from '@ncigdc/theme/icons/BubbleIcon';
 
 const styles = {
+  column: {
+    minWidth: 450,
+    width: '100%',
+  },
   summary: {
     marginBottom: '2rem',
     minWidth: '450px',
   },
-  column: {
-    width: '100%',
-    minWidth: 450,
-  },
 };
 
+const SSMSummary = ({
+  canonicalTranscript: {
+    annotation: {
+      polyphen_impact,
+      polyphen_score,
+      sift_impact,
+      sift_score,
+      vep_impact,
+    },
+    transcript_id,
+  },
+  node,
+  theme,
+} = {}) => (
+  <EntityPageVerticalTable
+    data-test="ssm-summary"
+    id="Summary"
+    style={{
+      ...styles.summary,
+      ...styles.column,
+      alignSelf: 'flex-start',
+    }}
+    thToTd={[
+      {
+        td: node.ssm_id,
+        th: 'UUID',
+      },
+      {
+        th: 'DNA change',
+        td: (
+          <span style={{
+            whiteSpace: 'pre-line',
+            wordBreak: 'break-all',
+          }}
+                >
+            {node.genomic_dna_change}
+          </span>
+        ),
+      },
+      {
+        th: 'Type',
+        td: node.mutation_subtype,
+      },
+      {
+        th: 'Reference genome assembly',
+        td: node.ncbi_build || '',
+      },
+      {
+        th: 'Allele in the reference assembly',
+        td: node.reference_allele || '',
+      },
+      {
+        th: 'Functional Impact',
+        td: (
+          <div>
+            {transcript_id
+              ? (
+                <span>
+                  <span>
+                    <ExternalLink
+                      data-test="function-impact-transcript-link"
+                      href={externalReferenceLinks.ensembl(transcript_id)}
+                      key={transcript_id}
+                      style={{ paddingRight: '0.5em' }}
+                      >
+                      {transcript_id}
+                    </ExternalLink>
+                    <BubbleIcon
+                      backgroundColor={theme.primary}
+                      text="C"
+                      toolTipText="Canonical"
+                      />
+                  </span>
+                  <Row>
+                    VEP:
+                    {' '}
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        marginLeft: '0.4em',
+                        marginRight: '0.4em',
+                      }}
+                      >
+                      {vep_impact}
+                    </span>
+                  </Row>
+                  {sift_impact && (
+                    <Row>
+                      SIFT:
+                      {' '}
+                      {sift_impact}
+                      , score:
+                      {' '}
+                      {sift_score}
+                    </Row>
+                  )}
+                  {polyphen_impact && (
+                    <Row>
+                      PolyPhen:
+                      {' '}
+                      {polyphen_impact}
+                      , score:
+                      {' '}
+                      {polyphen_score}
+                    </Row>
+                  )}
+                </span>
+              )
+            : 'No canonical transcript'}
+          </div>
+        ),
+      },
+    ]}
+    title={(
+      <span>
+        <TableIcon style={{ marginRight: '1rem' }} />
+        Summary
+      </span>
+    )}
+    />
+);
+
 export default compose(
+  setDisplayName('EnhancedSSMSummary'),
   branch(
     ({ viewer }) => !viewer.explore.ssms.hits.edges[0],
     renderComponent(() => <div>No ssm found.</div>),
@@ -31,12 +160,12 @@ export default compose(
   withPropsOnChange(
     ['viewer'],
     ({ viewer: { explore: { ssms: { hits: { edges } } } } }) => {
-      const node = edges[0].node;
+      const { node } = edges[0];
 
       const { transcript } = get(node, 'consequence.hits.edges[0].node', {
         transcript: {
-          transcript_id: '',
           annotation: {},
+          transcript_id: '',
         },
       });
 
@@ -46,102 +175,4 @@ export default compose(
       };
     },
   ),
-)(
-  (
-    {
-      node,
-      canonicalTranscript: {
-        transcript_id,
-        annotation: {
-          polyphen_impact,
-          polyphen_score,
-          sift_score,
-          sift_impact,
-          vep_impact,
-        },
-      },
-      theme,
-    } = {},
-  ) => (
-    <EntityPageVerticalTable
-      data-test="ssm-summary"
-      id="Summary"
-      title={
-        <span>
-          <TableIcon style={{ marginRight: '1rem' }} />Summary
-        </span>
-      }
-      thToTd={[
-        { th: 'UUID', td: node.ssm_id },
-        {
-          th: 'DNA change',
-          td: (
-            <span style={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
-              {node.genomic_dna_change}
-            </span>
-          ),
-        },
-        { th: 'Type', td: node.mutation_subtype },
-        { th: 'Reference genome assembly', td: node.ncbi_build || '' },
-        {
-          th: 'Allele in the reference assembly',
-          td: node.reference_allele || '',
-        },
-        {
-          th: 'Functional Impact',
-          td: (
-            <div>
-              {!transcript_id && 'No canonical transcript'}
-              {transcript_id && (
-                <span>
-                  <span>
-                    <ExternalLink
-                      data-test="function-impact-transcript-link"
-                      key={transcript_id}
-                      style={{ paddingRight: '0.5em' }}
-                      href={externalReferenceLinks.ensembl(transcript_id)}
-                    >
-                      {transcript_id}
-                    </ExternalLink>
-                    <BubbleIcon
-                      text="C"
-                      toolTipText="Canonical"
-                      backgroundColor={theme.primary}
-                    />
-                  </span>
-                  <Row>
-                    VEP:{' '}
-                    <span
-                      style={{
-                        display: 'inline-block',
-                        marginLeft: '0.4em',
-                        marginRight: '0.4em',
-                      }}
-                    >
-                      {vep_impact}
-                    </span>
-                  </Row>
-                  {sift_impact && (
-                    <Row>
-                      SIFT: {sift_impact}, score: {sift_score}
-                    </Row>
-                  )}
-                  {polyphen_impact && (
-                    <Row>
-                      PolyPhen: {polyphen_impact}, score: {polyphen_score}
-                    </Row>
-                  )}
-                </span>
-              )}
-            </div>
-          ),
-        },
-      ]}
-      style={{
-        ...styles.summary,
-        ...styles.column,
-        alignSelf: 'flex-start',
-      }}
-    />
-  ),
-);
+)(SSMSummary);

--- a/src/packages/@ncigdc/modern_components/SsmSummary/SsmSummary.relay.js
+++ b/src/packages/@ncigdc/modern_components/SsmSummary/SsmSummary.relay.js
@@ -1,77 +1,77 @@
-// @flow
-
 import React from 'react';
 import { graphql } from 'react-relay';
 import { makeFilter } from '@ncigdc/utils/filters';
-import { compose, withPropsOnChange, branch, renderComponent } from 'recompose';
+import {
+  branch,
+  compose,
+  renderComponent,
+  setDisplayName,
+  withPropsOnChange,
+} from 'recompose';
 import Query from '@ncigdc/modern_components/Query';
 
-export default (Component: ReactClass<*>) =>
-  compose(
-    branch(
-      ({ ssmId }) => !ssmId,
-      renderComponent(() => (
-        <div>
-          <pre>ssmId</pre> must be provided
-        </div>
-      )),
-    ),
-    withPropsOnChange(['ssmId'], ({ ssmId }) => {
-      return {
-        variables: {
-          filters: makeFilter([
-            {
-              field: 'ssms.ssm_id',
-              value: [ssmId],
-            },
-          ]),
-          consequenceFilters: makeFilter([
-            {
-              field: 'consequence.transcript.is_canonical',
-              value: 'true',
-            },
-          ]),
+export default (Component: ReactClass<*>) => compose(
+  setDisplayName('EnhancedSSMSummary_Relay'),
+  branch(
+    ({ ssmId }) => !ssmId,
+    renderComponent(() => (
+      <div>
+        <pre>ssmId</pre>
+        {' '}
+        must be provided
+      </div>
+    )),
+  ),
+  withPropsOnChange(['ssmId'], ({ ssmId }) => ({
+    variables: {
+      consequenceFilters: makeFilter([
+        {
+          field: 'consequence.transcript.is_canonical',
+          value: 'true',
         },
-      };
-    }),
-  )((props: Object) => {
-    return (
-      <Query
-        parentProps={props}
-        minHeight={props.minHeight || 200}
-        variables={props.variables}
-        Component={Component}
-        query={graphql`
-          query SsmSummary_relayQuery(
-            $filters: FiltersArgument
-            $consequenceFilters: FiltersArgument
-          ) {
-            viewer {
-              explore {
-                ssms {
-                  hits(first: 1, filters: $filters) {
-                    edges {
-                      node {
-                        ssm_id
-                        reference_allele
-                        mutation_subtype
-                        ncbi_build
-                        genomic_dna_change
-                        consequence {
-                          hits(first: 1, filters: $consequenceFilters) {
-                            edges {
-                              node {
-                                transcript {
-                                  is_canonical
-                                  transcript_id
-                                  annotation {
-                                    polyphen_impact
-                                    polyphen_score
-                                    sift_score
-                                    sift_impact
-                                    vep_impact
-                                  }
-                                }
+      ]),
+      filters: makeFilter([
+        {
+          field: 'ssms.ssm_id',
+          value: [ssmId],
+        },
+      ]),
+    },
+  })),
+)((props: Object) => (
+  <Query
+    Component={Component}
+    minHeight={props.minHeight || 200}
+    parentProps={props}
+    query={graphql`
+      query SsmSummary_relayQuery(
+        $filters: FiltersArgument
+        $consequenceFilters: FiltersArgument
+      ) {
+        viewer {
+          explore {
+            ssms {
+              hits(first: 1, filters: $filters) {
+                edges {
+                  node {
+                    ssm_id
+                    reference_allele
+                    mutation_subtype
+                    ncbi_build
+                    genomic_dna_change
+                    consequence {
+                      hits(first: 1, filters: $consequenceFilters) {
+                        edges {
+                          node {
+                            transcript {
+                              is_canonical
+                              transcript_id
+                              annotation {
+                                polyphen_impact
+                                polyphen_score
+                                sift_score
+                                sift_impact
+                                vep_impact
                               }
                             }
                           }
@@ -83,7 +83,9 @@ export default (Component: ReactClass<*>) =>
               }
             }
           }
-        `}
-      />
-    );
-  });
+        }
+      }
+    `}
+    variables={props.variables}
+    />
+));

--- a/src/packages/@ncigdc/modern_components/SsmSummary/index.js
+++ b/src/packages/@ncigdc/modern_components/SsmSummary/index.js
@@ -1,3 +1,4 @@
 import Component from './SsmSummary';
 import createRenderer from './SsmSummary.relay';
+
 export default createRenderer(Component);

--- a/src/packages/@ncigdc/routes/GeneRoute/GeneRoute.tsx
+++ b/src/packages/@ncigdc/routes/GeneRoute/GeneRoute.tsx
@@ -21,7 +21,7 @@ import { match as IMatch } from 'react-router';
 import { Location as ILocation } from 'history';
 import { isEmpty } from 'lodash';
 
-export default ({
+const GeneRoute =({
   match,
   geneId = match.params.id,
   location,
@@ -131,3 +131,5 @@ export default ({
     </Exists>
   );
 };
+
+export default GeneRoute;

--- a/src/packages/@ncigdc/routes/GeneRoute/index.tsx
+++ b/src/packages/@ncigdc/routes/GeneRoute/index.tsx
@@ -4,7 +4,7 @@ import LoadableWithLoading from '@ncigdc/components/LoadableWithLoading';
 
 export default (
   <Route
-    path="/genes/:id"
     component={LoadableWithLoading({ loader: () => import('./GeneRoute') })}
+    path="/genes/:id"
   />
 );

--- a/src/packages/@ncigdc/routes/SSMRoute/SSMRoute.js
+++ b/src/packages/@ncigdc/routes/SSMRoute/SSMRoute.js
@@ -28,11 +28,24 @@ const DnaChange = createSsmSummary(
 );
 
 const CancerDistributionTitle = ({ cases = 0, projects = [], filters }) => (
-  <div style={{ textTransform: 'uppercase', padding: '0 2rem' }}>
+  <div
+    style={{
+      padding: '0 2rem',
+      textTransform: 'uppercase',
+    }}
+    >
     THIS MUTATION AFFECTS&nbsp;
-    <ExploreLink query={{ searchTableTab: 'cases', filters }}>
+    <ExploreLink
+      query={{
+        searchTableTab: 'cases',
+        filters,
+      }}
+      >
       {cases.toLocaleString()}
-    </ExploreLink>&nbsp; CASES ACROSS&nbsp;
+    </ExploreLink>
+
+    &nbsp; CASES ACROSS&nbsp;
+
     <ProjectsLink
       query={{
         filters: {
@@ -48,28 +61,36 @@ const CancerDistributionTitle = ({ cases = 0, projects = [], filters }) => (
           ],
         },
       }}
-    >
+      >
       {projects.length.toLocaleString()}
-    </ProjectsLink>&nbsp; PROJECTS
+    </ProjectsLink>
+&nbsp; PROJECTS
   </div>
 );
 
-export default ({ match, ssmId = match.params.id, filters }) => {
+const SSMRoute = ({ match, ssmId = match.params.id, filters }) => {
   const cdFilters = makeFilter([
-    { field: 'ssms.ssm_id', value: ssmId },
-    { field: 'cases.available_variation_data', value: 'ssm' },
+    {
+      field: 'ssms.ssm_id',
+      value: ssmId,
+    },
+    {
+      field: 'cases.available_variation_data',
+      value: 'ssm',
+    },
   ]);
 
   return (
-    <Exists type="Ssm" id={ssmId}>
+    <Exists id={ssmId} type="Ssm">
       <FullWidthLayout
-        title={<DnaChange ssmId={ssmId} minHeight={31} />}
         entityType="MU"
-      >
-        <Row spacing="2rem" id="summary">
+        title={<DnaChange minHeight={31} ssmId={ssmId} />}
+        >
+        <Row id="summary" spacing="2rem">
           <Row flex="1">
             <SsmSummary ssmId={ssmId} />
           </Row>
+
           <Row flex="1">
             <SsmExternalReferences ssmId={ssmId} />
           </Row>
@@ -84,38 +105,60 @@ export default ({ match, ssmId = match.params.id, filters }) => {
           </Row>
         </Column>
         <Column
-          style={{ backgroundColor: 'white', marginTop: '2rem' }}
           id="cancer-distribution"
-        >
-          <Row style={{ padding: '1rem 1rem 2rem', alignItems: 'center' }}>
+          style={{
+            backgroundColor: 'white',
+            marginTop: '2rem',
+          }}
+          >
+          <Row
+            style={{
+              alignItems: 'center',
+              padding: '1rem 1rem 2rem',
+            }}
+            >
             <Heading>
               <ChartIcon style={{ marginRight: '1rem' }} />
               Cancer Distribution
             </Heading>
+
             <ExploreLink
-              query={{ searchTableTab: 'cases', filters: cdFilters }}
-            >
-              <GdcDataIcon /> Open in Exploration
+              query={{
+                searchTableTab: 'cases',
+                filters: cdFilters,
+              }}
+              >
+              <GdcDataIcon />
+              {' '}
+              Open in Exploration
             </ExploreLink>
           </Row>
           <Column>
             <CancerDistributionBarChart
-              filters={cdFilters}
               ChartTitle={CancerDistributionTitle}
               chartType="ssm"
-              style={{ width: '50%' }}
-            />
-            <CancerDistributionTable
               filters={cdFilters}
+              style={{ width: '50%' }}
+              />
+
+            <CancerDistributionTable
               entityName={ssmId}
+              filters={cdFilters}
               tableType="ssm"
-            />
+              />
           </Column>
         </Column>
-        <Column style={{ backgroundColor: 'white', marginTop: '2rem' }}>
+        <Column
+          style={{
+            backgroundColor: 'white',
+            marginTop: '2rem',
+          }}
+          >
           <SsmLolliplot mutationId={ssmId} ssmId={ssmId} />
         </Column>
       </FullWidthLayout>
     </Exists>
   );
 };
+
+export default SSMRoute;

--- a/src/packages/@ncigdc/routes/SSMRoute/index.js
+++ b/src/packages/@ncigdc/routes/SSMRoute/index.js
@@ -4,7 +4,7 @@ import LoadableWithLoading from '@ncigdc/components/LoadableWithLoading';
 
 export default (
   <Route
-    path="/ssms/:id"
     component={LoadableWithLoading({ loader: () => import('./SSMRoute') })}
-  />
+    path="/ssms/:id"
+    />
 );

--- a/src/packages/@ncigdc/utils/externalReferenceLinks.js
+++ b/src/packages/@ncigdc/utils/externalReferenceLinks.js
@@ -1,6 +1,7 @@
 // @flow
 
 export const externalLinkNames = {
+  civic: 'CIViC',
   entrez_gene: 'NCBI Gene',
   hgnc: 'HGNC',
   omim_gene: 'OMIM',
@@ -8,16 +9,16 @@ export const externalLinkNames = {
 };
 
 export default {
-  hgnc: id =>
-    `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${id}`,
-  ensembl: id =>
-    `http://may2015.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
-  entrez_gene: id => `http://www.ncbi.nlm.nih.gov/gene/${id}`,
-  omim_gene: id => `http://omim.org/entry/${id}`,
-  uniprotkb_swissprot: id => `http://www.uniprot.org/uniprot/${id}`,
-  transcript: id =>
-    `http://feb2014.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=${id}`,
+  civic: (geneId, variantId) => `https://civicdb.org/events/genes/${geneId}/summary${
+    variantId ? `/variants/${variantId}/summary` : ''
+  }`,
   cosm: id => `http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=${id}`,
   cosn: id => `http://cancer.sanger.ac.uk/cosmic/ncv/overview?id=${id}`,
   dbsnp: id => `https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${id}`,
+  ensembl: id => `http://may2015.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
+  entrez_gene: id => `http://www.ncbi.nlm.nih.gov/gene/${id}`,
+  hgnc: id => `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${id}`,
+  omim_gene: id => `http://omim.org/entry/${id}`,
+  transcript: id => `http://feb2014.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=${id}`,
+  uniprotkb_swissprot: id => `http://www.uniprot.org/uniprot/${id}`,
 };


### PR DESCRIPTION
## Ticket Number

PRTL-2534

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
Adds relevant queries (though genes' uses aggregation from ssms, which disrupts the *-centric indexing pattern); and display the data when available in both of the entity views as instructed in the requirement.