### PR TITLE
[PRTL-2660] Tooltip not showing percent on histogram

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -611,7 +611,7 @@ const ClinicalVariableCard: React.ComponentType<IVariableCardProps> = ({
         return {
           fullLabel: d.key,
           label: truncate(d.key, { length: 18 }),
-          tooltip: `${d.key}: ${d.chart_doc_count.toLocaleString()}`,
+          tooltip: `${d.key}: ${d.chart_doc_count.toLocaleString()} (${(((d.chart_doc_count || 0) / totalDocs) * 100).toFixed(2)}%)`,
           value:
             variable.active_calculation === 'number'
               ? d.chart_doc_count


### PR DESCRIPTION
## Ticket Number

e.g. PRTL-2660

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
Added the percentage after the tooltip in histogram.