### PR TITLE
💄PRTL-2646 clinical tab divider lines

### DIFF
--- a/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
@@ -25,7 +25,8 @@ const BucketRow = styled(Row, {
 });
 
 const NotMissingFacet = (props: TProps) => {
-  const dotField = props.field.replace(/__/g, '.');
+  const { collapsed, field, notMissingDocCount, style, title } = props
+  const dotField = field.replace(/__/g, '.');
   return (
     <LocationSubscriber>
       {(ctx: { pathname: string, query: IRawQuery }) => {
@@ -34,8 +35,8 @@ const NotMissingFacet = (props: TProps) => {
             parseFilterParam((ctx.query || {}).filters, {}).content) ||
           [];
         return (
-          <Container style={props.style} className="test-not-missing-facet">
-            {!props.collapsed && (
+          <Container style={style} className="test-not-missing-facet">
+            {!collapsed && (
               <Column>
                 <BucketRow>
                   <BucketLink
@@ -67,18 +68,18 @@ const NotMissingFacet = (props: TProps) => {
                           field === dotField &&
                           value.includes('missing'),
                       )}
-                      id={`input-${props.title}-not-missing`}
-                      name={`input-${props.title}-not-missing`}
+                      id={`input-${title}-not-missing`}
+                      name={`input-${title}-not-missing`}
                     />
                     <label
-                      htmlFor={`input-${props.title}-not-missing`}
+                      htmlFor={`input-${title}-not-missing`}
                       style={{ verticalAlign: 'middle' }}
                     >
                       Not Missing
                     </label>
                   </BucketLink>
                   <CountBubble>
-                    {props.notMissingDocCount.toLocaleString()}
+                    {notMissingDocCount.toLocaleString()}
                   </CountBubble>
                 </BucketRow>
               </Column>

--- a/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/RangeFacet.js
@@ -337,7 +337,7 @@ const RangeFacet = (props: TProps) => {
   };
   const { maxDisplayed, minDisplayed } = props.state;
   return (
-    <Container className="test-range-facet" style={{ ...props.style }}>
+    <Container className="test-range-facet" style={{ ...props.style, paddingBottom: props.collapsed ? 0 : 10 }}>
       {!props.collapsed &&
         props.convertDays && (
           <Row style={{ marginBottom: '0.5rem' }}>

--- a/src/packages/@ncigdc/components/Aggregations/TermAggregation.js
+++ b/src/packages/@ncigdc/components/Aggregations/TermAggregation.js
@@ -72,7 +72,7 @@ const TermAggregation = (props: TProps) => {
             parseFilterParam((ctx.query || {}).filters, {}).content) ||
           [];
         return (
-          <Container className="test-term-aggregation" style={props.style}>
+          <Container className="test-term-aggregation" style={{...props.style, paddingBottom: props.collapsed ? 0 : 10}}>
             {!props.collapsed && props.showingValueSearch && (
               <Row>
                 <Input

--- a/src/packages/@ncigdc/components/FacetWrapper.js
+++ b/src/packages/@ncigdc/components/FacetWrapper.js
@@ -185,7 +185,6 @@ const FacetWrapper = compose(
   }),
   withState('showingValueSearch', 'setShowingValueSearch', false),
   withState('collapsed', 'setCollapsed', props => props.collapsed),
-  // withTheme
 )(WrapperComponent);
 
 export default FacetWrapper

--- a/src/packages/@ncigdc/components/FacetWrapper.js
+++ b/src/packages/@ncigdc/components/FacetWrapper.js
@@ -187,4 +187,4 @@ const FacetWrapper = compose(
   withState('collapsed', 'setCollapsed', props => props.collapsed),
 )(WrapperComponent);
 
-export default FacetWrapper
+export default FacetWrapper;

--- a/src/packages/@ncigdc/components/FacetWrapper.js
+++ b/src/packages/@ncigdc/components/FacetWrapper.js
@@ -11,6 +11,8 @@ import {
   withState,
 } from 'recompose';
 
+import { withTheme } from '@ncigdc/theme';
+
 import TermAggregation from '@ncigdc/components/Aggregations/TermAggregation';
 import DateFacet from '@ncigdc/components/Aggregations/DateFacet';
 import RangeFacet from '@ncigdc/components/Aggregations/RangeFacet';
@@ -74,7 +76,7 @@ const getFacetType = facet => {
 const FacetWrapperDiv = styled.div({
   position: 'relative',
 });
-export const WrapperComponent = ({
+export const WrapperComponent = compose(withTheme)(({
   setShowingValueSearch,
   showingValueSearch,
   collapsed,
@@ -94,6 +96,7 @@ export const WrapperComponent = ({
   dispatch,
   expandedAll,
   DescriptionComponent = null,
+  theme
 }: any) => {
   const facetType = getFacetType(facet);
   const displayTitle = title || fieldNameToTitle(facet.field);
@@ -147,7 +150,7 @@ export const WrapperComponent = ({
       .length >= 20;
 
   return (
-    <FacetWrapperDiv className="test-facet" style={style}>
+    <FacetWrapperDiv className="test-facet" style={{...style, borderTop: `1px solid ${theme.greyScale5}` }}>
       <FacetHeader
         collapsed={collapsed}
         DescriptionComponent={
@@ -167,10 +170,10 @@ export const WrapperComponent = ({
         title={displayTitle}
         />
       {searchValue && DescriptionComponent}
-      <div style={{ paddingLeft: '10px' }}>{facetComponent}</div>
+      <div>{facetComponent}</div>
     </FacetWrapperDiv>
   );
-};
+});
 const FacetWrapper = compose(
   setDisplayName('EnhancedFacetWrapper'),
   defaultProps({
@@ -182,6 +185,7 @@ const FacetWrapper = compose(
   }),
   withState('showingValueSearch', 'setShowingValueSearch', false),
   withState('collapsed', 'setCollapsed', props => props.collapsed),
+  // withTheme
 )(WrapperComponent);
 
-export default FacetWrapper;
+export default FacetWrapper

--- a/src/packages/@ncigdc/components/SearchPage.js
+++ b/src/packages/@ncigdc/components/SearchPage.js
@@ -72,6 +72,7 @@ const SearchPage = (
             defaultIndex={0}
             hideTabs={facetTabs.length <= 1}
             links={facetTabs}
+            linkStyle={{ paddingLeft: '1.2rem', paddingRight: '1.2rem' }}
             queryParam="facetTab"
             tabToolbar={(
               <UnstyledButton

--- a/src/packages/@ncigdc/containers/explore/CaseAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/CaseAggregations.js
@@ -312,7 +312,6 @@ export const CaseAggregationsComponent = (props: TProps) => (
       idField="cases.case_id"
       style={{
         width: '100%',
-        borderBottom: `1px solid ${props.theme.greyScale5}`,
         padding: '0 1.2rem 1rem',
       }}
       type="case"

--- a/src/packages/@ncigdc/containers/explore/CaseAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/CaseAggregations.js
@@ -272,7 +272,6 @@ export const CaseAggregationsComponent = (props: TProps) => (
         onRequestRemove={() => props.handleRequestRemoveFacet(facet)}
         relay={props.relay}
         relayVarName="exploreCaseCustomFacetFields"
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         />
     ))}
     <FacetHeader

--- a/src/packages/@ncigdc/containers/explore/CaseAggregations.tsx
+++ b/src/packages/@ncigdc/containers/explore/CaseAggregations.tsx
@@ -145,7 +145,6 @@ export const CaseAggregationsComponent = ({
         idField="cases.case_id"
         style={{
           width: '100%',
-          borderBottom: `1px solid ${theme.greyScale5}`,
           padding: '0 1.2rem 1rem',
         }}
         type="case"

--- a/src/packages/@ncigdc/containers/explore/CaseAggregations.tsx
+++ b/src/packages/@ncigdc/containers/explore/CaseAggregations.tsx
@@ -168,7 +168,6 @@ export const CaseAggregationsComponent = ({
               facet={facet}
               key={facet.full}
               relay={relay}
-              style={{ borderBottom: `1px solid ${theme.greyScale5}` }}
               title={facet.title}
               />
           ))}

--- a/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
+++ b/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
@@ -418,6 +418,7 @@ const enhance = compose(
                         alignItems: 'center',
                         justifyContent: 'space-between',
                         padding: '1rem 1.2rem 0.5rem 1.2rem',
+                        margin: '0.5rem 1rem 0rem 0rem',
                       }}
                       >
                       <div

--- a/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
+++ b/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
@@ -130,6 +130,9 @@ interface IFieldProps {
   name: string,
   type: { name: string, __dataID: string },
 }
+
+const headersHeight = 44;
+
 const facetMatchesQuery = (
   facet: IFacetProps,
   elements: IBucketProps[],
@@ -393,7 +396,7 @@ const enhance = compose(
             key="1"
             style={{
               overflowY: 'scroll',
-              maxHeight: `${maxFacetsPanelHeight - 44}px`, // 44 is the height of all elements above this div.
+              maxHeight: `${maxFacetsPanelHeight - headersHeight}px`,
               paddingBottom: '20px',
             }}
             >
@@ -415,7 +418,6 @@ const enhance = compose(
                         alignItems: 'center',
                         justifyContent: 'space-between',
                         padding: '1rem 1.2rem 0.5rem 1.2rem',
-                        margin: '0.5rem 1rem 0rem 1rem',
                       }}
                       >
                       <div

--- a/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
+++ b/src/packages/@ncigdc/containers/explore/ClinicalAggregations.tsx
@@ -517,7 +517,7 @@ const enhance = compose(
                                     )}
                                     facet={componentFacet}
                                     headerStyle={{
-                                      padding: '0.5rem 1.2rem 0.5rem 1.2rem',
+                                      padding: '1.2rem',
                                       fontSize: '16px',
                                     }}
                                     isMatchingSearchValue={(componentFacet.full +

--- a/src/packages/@ncigdc/containers/explore/GeneAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/GeneAggregations.js
@@ -120,7 +120,6 @@ export const GeneAggregationsComponent = compose(
         aggregation={props.aggregations[escapeForRelay(facet.field)]}
         relay={props.relay}
         additionalProps={facet.additionalProps}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
       />
     ))}
     {/* <FacetWrapper

--- a/src/packages/@ncigdc/containers/explore/SSMAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/SSMAggregations.js
@@ -163,7 +163,6 @@ export const SSMAggregationsComponent = compose(
       idField="ssms.ssm_id"
       style={{
         width: '100%',
-        borderBottom: `1px solid ${props.theme.greyScale5}`,
         padding: '0 1.2rem 1rem',
       }}
       type="ssm"
@@ -192,7 +191,6 @@ export const SSMAggregationsComponent = compose(
             facet={facet}
             key={facet.full}
             relay={props.relay}
-            style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
             title={facet.title}
             />
         ))}
@@ -201,12 +199,12 @@ export const SSMAggregationsComponent = compose(
         field="ssms.cosmic_id"
         setCollapsed={props.setCosmicIdCollapsed}
         title="COSMIC ID"
+        style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
         />
       <NotMissingFacet
         collapsed={props.cosmicIdCollapsed}
         field="ssms.cosmic_id"
         notMissingDocCount={props.ssms.cosmic_id_not_missing.total}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         title="COSMIC ID"
         />
       <FacetHeader
@@ -214,12 +212,12 @@ export const SSMAggregationsComponent = compose(
         field="ssms.consequence.transcript.annotation.dbsnp_rs"
         setCollapsed={props.setCosmicIdCollapsed}
         title="dbSNP rs ID"
+        style={{borderTop: `1px solid ${props.theme.greyScale5}`}}
         />
       <NotMissingFacet
         collapsed={props.dbSNPCollapsed}
         field="ssms.consequence.transcript.annotation.dbsnp_rs"
         notMissingDocCount={props.ssms.dbsnp_rs_not_missing.total}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         title="dbSNP rs ID"
         />
     </div>

--- a/src/packages/@ncigdc/modern_components/CaseAggregations/CaseAggregations.js
+++ b/src/packages/@ncigdc/modern_components/CaseAggregations/CaseAggregations.js
@@ -284,7 +284,6 @@ const CaseAggregationsComponent = (props: TProps) => (
         }
         relay={props.relay}
         additionalProps={facet.additionalProps}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
       />
     ))}
   </div>

--- a/src/packages/@ncigdc/modern_components/FileAggregations/FileAggregations.js
+++ b/src/packages/@ncigdc/modern_components/FileAggregations/FileAggregations.js
@@ -156,7 +156,6 @@ const FileAggregations = (props: TProps) => (
         facet={facet}
         aggregation={props.parsedFacets[facet.field]}
         onRequestRemove={() => props.handleRequestRemoveFacet(facet)}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
       />
     ))}
     <FacetHeader
@@ -173,7 +172,6 @@ const FileAggregations = (props: TProps) => (
       fieldNoDoctype="file_id"
       queryType="file"
       placeholder="e.g. 142682.bam, 4f6e2e7a-b..."
-      style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
       dropdownItem={x => (
         <Row>
           <FileIcon style={{ paddingRight: '1rem', paddingTop: '1rem' }} />
@@ -196,7 +194,6 @@ const FileAggregations = (props: TProps) => (
           ]
         }
         relay={props.relay}
-        style={{ borderBottom: `1px solid ${props.theme.greyScale5}` }}
         additionalProps={facet.additionalProps}
       />
     ))}


### PR DESCRIPTION
## Ticket Number

e.g. PRTL-2646

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
Adds border to facet wrapper component, removes double border on facets in explore and repository
Shrinks padding on explore facet tab links so there's room for the minimize chevron button