### PR TITLE
[PRTL-2675] fix issue with empty cards

### DIFF
--- a/src/packages/@ncigdc/components/Modals/ContinuousBinning/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/components/Modals/ContinuousBinning/ContinuousCustomBinsModal.js
@@ -7,6 +7,7 @@ import BinningMethodInput from './BinningMethodInput';
 import CustomIntervalFields from './CustomIntervalFields';
 import styles from './styles';
 import RangeInputRow from './RangeInputRow';
+import { parseContinuousValue } from '@ncigdc/utils/string';
 
 const countDecimals = num => {
   return Math.floor(num) === num
@@ -253,16 +254,16 @@ class ContinuousCustomBinsModal extends Component {
 
         const buckets = Array(bucketCount).fill(1)
           .map((val, key) => {
-            const from = Number((key * intervalAmount + intervalMin).toFixed(2));
-            const to = Number(((key + 1) === bucketCount
-              ? intervalMax
-              : intervalMin + (key + 1) * intervalAmount - 1).toFixed(2));
+            const from = key * intervalAmount + intervalMin;
+            const to = (key + 1) === bucketCount
+              ? intervalMax + 1
+              : intervalMin + (key + 1) * intervalAmount;
 
             const objKey = `${from}-${to}`;
 
             return ({
               [objKey]: {
-                groupName: `${from} ${(key + 1) === bucketCount ? 'and up' : `to ${to}`}`,
+                groupName: `${parseContinuousValue(from)} to ${parseContinuousValue(to)}`,
                 key: objKey,
               },
             });
@@ -417,7 +418,7 @@ class ContinuousCustomBinsModal extends Component {
                 validateIntervalFields={e => {
                   this.validateIntervalFields(e);
                 }}
-                />
+              />
             </Column>
           </Row>
           <div
@@ -428,7 +429,7 @@ class ContinuousCustomBinsModal extends Component {
               }
             }}
             role="presentation"
-            >
+          >
             <div style={{ marginBottom: '15px' }}>
               <BinningMethodInput
                 binningMethod="range"
@@ -437,32 +438,32 @@ class ContinuousCustomBinsModal extends Component {
                   this.setState({ binningMethod: 'range' });
                 }}
                 label="Manually"
-                />
+              />
             </div>
             <div style={styles.wrapper}>
               <div style={styles.heading}>
                 <div
                   id="range-table-label-name"
                   style={styles.column}
-                  >
+                >
                   Bin Name
                 </div>
                 <div
                   id="range-table-label-min"
                   style={styles.column}
-                  >
+                >
                   From
                 </div>
                 <div
                   id="range-table-label-max"
                   style={styles.column}
-                  >
+                >
                   To
                 </div>
                 <div
                   id="range-table-label-options"
                   style={styles.optionsColumn}
-                  >
+                >
                   Options
                 </div>
               </div>
@@ -484,7 +485,7 @@ class ContinuousCustomBinsModal extends Component {
                     rowNameError={rangeNameErrors[rowIndex] || ''}
                     rowOverlapErrors={rangeOverlapErrors[rowIndex] || []}
                     styles={styles}
-                    />
+                  />
                 ))}
               </div>
               <RangeInputRow
@@ -493,7 +494,7 @@ class ContinuousCustomBinsModal extends Component {
                 rangeMethodActive={binningMethod === 'range'}
                 rangeRows={rangeRows}
                 styles={styles}
-                />
+              />
             </div>
           </div>
         </div>
@@ -503,20 +504,20 @@ class ContinuousCustomBinsModal extends Component {
             justifyContent: 'flex-end',
             margin: '20px',
           }}
-          >
+        >
           <span style={{
             color: 'red',
             justifyContent: 'flex-start',
             visibility: modalWarning.length > 0 ? 'visible' : 'hidden',
           }}
-                >
+          >
             {`Warning: ${modalWarning}`}
           </span>
           <Button
             onClick={onClose}
             onMouseDown={onClose}
             style={styles.visualizingButton}
-            >
+          >
             Cancel
           </Button>
           <Button
