### PR TITLE
🚑 PRTL-2716 Remove link from clinical and bio totals

### DIFF
--- a/src/packages/@ncigdc/utils/constants.js
+++ b/src/packages/@ncigdc/utils/constants.js
@@ -86,8 +86,9 @@ export const DATA_CATEGORIES = {
 export const DATA_CATEGORIES_FOR_PROJECTS_TABLE = {
   ...DATA_CATEGORIES_COMMON,
   CLINICAL_METADATA: {
-    full: '',
     abbr: 'Clinical',
+    full: '',
+    hasTotalLink: false,
     tooltip: 'Clinical Metadata',
   },
   CLINICAL_SUPPLEMENT: {
@@ -97,8 +98,9 @@ export const DATA_CATEGORIES_FOR_PROJECTS_TABLE = {
     tooltip: 'Clinical Supplement',
   },
   BIOSPECIMEN_METADATA: {
-    full: '',
     abbr: 'Bio',
+    full: '',
+    hasTotalLink: false,
     tooltip: 'Biospecimen Metadata',
   },
   BIOSPECIMEN_SUPPLEMENT: {


### PR DESCRIPTION
## Ticket Number

SV-1480

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] qa-orange

## Description of Changes
Add optional key for category columns to remove link from column total. Default is true.
Addresses bug in filters for project clinical/bio totals.