### PR TITLE
[PRTL 2666] 5 continuous bins

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1589,21 +1589,26 @@ export default compose(
       return ({ defaultContinuousData: {} });
     }
 
-    const dataStats = explore ? explore.cases.aggregations[`${createFacetFieldString(fieldName)}`].stats
+    const dataStats = explore 
+      ? explore.cases.aggregations[`${createFacetFieldString(fieldName)}`].stats
       : {
-        Min: null,
         Max: null,
+        Min: null,
       };
 
     const defaultMin = dataStats.Min;
     const defaultMax = dataStats.Max;
 
     const defaultQuartile = Number(((defaultMax - defaultMin) / 4).toFixed(2));
-    const defaultBuckets = Array(4).fill(1).map((val, key) => {
-      const from = Math.floor(key * defaultQuartile + defaultMin);
-      const to = Math.floor((key + 1) === 4
+
+    const defaultNumberOfBuckets = 5;
+    const defaultBucketSize = Number(((defaultMax - defaultMin) / defaultNumberOfBuckets).toFixed(2))
+
+    const defaultBuckets = Array(defaultNumberOfBuckets).fill(1).map((val, key) => {
+      const from = Math.floor(key * defaultBucketSize + defaultMin);
+      const to = Math.floor((key + 1) === defaultNumberOfBuckets
         ? defaultMax
-        : (defaultMin + (key + 1) * defaultQuartile - 1));
+        : (defaultMin + (key + 1) * defaultBucketSize - 1));
       const objKey = `${from}-${to}`;
 
       return ({

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
@@ -19,7 +19,7 @@ import ClinicalVariableCard from './ClinicalVariableCard';
 
 const simpleAggCache = {};
 const pendingAggCache = {};
-const DEFAULT_CONTINUOUS_BUCKETS = 4;
+const DEFAULT_CONTINUOUS_BUCKETS = 5;
 
 const getContinuousAggs = ({ fieldName, stats, filters, bins }) => {
   // prevent query failing if interval will equal 0


### PR DESCRIPTION
## Ticket Number

PRTL 2666

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

Make 5 continuous bins by default instead of 4.

The custom binning modal still uses quartiles.