@@ -526,7 +527,7 @@ class ContinuousCustomBinsModal extends Component {
             style={submitDisabled
               ? styles.inputDisabled
               : styles.visualizingButton}
-            >
+          >
             Save Bins
           </Button>
         </Row>

--- a/src/packages/@ncigdc/dux/analysis.ts
+++ b/src/packages/@ncigdc/dux/analysis.ts
@@ -179,25 +179,19 @@ const reducer = (
               ...currentAnalysis.displayVariables,
               [action.payload.fieldName as string]: {
                 ...defaultVariableConfig,
-                ...(currentAnalysis.displayVariables.plotTypes === 'continuous' 
-                  ? defaultContinuousVariableConfig 
-                  : {}),
+                ...action.payload.plotTypes === 'continuous'
+                  ? defaultContinuousVariableConfig
+                  : {},
                 type: action.payload.fieldType,
                 plotTypes: action.payload.plotTypes,
                 scrollToCard: action.payload.scrollToCard,
-                ...(currentAnalysis.displayVariables.plotTypes === 'continuous'
-                  ? { 
-                      continuousBinType: action.payload.continuousBinType,
-                      continuousCustomInterval: action.payload.continuousCustomInterval, 
-                    }
-                  : {}),
               },
             },
           },
           ...state.saved.slice(currentAnalysisIndex + 1, Infinity),
         ],
       };
-    }
+    };
 
     // removes card from analysis
     case sets.REMOVE_CLINICAL_ANALYSIS_VARIABLE: {

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1663,9 +1663,11 @@ export default compose(
         setSurvivalPlotLoading(true);
         const dataForSurvival =
           variable.plotTypes === 'continuous'
-            ? dataBuckets
-              .sort((a, b) => a.key.split('-')[0] - b.key.split('-')[0])
-              .reduce(getContinuousBuckets, [])
+            ? dataBuckets.length > 0
+              ? dataBuckets
+                .sort((a, b) => a.key.split('-')[0] - b.key.split('-')[0])
+                .reduce(getContinuousBuckets, [])
+              : []
             : binData
               .filter(bucket => (IS_CDAVE_DEV ? bucket.key : bucket.key !== '_missing'))
               .map(b => ({

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1435,7 +1435,7 @@ export default compose(
                 ...acc,
                 [dataBuckets[index].key]: {
                   ...dataBuckets[index],
-                  groupName: [dataBuckets[index].key],
+                  groupName: dataBuckets[index].key,
                 }
               }), {})
               : (Object.keys(variable.bins).reduce((acc, curr, index) => ({
@@ -1467,7 +1467,8 @@ export default compose(
                 [r.key]: {
                   ...r,
                   groupName:
-                    typeof get(variable, `bins.${r.key}.groupName`, undefined) === 'string' // hidden value have groupName '', so check if it is string
+                    typeof get(variable, `bins.${r.key}.groupName`, undefined) === 'string'
+                      // hidden value have groupName '', so check if it is string
                       ? get(variable, `bins.${r.key}.groupName`, undefined)
                       : r.key,
                 },
@@ -1626,7 +1627,7 @@ export default compose(
 
       return ({
         [objKey]: {
-          groupName: objKey,
+          groupName: `${parseContinuousValue(from)} to ${parseContinuousValue(to)}`,
           key: objKey,
         },
       });

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1688,7 +1688,7 @@ export default compose(
         const valuesForTable =
           variable.plotTypes === 'categorical'
             ? filteredData.map(d => d.key).slice(0, 2)
-            : continuousTop2Values.map(d => d.key);
+            : continuousTop2Values.slice().reverse().map(d => d.key);
 
         const valuesForPlot =
           variable.plotTypes === 'categorical'

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1687,7 +1687,7 @@ export default compose(
         const valuesForTable =
           variable.plotTypes === 'categorical'
             ? filteredData.map(d => d.key).slice(0, 2)
-            : continuousTop2Values.map(d => d.key);
+            : continuousTop2Values.slice().reverse().map(d => d.key);
 
         const valuesForPlot =
           variable.plotTypes === 'categorical'

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1436,7 +1436,9 @@ export default compose(
             ...acc,
             [curr]: {
               ...variable.bins[curr],
-              doc_count: dataBuckets[index].doc_count,
+              doc_count: dataBuckets[index] 
+                ? dataBuckets[index].doc_count
+                : 0,
             },
           }), {})
           ) : ({
@@ -1713,7 +1715,7 @@ export default compose(
               .map(v => data.filter(d => d.key === v)[0])
               .map(filteredData => ({
                 ...filteredData,
-                doc_count: undefined,
+                doc_count: 0,
               }));
 
         getSurvivalCurvesArray({
@@ -1750,7 +1752,7 @@ export default compose(
         variable,
         wrapperId,
       } = this.props;
-      if (Object.keys(variable.bins).length === 0) {
+      if (variable.bins === undefined || isEmpty(variable.bins)) {
         dispatch(
           updateClinicalAnalysisVariable({
             fieldName,

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/index.js
@@ -1687,7 +1687,9 @@ export default compose(
         const valuesForTable =
           variable.plotTypes === 'categorical'
             ? filteredData.map(d => d.key).slice(0, 2)
-            : continuousTop2Values.slice().reverse().map(d => d.key);
+            : continuousTop2Values
+              .sort((a, b) => b.chart_doc_count - a.chart_doc_count)
+              .map(d => d.key);
 
         const valuesForPlot =
           variable.plotTypes === 'categorical'

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
@@ -31,10 +31,10 @@ const getContinuousAggs = ({ continuousBinType, fieldName, stats, filters, bins 
 
   const makeNewBuckets = () => Array(DEFAULT_CONTINUOUS_BUCKETS).fill(1).map(
     (val, key) => ({
-      from: parseContinuousValue(key * interval + stats.min),
-      to: parseContinuousValue((key + 1) === DEFAULT_CONTINUOUS_BUCKETS
-        ? stats.max
-        : (stats.min + (key + 1) * interval - 1)),
+      from: key * interval + stats.min,
+      to: (key + 1) === DEFAULT_CONTINUOUS_BUCKETS
+        ? stats.max + 1
+        : stats.min + (key + 1) * interval,
     })
   );
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
@@ -11,7 +11,7 @@ import _ from 'lodash';
 
 import consoleDebug from '@ncigdc/utils/consoleDebug';
 import { redirectToLogin } from '@ncigdc/utils/auth';
-import { createFacetFieldString } from '@ncigdc/utils/string'
+import { createFacetFieldString, parseContinuousValue } from '@ncigdc/utils/string'
 import Loader from '@ncigdc/uikit/Loaders/Loader';
 
 import { API, IS_AUTH_PORTAL } from '@ncigdc/utils/constants';
@@ -21,36 +21,43 @@ const simpleAggCache = {};
 const pendingAggCache = {};
 const DEFAULT_CONTINUOUS_BUCKETS = 4;
 
-const getContinuousAggs = ({ fieldName, stats, filters, bins }) => {
+const getContinuousAggs = ({ continuousBinType, fieldName, stats, filters, bins }) => {
   // prevent query failing if interval will equal 0
   if (_.isNull(stats.min) || _.isNull(stats.max)) {
     return null;
   }
 
-  let rangeArr = _.reduce(bins, (acc, bin, key) => {
-    const binValues = bin.key.split('-').map(keyValue => Number(keyValue));
-    const binFrom = binValues[0];
-    const binTo = binValues[1];
-    if (
-      !!bin &&
-      (typeof binFrom === 'number') &&
-      (typeof binTo === 'number') &&
-      (binFrom < binTo)
-    ) {
-      const result = [...acc, { from: binFrom, to: binTo }];
-      return result;
-    }
-    return acc;
-  }, []);
+  const interval = parseContinuousValue((stats.max - stats.min) / DEFAULT_CONTINUOUS_BUCKETS);
 
-  const interval = Math.round((stats.max - stats.min) / DEFAULT_CONTINUOUS_BUCKETS);
+  const makeNewBuckets = () => Array(DEFAULT_CONTINUOUS_BUCKETS).fill(1).map(
+    (val, key) => ({
+      from: parseContinuousValue(key * interval + stats.min),
+      to: parseContinuousValue((key + 1) === DEFAULT_CONTINUOUS_BUCKETS
+        ? stats.max
+        : (stats.min + (key + 1) * interval - 1)),
+    })
+  );
+
+  let rangeArr = continuousBinType === 'default'
+    ? rangeArr = makeNewBuckets()
+    : _.reduce(bins, (acc, bin, key) => {
+      const binValues = bin.key.split('-').map(keyValue => Number(keyValue));
+      const binFrom = binValues[0];
+      const binTo = binValues[1];
+      if (
+        !!bin &&
+        (typeof binFrom === 'number') &&
+        (typeof binTo === 'number') &&
+        (binFrom < binTo)
+      ) {
+        const result = [...acc, { from: binFrom, to: binTo }];
+        return result;
+      }
+      return acc;
+    }, []);
+
   if (rangeArr.length === 0) {
-    rangeArr = Array(DEFAULT_CONTINUOUS_BUCKETS).fill(1).map(
-      (val, key) => ({
-        from: key * interval + stats.min,
-        to: (key + 1) === DEFAULT_CONTINUOUS_BUCKETS ? stats.max : (stats.min + (key + 1) * interval - 1),
-      })
-    )
+    rangeArr = makeNewBuckets();
   }
 
   const filters2 = {
@@ -190,6 +197,7 @@ export default compose(
       hits,
     }) => {
       const res = await getContinuousAggs({
+        continuousBinType: variable.continuousBinType,
         fieldName,
         stats,
         filters,

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
@@ -27,37 +27,38 @@ const getContinuousAggs = ({ continuousBinType, fieldName, stats, filters, bins 
     return null;
   }
 
-  const interval = parseContinuousValue((stats.max - stats.min) / DEFAULT_CONTINUOUS_BUCKETS);
+  const interval = (stats.max - stats.min) / DEFAULT_CONTINUOUS_BUCKETS;
 
-  const makeNewBuckets = () => Array(DEFAULT_CONTINUOUS_BUCKETS).fill(1).map(
-    (val, key) => ({
-      from: key * interval + stats.min,
-      to: (key + 1) === DEFAULT_CONTINUOUS_BUCKETS
-        ? stats.max + 1
-        : stats.min + (key + 1) * interval,
-    })
-  );
+  const makeDefaultBuckets = () => Array(DEFAULT_CONTINUOUS_BUCKETS)
+    .fill(1).map(
+      (val, key) => ({
+        from: key * interval + stats.min,
+        to: (key + 1) === DEFAULT_CONTINUOUS_BUCKETS
+          ? stats.max + 1
+          : stats.min + (key + 1) * interval,
+      })
+    );
 
   let rangeArr = continuousBinType === 'default'
-    ? rangeArr = makeNewBuckets()
+    ? rangeArr = makeDefaultBuckets()
     : _.reduce(bins, (acc, bin, key) => {
       const binValues = bin.key.split('-').map(keyValue => Number(keyValue));
-      const binFrom = binValues[0];
-      const binTo = binValues[1];
+      const from = binValues[0];
+      const to = binValues[1];
       if (
         !!bin &&
-        (typeof binFrom === 'number') &&
-        (typeof binTo === 'number') &&
-        (binFrom < binTo)
+        (typeof from === 'number') &&
+        (typeof to === 'number') &&
+        (from < to)
       ) {
-        const result = [...acc, { from: binFrom, to: binTo }];
+        const result = [...acc, { from, to }];
         return result;
       }
       return acc;
     }, []);
 
   if (rangeArr.length === 0) {
-    rangeArr = makeNewBuckets();
+    rangeArr = makeDefaultBuckets();
   }
 
   const filters2 = {

--- a/src/packages/@ncigdc/utils/string.ts
+++ b/src/packages/@ncigdc/utils/string.ts
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 
 type TCapitalize = (original: string) => string;
-type THumanify = ({  }: IHumanifyParams) => string;
+type THumanify = ({ }: IHumanifyParams) => string;
 type TTruncateAfterMarker = (
   term: string,
   markers: [string],
@@ -11,6 +11,7 @@ type TTruncateAfterMarker = (
 ) => string;
 type TIsUuid = (query: string) => boolean;
 type TCreateFacetFieldString = (fieldName: string) => string;
+type TParseContinuousValue = (continuousValue: number | string) => number;
 
 interface IHumanifyParams {
   term: string;
@@ -92,3 +93,6 @@ export const isUUID: TIsUuid = query =>
   );
 
 export const createFacetFieldString: TCreateFacetFieldString = fieldName => fieldName.replace(/\./g, '__');
+
+export const parseContinuousValue: TParseContinuousValue = continuousValue =>
+  Number(Number(continuousValue).toFixed(2));


### PR DESCRIPTION
## Ticket Number

PRTL-2675

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

1. Fail gracefully if there's no data in continuous facets. 
2. When changing cohorts, update the buckets & disable the reset button.
3. Change continuous ranges to work with the API.
4. Only do rounding/parsing for display purposes (e.g. `groupName`), or to calculate the number of buckets (since that needs to be an integer)
5. Fix tooltip on survival plot selector button 