### PR TITLE
✨PRTL-2704 nest molecular under followup

### DIFF
--- a/data/getSchema.js
+++ b/data/getSchema.js
@@ -6,9 +6,11 @@ const {
   printSchema,
 } = require('graphql/utilities');
 const path = require('path');
+
 const schemaPath = path.join(__dirname, 'schema');
 
-const SERVER = 'http://localhost:5000/graphql';
+// Takes 'node /data/getSchema.js https://api.gdc.cancer.gov/v0/'
+const SERVER = `${process.argv[2] || 'http://localhost:5000/'}graphql`;
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
 fetch(SERVER, {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -644,14 +644,14 @@ type Case implements Node {
   annotations: CaseAnnotations
   demographic: Demographic
   diagnoses: Diagnoses
-  files: CaseFiles
   exposures: Exposures
   family_histories: FamilyHistories
+  files: CaseFiles
+  follow_ups: FollowUps
   project: Project
   samples: Samples
   summary: Summary
   tissue_source_site: TissueSourceSite
-  follow_ups: FollowUps
   score: Int
 }
 
@@ -3208,6 +3208,20 @@ type CaseFiles {
   hits(offset: Int, sort: [Sort], filters: FiltersArgument, before: String, after: String, first: Int, last: Int): CaseFileConnection
 }
 
+type CivicAnnotation {
+  # keyword
+  gene_id: String
+
+  # keyword
+  variant_id: String
+  id: String
+}
+
+type ClinicalAnnotations {
+  civic: CivicAnnotation
+  id: String
+}
+
 type CNV implements Node {
   id: ID!
 
@@ -4801,6 +4815,8 @@ type ECaseAggregations {
   gene__symbol: Aggregations
   gene__gene_id: Aggregations
   gene__ssm__ncbi_build: Aggregations
+  gene__ssm__clinical_annotations__civic__gene_id: Aggregations
+  gene__ssm__clinical_annotations__civic__variant_id: Aggregations
   gene__ssm__observation__src_vcf_id: Aggregations
   gene__ssm__observation__mutation_status: Aggregations
   gene__ssm__observation__tumor_genotype__tumor_seq_allele1: Aggregations
@@ -7406,8 +7422,8 @@ scalar FiltersArgument
 
 type FollowUp implements Node {
   id: ID!
-  molecular_tests: MolecularTests
   annotations: CaseAnnotations
+  molecular_tests: MolecularTests
 
   # The percentage comparison to a normal value reference range of the volume of
   # air that a patient can forcibly exhale from the lungs in one second
@@ -7777,6 +7793,8 @@ type GeneAggregations {
   case__demographic__year_of_death: NumericAggregations
   case__submitter_id: Aggregations
   case__ssm__ncbi_build: Aggregations
+  case__ssm__clinical_annotations__civic__gene_id: Aggregations
+  case__ssm__clinical_annotations__civic__variant_id: Aggregations
   case__ssm__observation__src_vcf_id: Aggregations
   case__ssm__observation__mutation_status: Aggregations
   case__ssm__observation__tumor_genotype__tumor_seq_allele1: Aggregations
@@ -8656,38 +8674,6 @@ type NumericAggregations {
   stats: Stats
   histogram(interval: Float): Aggregations
   percentiles: Percentiles
-
-  #
-  #         Example for correct usage:
-  #         query ...
-  #         aggregations(filters: $filter1) {
-  #           diagnoses__age_at_diagnosis {
-  #             range(ranges: $filter2) {
-  #               buckets {
-  #                 doc_count
-  #                 key
-  #               }
-  #             }
-  #           }
-  #         }
-  #         ...
-  #
-  #         query variables
-  #         {..."filter2":{
-  #             "op":"range",
-  #             "content":[
-  #                 {
-  #                     "ranges":[
-  #                             {"to": 10585},
-  #                             {"from": 10950, "to": 21535},
-  #                             {"from": 21900, "to": 32485},
-  #                             {"from":33000}
-  #                     ]
-  #                 }
-  #             ]
-  #         }...}
-  #
-  #         
   range(ranges: FiltersArgument): Aggregations
 }
 
@@ -9714,9 +9700,6 @@ type Ssm implements Node {
   ncbi_build: String
 
   # keyword
-  mutation_type: String
-
-  # keyword
   mutation_subtype: String
 
   # long
@@ -9738,21 +9721,26 @@ type Ssm implements Node {
   tumor_allele: String
 
   # keyword
+  mutation_type: String
+
+  # keyword
   chromosome: String
 
   # keyword
   genomic_dna_change: String
-  external_db_ids: SsmGeneExternalDbIds
+  clinical_annotations: ClinicalAnnotations
   consequence: SSMConsequences
-  occurrence: SSMOccurrences
   cosmic_id: [String]
+  external_db_ids: SsmGeneExternalDbIds
   gene_aa_change: [String]
+  occurrence: SSMOccurrences
   score: Int
 }
 
 type SsmAggregations {
   ncbi_build: Aggregations
-  mutation_type: Aggregations
+  clinical_annotations__civic__gene_id: Aggregations
+  clinical_annotations__civic__variant_id: Aggregations
   occurrence__case__exposures__cigarettes_per_day: NumericAggregations
   occurrence__case__exposures__weight: NumericAggregations
   occurrence__case__exposures__updated_datetime: Aggregations
@@ -9921,6 +9909,7 @@ type SsmAggregations {
   occurrence__case__available_variation_data: Aggregations
   occurrence__case__disease_type: Aggregations
   occurrence__occurrence_id: Aggregations
+  gene_aa_change: Aggregations
   mutation_subtype: Aggregations
   end_position: NumericAggregations
   reference_allele: Aggregations
@@ -9980,7 +9969,7 @@ type SsmAggregations {
   consequence__transcript__annotation__hgvsp_short: Aggregations
   consequence__transcript__ref_seq_accession: Aggregations
   tumor_allele: Aggregations
-  gene_aa_change: Aggregations
+  mutation_type: Aggregations
   chromosome: Aggregations
   genomic_dna_change: Aggregations
 }

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -625,6 +625,9 @@ type Case implements Node {
   disease_type: String
 
   # keyword
+  diagnosis_ids: String
+
+  # keyword
   submitter_aliquot_ids: String
 
   # keyword
@@ -632,6 +635,9 @@ type Case implements Node {
 
   # keyword
   primary_site: String
+
+  # keyword
+  submitter_diagnosis_ids: String
 
   # keyword
   submitter_slide_ids: String
@@ -645,6 +651,7 @@ type Case implements Node {
   samples: Samples
   summary: Summary
   tissue_source_site: TissueSourceSite
+  follow_ups: FollowUps
   score: Int
 }
 
@@ -755,7 +762,7 @@ type CaseAggregations {
 
   # Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.
   #
-  samples__time_between_excision_and_freezing: Aggregations
+  samples__time_between_excision_and_freezing: NumericAggregations
 
   # Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.
   #
@@ -770,13 +777,13 @@ type CaseAggregations {
   # UUID for identifying or recalling a node.
   #
   samples__submitter_id: Aggregations
-  samples__intermediate_dimension: Aggregations
+  samples__intermediate_dimension: NumericAggregations
   samples__sample_id: Aggregations
 
   # Numeric representation of the elapsed time between the surgical clamping of
   # blood supply and freezing of the sample, measured in minutes.
   #
-  samples__time_between_clamping_and_freezing: Aggregations
+  samples__time_between_clamping_and_freezing: NumericAggregations
 
   # UUID of the related pathology report.
   samples__pathology_report_uuid: Aggregations
@@ -872,7 +879,7 @@ type CaseAggregations {
 
   # Numeric value that represents the shortest dimension of the sample, measured in millimeters.
   #
-  samples__shortest_dimension: Aggregations
+  samples__shortest_dimension: NumericAggregations
 
   # The method used to procure the sample used to extract analyte(s).
   #
@@ -1411,7 +1418,7 @@ type CaseAggregations {
   # Numeric value that represents the initial weight of the sample, measured in milligrams.
   #
   samples__initial_weight: NumericAggregations
-  samples__longest_dimension: Aggregations
+  samples__longest_dimension: NumericAggregations
   submitter_sample_ids: Aggregations
 
   # Status of the annotation.
@@ -1465,10 +1472,6 @@ type CaseAggregations {
   #
   exposures__cigarettes_per_day: NumericAggregations
 
-  # The year in which the participant quit smoking.
-  #
-  exposures__tobacco_smoking_quit_year: NumericAggregations
-
   # The weight of the patient measured in kilograms.
   #
   exposures__weight: NumericAggregations
@@ -1476,19 +1479,6 @@ type CaseAggregations {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   exposures__updated_datetime: Aggregations
-
-  # A response to a question that asks whether the participant has consumed at
-  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
-  #
-  exposures__alcohol_history: Aggregations
-
-  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
-  #
-  exposures__alcohol_intensity: Aggregations
-
-  # A calculated numerical quantity that represents an individual's weight to height ratio.
-  #
-  exposures__bmi: NumericAggregations
 
   # Numeric value (or unknown) to represent the number of years a person has been smoking.
   #
@@ -1498,45 +1488,106 @@ type CaseAggregations {
   #
   exposures__height: NumericAggregations
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # smoke that is emitted from burning tobacco, including cigarettes, pipes, and
+  # cigars. This includes tobacco smoke exhaled by smokers.
   #
-  exposures__created_datetime: Aggregations
-
-  # The current state of the object.
-  #
-  exposures__state: Aggregations
+  exposures__environmental_tobacco_smoke_exposure: Aggregations
 
   # Category describing current smoking status and smoking history as self-reported by a patient.
   #
   exposures__tobacco_smoking_status: Aggregations
 
+  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  #
+  exposures__alcohol_days_per_week: NumericAggregations
+
+  # Numeric computed value to represent lifetime tobacco exposure defined as
+  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  #
+  exposures__pack_years_smoked: NumericAggregations
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposured
+  # to respirable crystalline silica, a widespread, naturally occurring,
+  # crystalline metal oxide that consists of different forms including quartz,
+  # cristobalite, tridymite, tripoli, ganister, chert and novaculite.
+  #
+  exposures__respirable_crystalline_silica_exposure: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # fine powder derived by the crushing of coal.
+  #
+  exposures__coal_dust_exposure: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  exposures__created_datetime: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.
+  #
+  exposures__asbestos_exposure: Aggregations
+
+  # The current state of the object.
+  #
+  exposures__state: Aggregations
+
+  # The text term used to describe the specific type of tobacco used by the patient.
+  #
+  exposures__type_of_tobacco_used: Aggregations
+
   # The year in which the participant began smoking.
   #
   exposures__tobacco_smoking_onset_year: NumericAggregations
+
+  # A response to a question that asks whether the participant has consumed at
+  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
+  #
+  exposures__alcohol_history: Aggregations
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  exposures__bmi: NumericAggregations
+
+  # The text term used to generally decribe how often the patient smokes.
+  #
+  exposures__smoking_frequency: Aggregations
 
   # Numeric value used to describe the average number of alcoholic beverages  a person consumes per day.
   #
   exposures__alcohol_drinks_per_day: NumericAggregations
 
-  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  # The text term used to describe the patient's specific type of smoke exposure.
   #
-  exposures__alcohol_days_per_week: NumericAggregations
+  exposures__type_of_smoke_exposure: Aggregations
+  exposures__exposure_id: Aggregations
 
   # A project-specific identifier for a node. This property is the calling
   # card/nickname/alias for a unit of submission. It can be used in place of the
   # UUID for identifying or recalling a node.
   #
   exposures__submitter_id: Aggregations
-  exposures__exposure_id: Aggregations
 
-  # Numeric computed value to represent lifetime tobacco exposure defined as
-  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
   #
-  exposures__pack_years_smoked: NumericAggregations
+  exposures__alcohol_intensity: Aggregations
+
+  # The text term used to describe the approximate amount of time elapsed between
+  # the time the patient wakes up in the morning to the time they smoke their
+  # first cigarette.
+  #
+  exposures__time_between_waking_and_first_smoke: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to radon.
+  #
+  exposures__radon_exposure: Aggregations
+
+  # The year in which the participant quit smoking.
+  #
+  exposures__tobacco_smoking_quit_year: NumericAggregations
   files__origin: Aggregations
-  files__proportion_base_mismatch: NumericAggregations
+  files__chip_id: Aggregations
+  files__index_files__chip_id: Aggregations
   files__index_files__proportion_base_mismatch: NumericAggregations
-  files__index_files__updated_datetime: Aggregations
   files__index_files__file_name: Aggregations
   files__index_files__submitter_id: Aggregations
   files__index_files__read_pair_number: Aggregations
@@ -1553,14 +1604,21 @@ type CaseAggregations {
   files__index_files__magnification: NumericAggregations
   files__index_files__mean_coverage: NumericAggregations
   files__index_files__average_read_length: NumericAggregations
+  files__index_files__contamination_error: NumericAggregations
+  files__index_files__channel: Aggregations
   files__index_files__experimental_strategy: Aggregations
+  files__index_files__updated_datetime: Aggregations
   files__index_files__data_type: Aggregations
+  files__index_files__chip_position: Aggregations
   files__index_files__proportion_coverage_10X: NumericAggregations
   files__index_files__file_id: Aggregations
+  files__index_files__contamination: NumericAggregations
   files__index_files__proportion_reads_duplicated: NumericAggregations
   files__index_files__total_reads: NumericAggregations
   files__index_files__state_comment: Aggregations
+  files__index_files__plate_well: Aggregations
   files__index_files__md5sum: Aggregations
+  files__index_files__plate_name: Aggregations
   files__index_files__data_format: Aggregations
   files__index_files__proportion_reads_mapped: NumericAggregations
   files__index_files__proportion_targets_no_coverage: NumericAggregations
@@ -1582,8 +1640,8 @@ type CaseAggregations {
   files__downstream_analyses__workflow_type: Aggregations
   files__downstream_analyses__workflow_start_datetime: Aggregations
   files__downstream_analyses__workflow_version: Aggregations
+  files__downstream_analyses__output_files__chip_id: Aggregations
   files__downstream_analyses__output_files__proportion_base_mismatch: NumericAggregations
-  files__downstream_analyses__output_files__updated_datetime: Aggregations
   files__downstream_analyses__output_files__file_name: Aggregations
   files__downstream_analyses__output_files__submitter_id: Aggregations
   files__downstream_analyses__output_files__read_pair_number: Aggregations
@@ -1600,14 +1658,21 @@ type CaseAggregations {
   files__downstream_analyses__output_files__magnification: NumericAggregations
   files__downstream_analyses__output_files__mean_coverage: NumericAggregations
   files__downstream_analyses__output_files__average_read_length: NumericAggregations
+  files__downstream_analyses__output_files__contamination_error: NumericAggregations
+  files__downstream_analyses__output_files__channel: Aggregations
   files__downstream_analyses__output_files__experimental_strategy: Aggregations
+  files__downstream_analyses__output_files__updated_datetime: Aggregations
   files__downstream_analyses__output_files__data_type: Aggregations
+  files__downstream_analyses__output_files__chip_position: Aggregations
   files__downstream_analyses__output_files__proportion_coverage_10X: NumericAggregations
   files__downstream_analyses__output_files__file_id: Aggregations
+  files__downstream_analyses__output_files__contamination: NumericAggregations
   files__downstream_analyses__output_files__proportion_reads_duplicated: NumericAggregations
   files__downstream_analyses__output_files__total_reads: NumericAggregations
   files__downstream_analyses__output_files__state_comment: Aggregations
+  files__downstream_analyses__output_files__plate_well: Aggregations
   files__downstream_analyses__output_files__md5sum: Aggregations
+  files__downstream_analyses__output_files__plate_name: Aggregations
   files__downstream_analyses__output_files__data_format: Aggregations
   files__downstream_analyses__output_files__proportion_reads_mapped: NumericAggregations
   files__downstream_analyses__output_files__proportion_targets_no_coverage: NumericAggregations
@@ -1655,11 +1720,9 @@ type CaseAggregations {
   # The current state of the object.
   #
   files__state: Aggregations
-  files__release_number: Aggregations
   files__access: Aggregations
   files__platform: Aggregations
   files__magnification: NumericAggregations
-  files__version: Aggregations
   files__metadata_files__md5sum: Aggregations
   files__metadata_files__type: Aggregations
   files__metadata_files__data_type: Aggregations
@@ -1676,18 +1739,28 @@ type CaseAggregations {
   files__metadata_files__file_size: NumericAggregations
   files__metadata_files__state_comment: Aggregations
   files__average_read_length: NumericAggregations
+  files__contamination_error: NumericAggregations
   files__type: Aggregations
+  files__channel: Aggregations
   files__revision: NumericAggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  files__updated_datetime: Aggregations
   files__data_type: Aggregations
   files__tags: Aggregations
+  files__chip_position: Aggregations
   files__proportion_coverage_10X: NumericAggregations
   files__file_id: Aggregations
+  files__contamination: NumericAggregations
+  files__proportion_base_mismatch: NumericAggregations
   files__proportion_reads_duplicated: NumericAggregations
   files__total_reads: NumericAggregations
 
   # Optional comment about why the file is in the current state, mainly for invalid state.
   #
   files__state_comment: Aggregations
+  files__plate_well: Aggregations
   files__data_format: Aggregations
   files__center__code: Aggregations
   files__center__name: Aggregations
@@ -1695,21 +1768,17 @@ type CaseAggregations {
   files__center__namespace: Aggregations
   files__center__center_id: Aggregations
   files__center__center_type: Aggregations
-  files__baseid: Aggregations
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
   files__md5sum: Aggregations
-
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-  #
-  files__updated_datetime: Aggregations
+  files__plate_name: Aggregations
   files__mean_coverage: NumericAggregations
   files__analysis__analysis_id: Aggregations
   files__analysis__updated_datetime: Aggregations
   files__analysis__created_datetime: Aggregations
+  files__analysis__input_files__chip_id: Aggregations
   files__analysis__input_files__proportion_base_mismatch: NumericAggregations
-  files__analysis__input_files__updated_datetime: Aggregations
   files__analysis__input_files__file_name: Aggregations
   files__analysis__input_files__submitter_id: Aggregations
   files__analysis__input_files__read_pair_number: Aggregations
@@ -1726,14 +1795,21 @@ type CaseAggregations {
   files__analysis__input_files__magnification: NumericAggregations
   files__analysis__input_files__mean_coverage: NumericAggregations
   files__analysis__input_files__average_read_length: NumericAggregations
+  files__analysis__input_files__contamination_error: NumericAggregations
+  files__analysis__input_files__channel: Aggregations
   files__analysis__input_files__experimental_strategy: Aggregations
+  files__analysis__input_files__updated_datetime: Aggregations
   files__analysis__input_files__data_type: Aggregations
+  files__analysis__input_files__chip_position: Aggregations
   files__analysis__input_files__proportion_coverage_10X: NumericAggregations
   files__analysis__input_files__file_id: Aggregations
+  files__analysis__input_files__contamination: NumericAggregations
   files__analysis__input_files__proportion_reads_duplicated: NumericAggregations
   files__analysis__input_files__total_reads: NumericAggregations
   files__analysis__input_files__state_comment: Aggregations
+  files__analysis__input_files__plate_well: Aggregations
   files__analysis__input_files__md5sum: Aggregations
+  files__analysis__input_files__plate_name: Aggregations
   files__analysis__input_files__data_format: Aggregations
   files__analysis__input_files__proportion_reads_mapped: NumericAggregations
   files__analysis__input_files__proportion_targets_no_coverage: NumericAggregations
@@ -1825,6 +1901,345 @@ type CaseAggregations {
   files__data_category: Aggregations
   files__experimental_strategy: Aggregations
   files__average_insert_size: NumericAggregations
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # post-bronchodilator.
+  #
+  follow_ups__fev1_ref_post_bronch_percent: NumericAggregations
+
+  # The weight of the patient measured in kilograms.
+  #
+  follow_ups__weight: NumericAggregations
+
+  # Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).
+  #
+  follow_ups__reflux_treatment_type: Aggregations
+
+  # The text term used to describe the type of progressive or recurrent disease or relapsed disease.
+  #
+  follow_ups__progression_or_recurrence_type: Aggregations
+
+  # The height of the patient in centimeters.
+  #
+  follow_ups__height: NumericAggregations
+
+  # Number of days between the date used for index and the date of the patient's adverse event.
+  #
+  follow_ups__days_to_adverse_event: NumericAggregations
+
+  # The text term used to describe the suspected cause or reason for the patient disease response.
+  #
+  follow_ups__cause_of_response: Aggregations
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.
+  #
+  follow_ups__fev1_fvc_pre_bronch_percent: NumericAggregations
+
+  # The ECOG functional performance status of the patient/participant.
+  #
+  follow_ups__ecog_performance_status: Aggregations
+
+  # Text classification to represent the strain or type of human papillomavirus identified in an individual.
+  #
+  follow_ups__hpv_positive_type: Aggregations
+
+  # Number of days between the date used for index and the date the patient's
+  # disease was formally confirmed as progression-free.
+  #
+  follow_ups__days_to_progression_free: NumericAggregations
+
+  # Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.
+  #
+  follow_ups__days_to_follow_up: NumericAggregations
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.
+  #
+  follow_ups__fev1_fvc_post_bronch_percent: NumericAggregations
+
+  # The text term used to describe the method used to diagnose the patient's comorbidity disease.
+  #
+  follow_ups__comorbidity_method_of_diagnosis: Aggregations
+
+  # The value, as a percentage of predicted lung volume, measuring the amount of
+  # carbon monoxide detected in a patient's lungs.
+  #
+  follow_ups__dlco_ref_predictive_percent: NumericAggregations
+
+  # The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.
+  #
+  follow_ups__comorbidity: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__updated_datetime: Aggregations
+
+  # The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__risk_factor: Aggregations
+
+  # The current state of the object.
+  #
+  follow_ups__state: Aggregations
+
+  # Number of days between the date used for index and the date the patient's disease progressed.
+  #
+  follow_ups__days_to_progression: NumericAggregations
+
+  # Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.
+  #
+  follow_ups__adverse_event: Aggregations
+
+  # Number of days between the date used for index and the date the patient's disease recurred.
+  #
+  follow_ups__days_to_recurrence: NumericAggregations
+
+  # The yes/no/unknown indicator used to describe whether the mutation included in
+  # molecular testing was known to have an affect on the mismatch repair process.
+  #
+  follow_ups__molecular_tests__mismatch_repair_mutation: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__molecular_tests__updated_datetime: Aggregations
+
+  # The text term used to describe an antigen included in molecular testing.
+  #
+  follow_ups__molecular_tests__antigen: Aggregations
+
+  # The text term used to describe the biological origin of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__variant_origin: Aggregations
+
+  # Numeric value used to describe the lower limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  follow_ups__molecular_tests__blood_test_normal_range_lower: NumericAggregations
+
+  # Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.
+  #
+  follow_ups__molecular_tests__locus: Aggregations
+
+  # The text term or numeric value used to describe a sepcific result of a molecular test.
+  #
+  follow_ups__molecular_tests__test_value: NumericAggregations
+
+  # The text term used to describe a secondary gene targeted or included in
+  # molecular analysis. For rearrangements, this is should represent the location
+  # of the variant.
+  #
+  follow_ups__molecular_tests__second_gene_symbol: Aggregations
+
+  # Text term used to describe the number of sets of homologous chromosomes.
+  #
+  follow_ups__molecular_tests__ploidy: Aggregations
+
+  # The text term used to describe a chromosome targeted or included in molecular
+  # testing. If a specific genetic variant is being reported, this property can be
+  # used to capture the chromosome where that variant is located.
+  #
+  follow_ups__molecular_tests__chromosome: Aggregations
+
+  # Text term used to describe a specific test that is not covered in the list of molecular analysis methods.
+  #
+  follow_ups__molecular_tests__specialized_molecular_test: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__molecular_tests__created_datetime: Aggregations
+
+  # Intron number targeted or included in molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # intron where that variant is located.
+  #
+  follow_ups__molecular_tests__intron: Aggregations
+
+  # The text term used to describe a gene targeted or included in molecular
+  # analysis. For rearrangements, this is shold be used to represent the reference gene.
+  #
+  follow_ups__molecular_tests__gene_symbol: Aggregations
+
+  # The current state of the object.
+  #
+  follow_ups__molecular_tests__state: Aggregations
+
+  # The text term used to describe a specific histone variants, which are proteins
+  # that substitute for the core canonical histones.
+  #
+  follow_ups__molecular_tests__histone_variant: Aggregations
+
+  # Numeric value used to describe the number of cells used for molecular testing.
+  #
+  follow_ups__molecular_tests__cell_count: NumericAggregations
+
+  # The text term used to describe the family, or classification of a group of
+  # basic proteins found in chromatin, called histones.
+  #
+  follow_ups__molecular_tests__histone_family: Aggregations
+
+  # Numeric value used to describe the number of times a section of the genome is
+  # repeated or copied within an insertion, duplication or deletion variant.
+  #
+  follow_ups__molecular_tests__copy_number: NumericAggregations
+
+  # The text term used to describe the type of analyte used for molecular testing.
+  #
+  follow_ups__molecular_tests__test_analyte_type: Aggregations
+
+  # Exon number targeted or included in a molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # exon where that variant is located.
+  #
+  follow_ups__molecular_tests__exon: Aggregations
+
+  # The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.
+  #
+  follow_ups__molecular_tests__laboratory_test: Aggregations
+
+  # The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.
+  #
+  follow_ups__molecular_tests__test_result: Aggregations
+
+  # Alphanumeric value used to describe the transcript of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__transcript: Aggregations
+
+  # Numeric value used to describe the upper limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  follow_ups__molecular_tests__blood_test_normal_range_upper: NumericAggregations
+
+  # The text term used to describe the units of the test value for a molecular
+  # test. This property is used in conjunction with test_value.
+  #
+  follow_ups__molecular_tests__test_units: Aggregations
+
+  # The text term used to describe the zygosity of a specific genetic variant.
+  #
+  follow_ups__molecular_tests__zygosity: Aggregations
+
+  # Alphanumeric value used to describe the cytoband or chromosomal location
+  # targeted or included in molecular analysis. If a specific genetic variant is
+  # being reported, this property can be used to capture the cytoband where the
+  # variant is located. Format: [chromosome][chromosome arm].[band+sub-bands].
+  # Example: 17p13.1.
+  #
+  follow_ups__molecular_tests__cytoband: Aggregations
+
+  # The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.
+  follow_ups__molecular_tests__biospecimen_type: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  follow_ups__molecular_tests__submitter_id: Aggregations
+
+  # The second exon number involved in molecular variation. If a specific genetic
+  # variant is being reported, this property can be used to capture the second
+  # exon where that variant is located. This property is typically used for a
+  # translocation where two different locations are involved in the variation.
+  #
+  follow_ups__molecular_tests__second_exon: Aggregations
+  follow_ups__molecular_tests__molecular_test_id: Aggregations
+
+  # The text term used to describe the method used for molecular analysis.
+  #
+  follow_ups__molecular_tests__molecular_analysis_method: Aggregations
+
+  # The text term used to describe the molecular consequence of genetic variation.
+  #
+  follow_ups__molecular_tests__molecular_consequence: Aggregations
+
+  # The text term used to describe the type of genetic variation.
+  #
+  follow_ups__molecular_tests__variant_type: Aggregations
+
+  # Numeric value used to describe the number of loci determined to be abnormal.
+  #
+  follow_ups__molecular_tests__loci_abnormal_count: NumericAggregations
+
+  # Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.
+  #
+  follow_ups__molecular_tests__aa_change: Aggregations
+
+  # Numeric value used to describe the number of loci tested.
+  #
+  follow_ups__molecular_tests__loci_count: NumericAggregations
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  follow_ups__bmi: NumericAggregations
+
+  # Text term used to describe the patient's menopause status.
+  #
+  follow_ups__menopause_status: Aggregations
+
+  # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
+  #
+  follow_ups__progression_or_recurrence: Aggregations
+
+  # Text term used to describe the types of treatment used to manage diabetes.
+  #
+  follow_ups__diabetes_treatment_type: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__risk_factor_treatment: Aggregations
+
+  # The text term used to describe the anatomic site of the progressive or recurrent disease.
+  #
+  follow_ups__progression_or_recurrence_anatomic_site: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  follow_ups__submitter_id: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether goblet cells were
+  # determined to be present in a patient diagnosed with Barrett's esophagus.
+  #
+  follow_ups__barretts_esophagus_goblet_cells_present: Aggregations
+
+  # Code assigned to describe the patient's response or outcome to the disease.
+  #
+  follow_ups__disease_response: Aggregations
+  follow_ups__follow_up_id: Aggregations
+
+  # Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.
+  #
+  follow_ups__pancreatitis_onset_year: NumericAggregations
+
+  # Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.
+  #
+  follow_ups__viral_hepatitis_serologies: Aggregations
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # pre-bronchodilator.
+  #
+  follow_ups__fev1_ref_pre_bronch_percent: NumericAggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  follow_ups__created_datetime: Aggregations
+
+  # Text term used to describe the classification used of the functional capabilities of a person.
+  #
+  follow_ups__karnofsky_performance_status: Aggregations
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  follow_ups__hepatitis_sustained_virological_response: Aggregations
+
+  # Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.
+  #
+  follow_ups__days_to_comorbidity: NumericAggregations
   index_date: Aggregations
   case_autocomplete: Aggregations
 
@@ -1868,6 +2283,7 @@ type CaseAggregations {
   #
   family_histories__relationship_age_at_diagnosis: NumericAggregations
   submitter_id: Aggregations
+  disease_type: Aggregations
 
   # Text term that represents the type of vascular tumor invasion.
   #
@@ -1897,9 +2313,9 @@ type CaseAggregations {
   #
   diagnoses__submitter_id: Aggregations
 
-  # The survival state of the person registered on the protocol.
+  # The text term used to describe the extent of metastatic disease present at diagnosis.
   #
-  diagnoses__vital_status: Aggregations
+  diagnoses__metastasis_at_diagnosis: Aggregations
 
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
@@ -1911,7 +2327,6 @@ type CaseAggregations {
   # immunocytochemical stains. A system of numbered categories for representation of data.
   #
   diagnoses__morphology: Aggregations
-  diagnoses__days_to_death: NumericAggregations
 
   # Time interval from the date of last follow up to the date of initial
   # pathologic diagnosis, represented as a calculated number of days.
@@ -1921,7 +2336,6 @@ type CaseAggregations {
   # Text term used to describe the classification of rhabdomyosarcoma, as defined by the Children's Oncology Group (COG).
   #
   diagnoses__cog_rhabdomyosarcoma_risk_group: Aggregations
-  diagnoses__days_to_hiv_diagnosis: NumericAggregations
 
   # Code of pathological T (primary tumor) to define the size or contiguous
   # extension of the primary tumor (T), using staging criteria from the American
@@ -1952,6 +2366,16 @@ type CaseAggregations {
   #
   diagnoses__ajcc_pathologic_n: Aggregations
 
+  # The text term used to describe the overall Weiss assessment score, a commonly
+  # used assessment describing the malignancy of adrenocortical tumors. The Weiss
+  # score is determined based on nine histological criteria including the
+  # following: high nuclear grade, mitotic rate greater than five per 50 high
+  # power fields (HPF), atypical mitotic figures, eosinophilic tumor cell
+  # cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than
+  # 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.
+  #
+  diagnoses__weiss_assessment_score: Aggregations
+
   # Text term and code that represents the metastatic stage of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
@@ -1961,6 +2385,11 @@ type CaseAggregations {
   # Text term to describe the amount of dysplasia found within the benign esophageal columnar mucosa.
   #
   diagnoses__esophageal_columnar_dysplasia_degree: Aggregations
+
+  # The number of lymph nodes tested to determine whether lymph nodes were 
+  # involved with disease as determined by a pathologic examination.
+  #
+  diagnoses__lymph_nodes_tested: NumericAggregations
 
   # The text term used to describe the classification of the histopathologic degree of liver damage.
   #
@@ -1973,6 +2402,12 @@ type CaseAggregations {
   # Text term to specify the location of the supratentorial tumor.
   #
   diagnoses__supratentorial_localization: Aggregations
+
+  # The text term used to describe the International Germ Cell Cancer
+  # Collaborative Group (IGCCCG), a grouping used to further classify metastatic
+  # testicular tumors.
+  #
+  diagnoses__igcccg_stage: Aggregations
 
   # The yes/no/unknown/not reported indicator used to describe whether the tumor
   # is located across the gastroesophageal junction.
@@ -1987,13 +2422,17 @@ type CaseAggregations {
   # The multiple myeloma disease stage at diagnosis.
   #
   diagnoses__iss_stage: Aggregations
-  diagnoses__cause_of_death: Aggregations
 
   # Text term and code that represents the tumor site of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
   #
   diagnoses__enneking_msts_tumor_site: Aggregations
+
+  # A numeric value used to measure therapeutic response of the primary tumor and
+  # predict patient outcomes based on a three-point tumor regression grading system.
+  #
+  diagnoses__tumor_regression_grade: Aggregations
 
   # Numeric value used to describe the gross pathologic tumor weight, measured in grams.
   #
@@ -2003,7 +2442,6 @@ type CaseAggregations {
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
   #
   diagnoses__ajcc_clinical_stage: Aggregations
-  diagnoses__hiv_positive: Aggregations
 
   # Text term to signify whether lymphoma B-symptoms are present as noted in the patient's medical record.
   #
@@ -2018,10 +2456,6 @@ type CaseAggregations {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   diagnoses__updated_datetime: Aggregations
-
-  # The text term used to describe the extent of metastatic disease present at diagnosis.
-  #
-  diagnoses__metastasis_at_diagnosis: Aggregations
 
   # Number of days between the date used for index and the date of the patient was
   # thought to have the best overall response to their disease.
@@ -2039,7 +2473,6 @@ type CaseAggregations {
   # Age at the time of diagnosis expressed in number of days since birth.
   #
   diagnoses__age_at_diagnosis: NumericAggregations
-  diagnoses__hpv_positive_type: Aggregations
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
@@ -2095,7 +2528,6 @@ type CaseAggregations {
   # The yes/no/unknown indicator used to describe the patient's history of prior cancer diagnosis.
   #
   diagnoses__prior_malignancy: Aggregations
-  diagnoses__days_to_new_event: NumericAggregations
 
   # Numeric value used to describe the non-peritonealised bare area of rectum,
   # comprising anterior and posterior segments, when submitted as a surgical
@@ -2128,7 +2560,15 @@ type CaseAggregations {
   # Numeric value to represent the year of an individual's initial pathologic diagnosis of cancer.
   #
   diagnoses__year_of_diagnosis: NumericAggregations
-  diagnoses__progression_free_survival: NumericAggregations
+
+  # The text term used to describe the secondary Gleason score, which describes
+  # the pattern of cells making up the second largest area of the tumor. The
+  # primary and secondary Gleason pattern grades are combined to determine the
+  # patient's Gleason grade group, which is used to determine the aggresiveness of
+  # prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  diagnoses__secondary_gleason_grade: Aggregations
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -2153,6 +2593,10 @@ type CaseAggregations {
   #
   diagnoses__perineural_invasion_present: Aggregations
 
+  # The text term used to describe whether the patient's disease originated in a single location or multiple locations.
+  #
+  diagnoses__tumor_focality: Aggregations
+
   # The text term used to describe the classification of Wilms tumors
   # distinguishing between favorable and unfavorable histologic groups.
   #
@@ -2161,7 +2605,6 @@ type CaseAggregations {
   # Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.
   #
   diagnoses__ajcc_clinical_t: Aggregations
-  diagnoses__colon_polyps_history: Aggregations
 
   # Extent of the regional lymph node involvement for the cancer based on evidence
   # obtained from clinical assessment parameters determined prior to treatment.
@@ -2188,7 +2631,53 @@ type CaseAggregations {
   # specifically describes the extent of the primary tumor prior to treatment.
   #
   diagnoses__cog_liver_stage: Aggregations
-  diagnoses__progression_free_survival_event: Aggregations
+
+  # Status of the annotation.
+  diagnoses__annotations__status: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__legacy_updated_datetime: Aggregations
+  diagnoses__annotations__entity_id: Aggregations
+
+  # Top level classification of the annotation.
+  diagnoses__annotations__classification: Aggregations
+
+  # Name of the person or entity responsible for the creation of the annotation.
+  diagnoses__annotations__creator: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__created_datetime: Aggregations
+  diagnoses__annotations__entity_submitter_id: Aggregations
+
+  # Open entry for any further description or characterization of the data.
+  diagnoses__annotations__notes: Aggregations
+  diagnoses__annotations__entity_type: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__updated_datetime: Aggregations
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  diagnoses__annotations__legacy_created_datetime: Aggregations
+
+  # The current state of the object.
+  #
+  diagnoses__annotations__state: Aggregations
+  diagnoses__annotations__case_id: Aggregations
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  diagnoses__annotations__submitter_id: Aggregations
+  diagnoses__annotations__annotation_id: Aggregations
+  diagnoses__annotations__case_submitter_id: Aggregations
+
+  # Top level characterization of the annotation.
+  diagnoses__annotations__category: Aggregations
 
   # Text term used to describe the stage of the musculoskeletal sarcoma, using the
   # Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).
@@ -2226,7 +2715,11 @@ type CaseAggregations {
   # The total number of peripancreatic lymph nodes tested for the presence of pancreatic cancer cells.
   #
   diagnoses__peripancreatic_lymph_nodes_tested: NumericAggregations
-  diagnoses__overall_survival: NumericAggregations
+
+  # The text term used to describe the Masaoka staging system, a classification
+  # that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.
+  #
+  diagnoses__masaoka_stage: Aggregations
 
   # Text term that represents the component of the International Neuroblastoma
   # Pathology Classification (INPC) for mitosis-karyorrhexis index (MKI).
@@ -2250,7 +2743,6 @@ type CaseAggregations {
   # The yes/no/unknown indicator used to describe whether esophageal columnar metaplasia was determined to be present.
   #
   diagnoses__esophageal_columnar_metaplasia_present: Aggregations
-  diagnoses__new_event_anatomic_site: Aggregations
 
   # The best improvement achieved throughout the entire course of protocol treatment.
   #
@@ -2267,6 +2759,15 @@ type CaseAggregations {
   # Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.
   #
   diagnoses__tumor_grade: Aggregations
+
+  # The text term used to describe the primary Gleason score, which describes the
+  # pattern of cells making up the largest area of the tumor. The primary and
+  # secondary Gleason pattern grades are combined to determine the patient's
+  # Gleason grade group, which is used to determine the aggresiveness of prostate
+  # cancer. Note that this grade describes the entire prostatectomy specimen and
+  # is not specific to the sample used for sequencing.
+  #
+  diagnoses__primary_gleason_grade: Aggregations
 
   # Number of days between the date used for index and the date the treatment started.
   #
@@ -2294,6 +2795,10 @@ type CaseAggregations {
   #
   diagnoses__treatments__submitter_id: Aggregations
   diagnoses__treatments__treatment_id: Aggregations
+
+  # The text term used to describe the pathologic effect a treatment(s) had on the tumor.
+  #
+  diagnoses__treatments__treatment_effect: Aggregations
 
   # The current state of the object.
   #
@@ -2330,8 +2835,6 @@ type CaseAggregations {
   # Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.
   #
   diagnoses__days_to_diagnosis: NumericAggregations
-  diagnoses__days_to_birth: NumericAggregations
-  diagnoses__hpv_status: Aggregations
 
   # The text term used to describe the version or edition of the American Joint
   # Committee on Cancer Staging Handbooks, a publication by the group formed for
@@ -2340,12 +2843,10 @@ type CaseAggregations {
   # classifications.
   #
   diagnoses__ajcc_staging_system_edition: Aggregations
-  diagnoses__new_event_type: Aggregations
 
   # The text term used to describe the classification of medulloblastoma tumors based on molecular features.
   #
   diagnoses__medulloblastoma_molecular_classification: Aggregations
-  diagnoses__ldh_normal_range_upper: NumericAggregations
 
   # The text term used to describe the staging classification of renal tumors, as
   # defined by the Children's Oncology Group (COG).
@@ -2368,7 +2869,14 @@ type CaseAggregations {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__site_of_resection_or_biopsy: Aggregations
-  disease_type: Aggregations
+
+  # The text term used to describe the overall grouping of grades defined by the
+  # Gleason grading classification, which is used to determine the aggressiveness
+  # of prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  diagnoses__gleason_grade_group: Aggregations
+  diagnosis_ids: Aggregations
   submitter_aliquot_ids: Aggregations
   summary__data_categories__file_count: NumericAggregations
   summary__data_categories__data_category: Aggregations
@@ -2413,6 +2921,7 @@ type CaseAggregations {
   project__name: Aggregations
   aliquot_ids: Aggregations
   primary_site: Aggregations
+  submitter_diagnosis_ids: Aggregations
 
   # Study name of the project.
   tissue_source_site__project: Aggregations
@@ -2543,8 +3052,8 @@ type CaseFile implements Node {
   # keyword
   origin: String
 
-  # long
-  proportion_base_mismatch: Float
+  # keyword
+  chip_id: String
 
   # The name (or part of a name) of a file (of any type).
   #
@@ -2588,9 +3097,6 @@ type CaseFile implements Node {
   state: String
 
   # keyword
-  release_number: String
-
-  # keyword
   access: String
 
   # keyword
@@ -2599,26 +3105,42 @@ type CaseFile implements Node {
   # long
   magnification: Float
 
-  # keyword
-  version: String
-
   # long
   average_read_length: Float
+
+  # long
+  contamination_error: Float
 
   # keyword
   type: String
 
+  # keyword
+  channel: String
+
   # long
   revision: Float
 
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  updated_datetime: String
+
   # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
+
+  # long
+  proportion_base_mismatch: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -2631,18 +3153,17 @@ type CaseFile implements Node {
   state_comment: String
 
   # keyword
-  data_format: String
+  plate_well: String
 
   # keyword
-  baseid: String
+  data_format: String
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
   md5sum: String
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-  #
-  updated_datetime: String
+  # keyword
+  plate_name: String
 
   # long
   mean_coverage: Float
@@ -2761,9 +3282,8 @@ type CNVAggregations {
   occurrence__case__diagnoses__tumor_stage: Aggregations
   occurrence__case__diagnoses__age_at_diagnosis: NumericAggregations
   occurrence__case__diagnoses__hpv_positive_type: Aggregations
-  occurrence__case__diagnoses__vital_status: Aggregations
   occurrence__case__diagnoses__morphology: Aggregations
-  occurrence__case__diagnoses__days_to_death: NumericAggregations
+  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__new_event_anatomic_site: Aggregations
   occurrence__case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   occurrence__case__diagnoses__perineural_invasion_present: Aggregations
@@ -2778,7 +3298,7 @@ type CNVAggregations {
   occurrence__case__diagnoses__ajcc_pathologic_n: Aggregations
   occurrence__case__diagnoses__vascular_invasion_present: Aggregations
   occurrence__case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
+  occurrence__case__diagnoses__created_datetime: Aggregations
   occurrence__case__diagnoses__residual_disease: Aggregations
   occurrence__case__diagnoses__days_to_recurrence: NumericAggregations
   occurrence__case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -2801,7 +3321,6 @@ type CNVAggregations {
   occurrence__case__diagnoses__treatments__treatment_or_therapy: Aggregations
   occurrence__case__diagnoses__lymphatic_invasion_present: Aggregations
   occurrence__case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  occurrence__case__diagnoses__days_to_birth: NumericAggregations
   occurrence__case__diagnoses__progression_or_recurrence: Aggregations
   occurrence__case__diagnoses__hpv_status: Aggregations
   occurrence__case__diagnoses__prior_malignancy: Aggregations
@@ -2814,9 +3333,8 @@ type CNVAggregations {
   occurrence__case__diagnoses__ldh_normal_range_upper: NumericAggregations
   occurrence__case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   occurrence__case__diagnoses__lymph_nodes_positive: NumericAggregations
-  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  occurrence__case__diagnoses__created_datetime: Aggregations
+  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
   occurrence__case__diagnoses__ajcc_clinical_stage: Aggregations
   occurrence__case__diagnoses__days_to_new_event: NumericAggregations
   occurrence__case__diagnoses__hiv_positive: Aggregations
@@ -2832,6 +3350,9 @@ type CNVAggregations {
   occurrence__case__demographic__demographic_id: Aggregations
   occurrence__case__demographic__state: Aggregations
   occurrence__case__demographic__race: Aggregations
+  occurrence__case__demographic__days_to_birth: NumericAggregations
+  occurrence__case__demographic__vital_status: Aggregations
+  occurrence__case__demographic__days_to_death: NumericAggregations
   occurrence__case__demographic__submitter_id: Aggregations
   occurrence__case__demographic__ethnicity: Aggregations
   occurrence__case__demographic__year_of_death: NumericAggregations
@@ -3308,9 +3829,9 @@ type Diagnosis implements Node {
   #
   submitter_id: String
 
-  # The survival state of the person registered on the protocol.
+  # The text term used to describe the extent of metastatic disease present at diagnosis.
   #
-  vital_status: String
+  metastasis_at_diagnosis: String
 
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
@@ -3323,9 +3844,6 @@ type Diagnosis implements Node {
   #
   morphology: String
 
-  # long
-  days_to_death: Float
-
   # Time interval from the date of last follow up to the date of initial
   # pathologic diagnosis, represented as a calculated number of days.
   #
@@ -3334,9 +3852,6 @@ type Diagnosis implements Node {
   # Text term used to describe the classification of rhabdomyosarcoma, as defined by the Children's Oncology Group (COG).
   #
   cog_rhabdomyosarcoma_risk_group: String
-
-  # long
-  days_to_hiv_diagnosis: Float
 
   # Code of pathological T (primary tumor) to define the size or contiguous
   # extension of the primary tumor (T), using staging criteria from the American
@@ -3367,6 +3882,16 @@ type Diagnosis implements Node {
   #
   ajcc_pathologic_n: String
 
+  # The text term used to describe the overall Weiss assessment score, a commonly
+  # used assessment describing the malignancy of adrenocortical tumors. The Weiss
+  # score is determined based on nine histological criteria including the
+  # following: high nuclear grade, mitotic rate greater than five per 50 high
+  # power fields (HPF), atypical mitotic figures, eosinophilic tumor cell
+  # cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than
+  # 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.
+  #
+  weiss_assessment_score: String
+
   # Text term and code that represents the metastatic stage of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
@@ -3376,6 +3901,11 @@ type Diagnosis implements Node {
   # Text term to describe the amount of dysplasia found within the benign esophageal columnar mucosa.
   #
   esophageal_columnar_dysplasia_degree: String
+
+  # The number of lymph nodes tested to determine whether lymph nodes were 
+  # involved with disease as determined by a pathologic examination.
+  #
+  lymph_nodes_tested: Float
 
   # The text term used to describe the classification of the histopathologic degree of liver damage.
   #
@@ -3388,6 +3918,12 @@ type Diagnosis implements Node {
   # Text term to specify the location of the supratentorial tumor.
   #
   supratentorial_localization: String
+
+  # The text term used to describe the International Germ Cell Cancer
+  # Collaborative Group (IGCCCG), a grouping used to further classify metastatic
+  # testicular tumors.
+  #
+  igcccg_stage: String
 
   # The yes/no/unknown/not reported indicator used to describe whether the tumor
   # is located across the gastroesophageal junction.
@@ -3403,14 +3939,16 @@ type Diagnosis implements Node {
   #
   iss_stage: String
 
-  # keyword
-  cause_of_death: String
-
   # Text term and code that represents the tumor site of the musculoskeletal
   # sarcoma, using the Enneking staging system approved by the Musculoskeletal
   # Tumor Society (MSTS).
   #
   enneking_msts_tumor_site: String
+
+  # A numeric value used to measure therapeutic response of the primary tumor and
+  # predict patient outcomes based on a three-point tumor regression grading system.
+  #
+  tumor_regression_grade: String
 
   # Numeric value used to describe the gross pathologic tumor weight, measured in grams.
   #
@@ -3420,9 +3958,6 @@ type Diagnosis implements Node {
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
   #
   ajcc_clinical_stage: String
-
-  # keyword
-  hiv_positive: String
 
   # Text term to signify whether lymphoma B-symptoms are present as noted in the patient's medical record.
   #
@@ -3437,10 +3972,6 @@ type Diagnosis implements Node {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   updated_datetime: String
-
-  # The text term used to describe the extent of metastatic disease present at diagnosis.
-  #
-  metastasis_at_diagnosis: String
 
   # Number of days between the date used for index and the date of the patient was
   # thought to have the best overall response to their disease.
@@ -3458,9 +3989,6 @@ type Diagnosis implements Node {
   # Age at the time of diagnosis expressed in number of days since birth.
   #
   age_at_diagnosis: Float
-
-  # keyword
-  hpv_positive_type: String
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
@@ -3519,9 +4047,6 @@ type Diagnosis implements Node {
   #
   prior_malignancy: String
 
-  # long
-  days_to_new_event: Float
-
   # Numeric value used to describe the non-peritonealised bare area of rectum,
   # comprising anterior and posterior segments, when submitted as a surgical
   # specimen resulting from excision of cancer of the rectum.
@@ -3554,8 +4079,14 @@ type Diagnosis implements Node {
   #
   year_of_diagnosis: Float
 
-  # long
-  progression_free_survival: Float
+  # The text term used to describe the secondary Gleason score, which describes
+  # the pattern of cells making up the second largest area of the tumor. The
+  # primary and secondary Gleason pattern grades are combined to determine the
+  # patient's Gleason grade group, which is used to determine the aggresiveness of
+  # prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  secondary_gleason_grade: String
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -3580,6 +4111,10 @@ type Diagnosis implements Node {
   #
   perineural_invasion_present: String
 
+  # The text term used to describe whether the patient's disease originated in a single location or multiple locations.
+  #
+  tumor_focality: String
+
   # The text term used to describe the classification of Wilms tumors
   # distinguishing between favorable and unfavorable histologic groups.
   #
@@ -3588,9 +4123,6 @@ type Diagnosis implements Node {
   # Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.
   #
   ajcc_clinical_t: String
-
-  # keyword
-  colon_polyps_history: String
 
   # Extent of the regional lymph node involvement for the cancer based on evidence
   # obtained from clinical assessment parameters determined prior to treatment.
@@ -3617,9 +4149,6 @@ type Diagnosis implements Node {
   # specifically describes the extent of the primary tumor prior to treatment.
   #
   cog_liver_stage: String
-
-  # keyword
-  progression_free_survival_event: String
 
   # Text term used to describe the stage of the musculoskeletal sarcoma, using the
   # Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).
@@ -3658,8 +4187,10 @@ type Diagnosis implements Node {
   #
   peripancreatic_lymph_nodes_tested: Float
 
-  # long
-  overall_survival: Float
+  # The text term used to describe the Masaoka staging system, a classification
+  # that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.
+  #
+  masaoka_stage: String
 
   # Text term that represents the component of the International Neuroblastoma
   # Pathology Classification (INPC) for mitosis-karyorrhexis index (MKI).
@@ -3684,9 +4215,6 @@ type Diagnosis implements Node {
   #
   esophageal_columnar_metaplasia_present: String
 
-  # keyword
-  new_event_anatomic_site: String
-
   # The best improvement achieved throughout the entire course of protocol treatment.
   #
   best_overall_response: String
@@ -3703,15 +4231,18 @@ type Diagnosis implements Node {
   #
   tumor_grade: String
 
+  # The text term used to describe the primary Gleason score, which describes the
+  # pattern of cells making up the largest area of the tumor. The primary and
+  # secondary Gleason pattern grades are combined to determine the patient's
+  # Gleason grade group, which is used to determine the aggresiveness of prostate
+  # cancer. Note that this grade describes the entire prostatectomy specimen and
+  # is not specific to the sample used for sequencing.
+  #
+  primary_gleason_grade: String
+
   # Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.
   #
   days_to_diagnosis: Float
-
-  # long
-  days_to_birth: Float
-
-  # keyword
-  hpv_status: String
 
   # The text term used to describe the version or edition of the American Joint
   # Committee on Cancer Staging Handbooks, a publication by the group formed for
@@ -3721,15 +4252,9 @@ type Diagnosis implements Node {
   #
   ajcc_staging_system_edition: String
 
-  # keyword
-  new_event_type: String
-
   # The text term used to describe the classification of medulloblastoma tumors based on molecular features.
   #
   medulloblastoma_molecular_classification: String
-
-  # long
-  ldh_normal_range_upper: Float
 
   # The text term used to describe the staging classification of renal tumors, as
   # defined by the Children's Oncology Group (COG).
@@ -3752,6 +4277,13 @@ type Diagnosis implements Node {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   site_of_resection_or_biopsy: String
+
+  # The text term used to describe the overall grouping of grades defined by the
+  # Gleason grading classification, which is used to determine the aggressiveness
+  # of prostate cancer. Note that this grade describes the entire prostatectomy
+  # specimen and is not specific to the sample used for sequencing.
+  #
+  gleason_grade_group: String
   score: Int
 }
 
@@ -4024,10 +4556,6 @@ type ECaseAggregations {
   diagnoses__age_at_diagnosis: NumericAggregations
   diagnoses__hpv_positive_type: Aggregations
 
-  # The survival state of the person registered on the protocol.
-  #
-  diagnoses__vital_status: Aggregations
-
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
   # for coding the site (topography) and the histology (morphology) of neoplasms.
@@ -4038,7 +4566,11 @@ type ECaseAggregations {
   # immunocytochemical stains. A system of numbered categories for representation of data.
   #
   diagnoses__morphology: Aggregations
-  diagnoses__days_to_death: NumericAggregations
+
+  # The text term used to describe the clinical classification of lymphoma, as
+  # defined by the Ann Arbor Lymphoma Staging System.
+  #
+  diagnoses__ann_arbor_clinical_stage: Aggregations
   diagnoses__new_event_anatomic_site: Aggregations
 
   # Time interval from the date of last follow up to the date of initial
@@ -4095,10 +4627,9 @@ type ECaseAggregations {
   diagnoses__vascular_invasion_present: Aggregations
   diagnoses__ldh_level_at_diagnosis: NumericAggregations
 
-  # Time interval from the date of last follow up to the date of initial
-  # pathologic diagnosis, represented as a calculated number of days.
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
-  diagnoses__days_to_last_follow_up: NumericAggregations
+  diagnoses__created_datetime: Aggregations
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -4188,7 +4719,6 @@ type ECaseAggregations {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__tissue_or_organ_of_origin: Aggregations
-  diagnoses__days_to_birth: NumericAggregations
 
   # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
   #
@@ -4233,20 +4763,16 @@ type ECaseAggregations {
   #
   diagnoses__lymph_nodes_positive: NumericAggregations
 
-  # The text term used to describe the clinical classification of lymphoma, as
-  # defined by the Ann Arbor Lymphoma Staging System.
-  #
-  diagnoses__ann_arbor_clinical_stage: Aggregations
-
   # The text term used to describe the anatomic site of origin, of the patient's
   # malignant disease, as described by the World Health Organization's (WHO)
   # International Classification of Diseases for Oncology (ICD-O).
   #
   diagnoses__site_of_resection_or_biopsy: Aggregations
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # Time interval from the date of last follow up to the date of initial
+  # pathologic diagnosis, represented as a calculated number of days.
   #
-  diagnoses__created_datetime: Aggregations
+  diagnoses__days_to_last_follow_up: NumericAggregations
 
   # Stage group determined from clinical information on the tumor (T), regional
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
@@ -4683,10 +5209,6 @@ type EDiagnosis implements Node {
   # keyword
   hpv_positive_type: String
 
-  # The survival state of the person registered on the protocol.
-  #
-  vital_status: String
-
   # The third edition of the International Classification of Diseases for
   # Oncology, published in 2000 used principally in tumor and cancer registries
   # for coding the site (topography) and the histology (morphology) of neoplasms.
@@ -4698,8 +5220,10 @@ type EDiagnosis implements Node {
   #
   morphology: String
 
-  # long
-  days_to_death: Float
+  # The text term used to describe the clinical classification of lymphoma, as
+  # defined by the Ann Arbor Lymphoma Staging System.
+  #
+  ann_arbor_clinical_stage: String
 
   # keyword
   new_event_anatomic_site: String
@@ -4764,10 +5288,9 @@ type EDiagnosis implements Node {
   # long
   ldh_level_at_diagnosis: Float
 
-  # Time interval from the date of last follow up to the date of initial
-  # pathologic diagnosis, represented as a calculated number of days.
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
-  days_to_last_follow_up: Float
+  created_datetime: String
 
   # Text terms to describe the status of a tissue margin following surgical resection.
   #
@@ -4808,9 +5331,6 @@ type EDiagnosis implements Node {
   # International Classification of Diseases for Oncology (ICD-O).
   #
   tissue_or_organ_of_origin: String
-
-  # long
-  days_to_birth: Float
 
   # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
   #
@@ -4863,20 +5383,16 @@ type EDiagnosis implements Node {
   #
   lymph_nodes_positive: Float
 
-  # The text term used to describe the clinical classification of lymphoma, as
-  # defined by the Ann Arbor Lymphoma Staging System.
-  #
-  ann_arbor_clinical_stage: String
-
   # The text term used to describe the anatomic site of origin, of the patient's
   # malignant disease, as described by the World Health Organization's (WHO)
   # International Classification of Diseases for Oncology (ICD-O).
   #
   site_of_resection_or_biopsy: String
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # Time interval from the date of last follow up to the date of initial
+  # pathologic diagnosis, represented as a calculated number of days.
   #
-  created_datetime: String
+  days_to_last_follow_up: Float
 
   # Stage group determined from clinical information on the tumor (T), regional
   # node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.
@@ -5247,10 +5763,6 @@ type Exposure implements Node {
   #
   cigarettes_per_day: Float
 
-  # The year in which the participant quit smoking.
-  #
-  tobacco_smoking_quit_year: Float
-
   # The weight of the patient measured in kilograms.
   #
   weight: Float
@@ -5258,19 +5770,6 @@ type Exposure implements Node {
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
   #
   updated_datetime: String
-
-  # A response to a question that asks whether the participant has consumed at
-  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
-  #
-  alcohol_history: String
-
-  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
-  #
-  alcohol_intensity: String
-
-  # A calculated numerical quantity that represents an individual's weight to height ratio.
-  #
-  bmi: Float
 
   # Numeric value (or unknown) to represent the number of years a person has been smoking.
   #
@@ -5280,29 +5779,80 @@ type Exposure implements Node {
   #
   height: Float
 
-  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # smoke that is emitted from burning tobacco, including cigarettes, pipes, and
+  # cigars. This includes tobacco smoke exhaled by smokers.
   #
-  created_datetime: String
-
-  # The current state of the object.
-  #
-  state: String
+  environmental_tobacco_smoke_exposure: String
 
   # Category describing current smoking status and smoking history as self-reported by a patient.
   #
   tobacco_smoking_status: String
 
+  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  #
+  alcohol_days_per_week: Float
+
+  # Numeric computed value to represent lifetime tobacco exposure defined as
+  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  #
+  pack_years_smoked: Float
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposured
+  # to respirable crystalline silica, a widespread, naturally occurring,
+  # crystalline metal oxide that consists of different forms including quartz,
+  # cristobalite, tridymite, tripoli, ganister, chert and novaculite.
+  #
+  respirable_crystalline_silica_exposure: String
+
+  # The yes/no/unknown indicator used to describe whether a patient was exposed to
+  # fine powder derived by the crushing of coal.
+  #
+  coal_dust_exposure: String
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  created_datetime: String
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.
+  #
+  asbestos_exposure: String
+
+  # The current state of the object.
+  #
+  state: String
+
+  # The text term used to describe the specific type of tobacco used by the patient.
+  #
+  type_of_tobacco_used: String
+
   # The year in which the participant began smoking.
   #
   tobacco_smoking_onset_year: Float
+
+  # A response to a question that asks whether the participant has consumed at
+  # least 12 drinks of any kind of alcoholic beverage in their lifetime.
+  #
+  alcohol_history: String
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  bmi: Float
+
+  # The text term used to generally decribe how often the patient smokes.
+  #
+  smoking_frequency: String
 
   # Numeric value used to describe the average number of alcoholic beverages  a person consumes per day.
   #
   alcohol_drinks_per_day: Float
 
-  # Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.
+  # The text term used to describe the patient's specific type of smoke exposure.
   #
-  alcohol_days_per_week: Float
+  type_of_smoke_exposure: String
+
+  # keyword
+  exposure_id: String
 
   # A project-specific identifier for a node. This property is the calling
   # card/nickname/alias for a unit of submission. It can be used in place of the
@@ -5310,13 +5860,23 @@ type Exposure implements Node {
   #
   submitter_id: String
 
-  # keyword
-  exposure_id: String
-
-  # Numeric computed value to represent lifetime tobacco exposure defined as
-  # number of cigarettes smoked per day x number of years smoked divided by 20.
+  # Category to describe the patient's current level of alcohol use as self-reported by the patient.
   #
-  pack_years_smoked: Float
+  alcohol_intensity: String
+
+  # The text term used to describe the approximate amount of time elapsed between
+  # the time the patient wakes up in the morning to the time they smoke their
+  # first cigarette.
+  #
+  time_between_waking_and_first_smoke: String
+
+  # The yes/no/unknown indicator used to describe whether the patient was exposed to radon.
+  #
+  radon_exposure: String
+
+  # The year in which the participant quit smoking.
+  #
+  tobacco_smoking_quit_year: Float
   score: Int
 }
 
@@ -5427,8 +5987,8 @@ type File implements Node {
   # keyword
   origin: String
 
-  # long
-  proportion_base_mismatch: Float
+  # keyword
+  chip_id: String
 
   # keyword
   file_name: String
@@ -5464,9 +6024,6 @@ type File implements Node {
   state: String
 
   # keyword
-  release_number: String
-
-  # keyword
   access: String
 
   # keyword
@@ -5475,26 +6032,41 @@ type File implements Node {
   # long
   magnification: Float
 
-  # keyword
-  version: String
-
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
   # keyword
   type: String
+
+  # keyword
+  channel: String
 
   # long
   revision: Float
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
+
+  # long
+  proportion_base_mismatch: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -5506,16 +6078,16 @@ type File implements Node {
   state_comment: String
 
   # keyword
-  data_format: String
+  plate_well: String
 
   # keyword
-  baseid: String
+  data_format: String
 
   # keyword
   md5sum: String
 
   # keyword
-  updated_datetime: String
+  plate_name: String
 
   # long
   mean_coverage: Float
@@ -5553,9 +6125,9 @@ type File implements Node {
 
 type FileAggregations {
   origin: Aggregations
-  proportion_base_mismatch: NumericAggregations
+  chip_id: Aggregations
+  index_files__chip_id: Aggregations
   index_files__proportion_base_mismatch: NumericAggregations
-  index_files__updated_datetime: Aggregations
   index_files__file_name: Aggregations
   index_files__submitter_id: Aggregations
   index_files__read_pair_number: Aggregations
@@ -5572,14 +6144,21 @@ type FileAggregations {
   index_files__magnification: NumericAggregations
   index_files__mean_coverage: NumericAggregations
   index_files__average_read_length: NumericAggregations
+  index_files__contamination_error: NumericAggregations
+  index_files__channel: Aggregations
   index_files__experimental_strategy: Aggregations
+  index_files__updated_datetime: Aggregations
   index_files__data_type: Aggregations
+  index_files__chip_position: Aggregations
   index_files__proportion_coverage_10X: NumericAggregations
   index_files__file_id: Aggregations
+  index_files__contamination: NumericAggregations
   index_files__proportion_reads_duplicated: NumericAggregations
   index_files__total_reads: NumericAggregations
   index_files__state_comment: Aggregations
+  index_files__plate_well: Aggregations
   index_files__md5sum: Aggregations
+  index_files__plate_name: Aggregations
   index_files__data_format: Aggregations
   index_files__proportion_reads_mapped: NumericAggregations
   index_files__proportion_targets_no_coverage: NumericAggregations
@@ -5598,8 +6177,8 @@ type FileAggregations {
   downstream_analyses__workflow_type: Aggregations
   downstream_analyses__workflow_start_datetime: Aggregations
   downstream_analyses__workflow_version: Aggregations
+  downstream_analyses__output_files__chip_id: Aggregations
   downstream_analyses__output_files__proportion_base_mismatch: NumericAggregations
-  downstream_analyses__output_files__updated_datetime: Aggregations
   downstream_analyses__output_files__file_name: Aggregations
   downstream_analyses__output_files__submitter_id: Aggregations
   downstream_analyses__output_files__read_pair_number: Aggregations
@@ -5616,14 +6195,21 @@ type FileAggregations {
   downstream_analyses__output_files__magnification: NumericAggregations
   downstream_analyses__output_files__mean_coverage: NumericAggregations
   downstream_analyses__output_files__average_read_length: NumericAggregations
+  downstream_analyses__output_files__contamination_error: NumericAggregations
+  downstream_analyses__output_files__channel: Aggregations
   downstream_analyses__output_files__experimental_strategy: Aggregations
+  downstream_analyses__output_files__updated_datetime: Aggregations
   downstream_analyses__output_files__data_type: Aggregations
+  downstream_analyses__output_files__chip_position: Aggregations
   downstream_analyses__output_files__proportion_coverage_10X: NumericAggregations
   downstream_analyses__output_files__file_id: Aggregations
+  downstream_analyses__output_files__contamination: NumericAggregations
   downstream_analyses__output_files__proportion_reads_duplicated: NumericAggregations
   downstream_analyses__output_files__total_reads: NumericAggregations
   downstream_analyses__output_files__state_comment: Aggregations
+  downstream_analyses__output_files__plate_well: Aggregations
   downstream_analyses__output_files__md5sum: Aggregations
+  downstream_analyses__output_files__plate_name: Aggregations
   downstream_analyses__output_files__data_format: Aggregations
   downstream_analyses__output_files__proportion_reads_mapped: NumericAggregations
   downstream_analyses__output_files__proportion_targets_no_coverage: NumericAggregations
@@ -5694,11 +6280,9 @@ type FileAggregations {
   imaging_date: Aggregations
   error_type: Aggregations
   state: Aggregations
-  release_number: Aggregations
   access: Aggregations
   platform: Aggregations
   magnification: NumericAggregations
-  version: Aggregations
 
   # The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.
   #
@@ -5744,6 +6328,7 @@ type FileAggregations {
   #
   metadata_files__state_comment: Aggregations
   average_read_length: NumericAggregations
+  contamination_error: NumericAggregations
   type: Aggregations
 
   # Status of the annotation.
@@ -5792,11 +6377,16 @@ type FileAggregations {
 
   # Top level characterization of the annotation.
   annotations__category: Aggregations
+  channel: Aggregations
   revision: NumericAggregations
+  updated_datetime: Aggregations
   data_type: Aggregations
   tags: Aggregations
+  chip_position: Aggregations
   proportion_coverage_10X: NumericAggregations
   file_id: Aggregations
+  contamination: NumericAggregations
+  proportion_base_mismatch: NumericAggregations
   proportion_reads_duplicated: NumericAggregations
 
   # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
@@ -5846,13 +6436,13 @@ type FileAggregations {
   cases__case_id: Aggregations
   cases__samples__sample_type_id: Aggregations
   cases__samples__updated_datetime: Aggregations
-  cases__samples__time_between_excision_and_freezing: Aggregations
+  cases__samples__time_between_excision_and_freezing: NumericAggregations
   cases__samples__oct_embedded: Aggregations
   cases__samples__tumor_code_id: Aggregations
   cases__samples__submitter_id: Aggregations
-  cases__samples__intermediate_dimension: Aggregations
+  cases__samples__intermediate_dimension: NumericAggregations
   cases__samples__sample_id: Aggregations
-  cases__samples__time_between_clamping_and_freezing: Aggregations
+  cases__samples__time_between_clamping_and_freezing: NumericAggregations
   cases__samples__pathology_report_uuid: Aggregations
   cases__samples__created_datetime: Aggregations
   cases__samples__tumor_descriptor: Aggregations
@@ -5882,7 +6472,7 @@ type FileAggregations {
   cases__samples__annotations__category: Aggregations
   cases__samples__is_ffpe: Aggregations
   cases__samples__distributor_reference: Aggregations
-  cases__samples__shortest_dimension: Aggregations
+  cases__samples__shortest_dimension: NumericAggregations
   cases__samples__method_of_sample_procurement: Aggregations
   cases__samples__tumor_code: Aggregations
   cases__samples__passage_count: NumericAggregations
@@ -6038,7 +6628,7 @@ type FileAggregations {
   cases__samples__days_to_collection: NumericAggregations
   cases__samples__catalog_reference: Aggregations
   cases__samples__initial_weight: NumericAggregations
-  cases__samples__longest_dimension: Aggregations
+  cases__samples__longest_dimension: NumericAggregations
   cases__submitter_sample_ids: Aggregations
   cases__annotations__status: Aggregations
   cases__annotations__legacy_updated_datetime: Aggregations
@@ -6058,23 +6648,109 @@ type FileAggregations {
   cases__annotations__case_submitter_id: Aggregations
   cases__annotations__category: Aggregations
   cases__exposures__cigarettes_per_day: NumericAggregations
-  cases__exposures__tobacco_smoking_quit_year: NumericAggregations
   cases__exposures__weight: NumericAggregations
   cases__exposures__updated_datetime: Aggregations
-  cases__exposures__alcohol_history: Aggregations
-  cases__exposures__alcohol_intensity: Aggregations
-  cases__exposures__bmi: NumericAggregations
   cases__exposures__years_smoked: NumericAggregations
   cases__exposures__height: NumericAggregations
-  cases__exposures__created_datetime: Aggregations
-  cases__exposures__state: Aggregations
+  cases__exposures__environmental_tobacco_smoke_exposure: Aggregations
   cases__exposures__tobacco_smoking_status: Aggregations
-  cases__exposures__tobacco_smoking_onset_year: NumericAggregations
-  cases__exposures__alcohol_drinks_per_day: NumericAggregations
   cases__exposures__alcohol_days_per_week: NumericAggregations
-  cases__exposures__submitter_id: Aggregations
-  cases__exposures__exposure_id: Aggregations
   cases__exposures__pack_years_smoked: NumericAggregations
+  cases__exposures__respirable_crystalline_silica_exposure: Aggregations
+  cases__exposures__coal_dust_exposure: Aggregations
+  cases__exposures__created_datetime: Aggregations
+  cases__exposures__asbestos_exposure: Aggregations
+  cases__exposures__state: Aggregations
+  cases__exposures__type_of_tobacco_used: Aggregations
+  cases__exposures__tobacco_smoking_onset_year: NumericAggregations
+  cases__exposures__alcohol_history: Aggregations
+  cases__exposures__bmi: NumericAggregations
+  cases__exposures__smoking_frequency: Aggregations
+  cases__exposures__alcohol_drinks_per_day: NumericAggregations
+  cases__exposures__type_of_smoke_exposure: Aggregations
+  cases__exposures__exposure_id: Aggregations
+  cases__exposures__submitter_id: Aggregations
+  cases__exposures__alcohol_intensity: Aggregations
+  cases__exposures__time_between_waking_and_first_smoke: Aggregations
+  cases__exposures__radon_exposure: Aggregations
+  cases__exposures__tobacco_smoking_quit_year: NumericAggregations
+  cases__follow_ups__fev1_ref_post_bronch_percent: NumericAggregations
+  cases__follow_ups__weight: NumericAggregations
+  cases__follow_ups__reflux_treatment_type: Aggregations
+  cases__follow_ups__progression_or_recurrence_type: Aggregations
+  cases__follow_ups__height: NumericAggregations
+  cases__follow_ups__days_to_adverse_event: NumericAggregations
+  cases__follow_ups__cause_of_response: Aggregations
+  cases__follow_ups__fev1_fvc_pre_bronch_percent: NumericAggregations
+  cases__follow_ups__ecog_performance_status: Aggregations
+  cases__follow_ups__hpv_positive_type: Aggregations
+  cases__follow_ups__days_to_progression_free: NumericAggregations
+  cases__follow_ups__days_to_follow_up: NumericAggregations
+  cases__follow_ups__fev1_fvc_post_bronch_percent: NumericAggregations
+  cases__follow_ups__comorbidity_method_of_diagnosis: Aggregations
+  cases__follow_ups__dlco_ref_predictive_percent: NumericAggregations
+  cases__follow_ups__comorbidity: Aggregations
+  cases__follow_ups__updated_datetime: Aggregations
+  cases__follow_ups__risk_factor: Aggregations
+  cases__follow_ups__state: Aggregations
+  cases__follow_ups__days_to_progression: NumericAggregations
+  cases__follow_ups__adverse_event: Aggregations
+  cases__follow_ups__days_to_recurrence: NumericAggregations
+  cases__follow_ups__molecular_tests__mismatch_repair_mutation: Aggregations
+  cases__follow_ups__molecular_tests__updated_datetime: Aggregations
+  cases__follow_ups__molecular_tests__antigen: Aggregations
+  cases__follow_ups__molecular_tests__variant_origin: Aggregations
+  cases__follow_ups__molecular_tests__blood_test_normal_range_lower: NumericAggregations
+  cases__follow_ups__molecular_tests__locus: Aggregations
+  cases__follow_ups__molecular_tests__test_value: NumericAggregations
+  cases__follow_ups__molecular_tests__second_gene_symbol: Aggregations
+  cases__follow_ups__molecular_tests__ploidy: Aggregations
+  cases__follow_ups__molecular_tests__chromosome: Aggregations
+  cases__follow_ups__molecular_tests__specialized_molecular_test: Aggregations
+  cases__follow_ups__molecular_tests__created_datetime: Aggregations
+  cases__follow_ups__molecular_tests__intron: Aggregations
+  cases__follow_ups__molecular_tests__gene_symbol: Aggregations
+  cases__follow_ups__molecular_tests__state: Aggregations
+  cases__follow_ups__molecular_tests__histone_variant: Aggregations
+  cases__follow_ups__molecular_tests__cell_count: NumericAggregations
+  cases__follow_ups__molecular_tests__histone_family: Aggregations
+  cases__follow_ups__molecular_tests__copy_number: NumericAggregations
+  cases__follow_ups__molecular_tests__test_analyte_type: Aggregations
+  cases__follow_ups__molecular_tests__exon: Aggregations
+  cases__follow_ups__molecular_tests__laboratory_test: Aggregations
+  cases__follow_ups__molecular_tests__test_result: Aggregations
+  cases__follow_ups__molecular_tests__transcript: Aggregations
+  cases__follow_ups__molecular_tests__blood_test_normal_range_upper: NumericAggregations
+  cases__follow_ups__molecular_tests__test_units: Aggregations
+  cases__follow_ups__molecular_tests__zygosity: Aggregations
+  cases__follow_ups__molecular_tests__cytoband: Aggregations
+  cases__follow_ups__molecular_tests__biospecimen_type: Aggregations
+  cases__follow_ups__molecular_tests__submitter_id: Aggregations
+  cases__follow_ups__molecular_tests__second_exon: Aggregations
+  cases__follow_ups__molecular_tests__molecular_test_id: Aggregations
+  cases__follow_ups__molecular_tests__molecular_analysis_method: Aggregations
+  cases__follow_ups__molecular_tests__molecular_consequence: Aggregations
+  cases__follow_ups__molecular_tests__variant_type: Aggregations
+  cases__follow_ups__molecular_tests__loci_abnormal_count: NumericAggregations
+  cases__follow_ups__molecular_tests__aa_change: Aggregations
+  cases__follow_ups__molecular_tests__loci_count: NumericAggregations
+  cases__follow_ups__bmi: NumericAggregations
+  cases__follow_ups__menopause_status: Aggregations
+  cases__follow_ups__progression_or_recurrence: Aggregations
+  cases__follow_ups__diabetes_treatment_type: Aggregations
+  cases__follow_ups__risk_factor_treatment: Aggregations
+  cases__follow_ups__progression_or_recurrence_anatomic_site: Aggregations
+  cases__follow_ups__submitter_id: Aggregations
+  cases__follow_ups__barretts_esophagus_goblet_cells_present: Aggregations
+  cases__follow_ups__disease_response: Aggregations
+  cases__follow_ups__follow_up_id: Aggregations
+  cases__follow_ups__pancreatitis_onset_year: NumericAggregations
+  cases__follow_ups__viral_hepatitis_serologies: Aggregations
+  cases__follow_ups__fev1_ref_pre_bronch_percent: NumericAggregations
+  cases__follow_ups__created_datetime: Aggregations
+  cases__follow_ups__karnofsky_performance_status: Aggregations
+  cases__follow_ups__hepatitis_sustained_virological_response: Aggregations
+  cases__follow_ups__days_to_comorbidity: NumericAggregations
 
   # The text term used to describe the reference or anchor date used when for date
   # obfuscation, where a single date is obscurred by creating one or more date
@@ -6097,44 +6773,48 @@ type FileAggregations {
   # UUID for identifying or recalling a node.
   #
   cases__submitter_id: Aggregations
+
+  # The text term used to describe the type of malignant disease, as categorized
+  # by the World Health Organization's (WHO) International Classification of
+  # Diseases for Oncology (ICD-O).
+  #
+  cases__disease_type: Aggregations
   cases__diagnoses__vascular_invasion_type: Aggregations
   cases__diagnoses__method_of_diagnosis: Aggregations
   cases__diagnoses__laterality: Aggregations
   cases__diagnoses__ann_arbor_pathologic_stage: Aggregations
   cases__diagnoses__inrg_stage: Aggregations
   cases__diagnoses__submitter_id: Aggregations
-  cases__diagnoses__vital_status: Aggregations
+  cases__diagnoses__metastasis_at_diagnosis: Aggregations
   cases__diagnoses__morphology: Aggregations
-  cases__diagnoses__days_to_death: NumericAggregations
   cases__diagnoses__days_to_last_known_disease_status: NumericAggregations
   cases__diagnoses__cog_rhabdomyosarcoma_risk_group: Aggregations
-  cases__diagnoses__days_to_hiv_diagnosis: NumericAggregations
   cases__diagnoses__ajcc_pathologic_t: Aggregations
   cases__diagnoses__prior_treatment: Aggregations
   cases__diagnoses__irs_group: Aggregations
   cases__diagnoses__ajcc_pathologic_m: Aggregations
   cases__diagnoses__ajcc_pathologic_n: Aggregations
+  cases__diagnoses__weiss_assessment_score: Aggregations
   cases__diagnoses__enneking_msts_metastasis: Aggregations
   cases__diagnoses__esophageal_columnar_dysplasia_degree: Aggregations
+  cases__diagnoses__lymph_nodes_tested: NumericAggregations
   cases__diagnoses__ishak_fibrosis_score: Aggregations
   cases__diagnoses__lymphatic_invasion_present: Aggregations
   cases__diagnoses__supratentorial_localization: Aggregations
+  cases__diagnoses__igcccg_stage: Aggregations
   cases__diagnoses__gastric_esophageal_junction_involvement: Aggregations
   cases__diagnoses__goblet_cells_columnar_mucosa_present: Aggregations
   cases__diagnoses__iss_stage: Aggregations
-  cases__diagnoses__cause_of_death: Aggregations
   cases__diagnoses__enneking_msts_tumor_site: Aggregations
+  cases__diagnoses__tumor_regression_grade: Aggregations
   cases__diagnoses__gross_tumor_weight: NumericAggregations
   cases__diagnoses__ajcc_clinical_stage: Aggregations
-  cases__diagnoses__hiv_positive: Aggregations
   cases__diagnoses__ann_arbor_b_symptoms: Aggregations
   cases__diagnoses__cog_neuroblastoma_risk_group: Aggregations
   cases__diagnoses__updated_datetime: Aggregations
-  cases__diagnoses__metastasis_at_diagnosis: Aggregations
   cases__diagnoses__days_to_best_overall_response: NumericAggregations
   cases__diagnoses__tumor_stage: Aggregations
   cases__diagnoses__age_at_diagnosis: NumericAggregations
-  cases__diagnoses__hpv_positive_type: Aggregations
   cases__diagnoses__created_datetime: Aggregations
   cases__diagnoses__enneking_msts_grade: Aggregations
   cases__diagnoses__state: Aggregations
@@ -6147,28 +6827,43 @@ type FileAggregations {
   cases__diagnoses__tissue_or_organ_of_origin: Aggregations
   cases__diagnoses__peripancreatic_lymph_nodes_positive: Aggregations
   cases__diagnoses__prior_malignancy: Aggregations
-  cases__diagnoses__days_to_new_event: NumericAggregations
   cases__diagnoses__circumferential_resection_margin: NumericAggregations
   cases__diagnoses__lymph_nodes_positive: NumericAggregations
   cases__diagnoses__days_to_last_follow_up: NumericAggregations
   cases__diagnoses__inss_stage: Aggregations
   cases__diagnoses__inpc_histologic_group: Aggregations
   cases__diagnoses__year_of_diagnosis: NumericAggregations
-  cases__diagnoses__progression_free_survival: NumericAggregations
+  cases__diagnoses__secondary_gleason_grade: Aggregations
   cases__diagnoses__residual_disease: Aggregations
   cases__diagnoses__anaplasia_present: Aggregations
   cases__diagnoses__ann_arbor_clinical_stage: Aggregations
   cases__diagnoses__tumor_confined_to_organ_of_origin: Aggregations
   cases__diagnoses__perineural_invasion_present: Aggregations
+  cases__diagnoses__tumor_focality: Aggregations
   cases__diagnoses__wilms_tumor_histologic_subtype: Aggregations
   cases__diagnoses__ajcc_clinical_t: Aggregations
-  cases__diagnoses__colon_polyps_history: Aggregations
   cases__diagnoses__ajcc_clinical_n: Aggregations
   cases__diagnoses__ajcc_clinical_m: Aggregations
   cases__diagnoses__irs_stage: Aggregations
   cases__diagnoses__first_symptom_prior_to_diagnosis: Aggregations
   cases__diagnoses__cog_liver_stage: Aggregations
-  cases__diagnoses__progression_free_survival_event: Aggregations
+  cases__diagnoses__annotations__status: Aggregations
+  cases__diagnoses__annotations__legacy_updated_datetime: Aggregations
+  cases__diagnoses__annotations__entity_id: Aggregations
+  cases__diagnoses__annotations__classification: Aggregations
+  cases__diagnoses__annotations__creator: Aggregations
+  cases__diagnoses__annotations__created_datetime: Aggregations
+  cases__diagnoses__annotations__entity_submitter_id: Aggregations
+  cases__diagnoses__annotations__notes: Aggregations
+  cases__diagnoses__annotations__entity_type: Aggregations
+  cases__diagnoses__annotations__updated_datetime: Aggregations
+  cases__diagnoses__annotations__legacy_created_datetime: Aggregations
+  cases__diagnoses__annotations__state: Aggregations
+  cases__diagnoses__annotations__case_id: Aggregations
+  cases__diagnoses__annotations__submitter_id: Aggregations
+  cases__diagnoses__annotations__annotation_id: Aggregations
+  cases__diagnoses__annotations__case_submitter_id: Aggregations
+  cases__diagnoses__annotations__category: Aggregations
   cases__diagnoses__enneking_msts_stage: Aggregations
   cases__diagnoses__icd_10_code: Aggregations
   cases__diagnoses__inpc_grade: Aggregations
@@ -6177,17 +6872,17 @@ type FileAggregations {
   cases__diagnoses__burkitt_lymphoma_clinical_variant: Aggregations
   cases__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   cases__diagnoses__peripancreatic_lymph_nodes_tested: NumericAggregations
-  cases__diagnoses__overall_survival: NumericAggregations
+  cases__diagnoses__masaoka_stage: Aggregations
   cases__diagnoses__mitosis_karyorrhexis_index: Aggregations
   cases__diagnoses__classification_of_tumor: Aggregations
   cases__diagnoses__last_known_disease_status: Aggregations
   cases__diagnoses__primary_diagnosis: Aggregations
   cases__diagnoses__esophageal_columnar_metaplasia_present: Aggregations
-  cases__diagnoses__new_event_anatomic_site: Aggregations
   cases__diagnoses__best_overall_response: Aggregations
   cases__diagnoses__vascular_invasion_present: Aggregations
   cases__diagnoses__micropapillary_features: Aggregations
   cases__diagnoses__tumor_grade: Aggregations
+  cases__diagnoses__primary_gleason_grade: Aggregations
   cases__diagnoses__treatments__days_to_treatment_start: NumericAggregations
   cases__diagnoses__treatments__updated_datetime: Aggregations
   cases__diagnoses__treatments__created_datetime: Aggregations
@@ -6195,6 +6890,7 @@ type FileAggregations {
   cases__diagnoses__treatments__treatment_type: Aggregations
   cases__diagnoses__treatments__submitter_id: Aggregations
   cases__diagnoses__treatments__treatment_id: Aggregations
+  cases__diagnoses__treatments__treatment_effect: Aggregations
   cases__diagnoses__treatments__state: Aggregations
   cases__diagnoses__treatments__therapeutic_agents: Aggregations
   cases__diagnoses__treatments__regimen_or_line_of_therapy: Aggregations
@@ -6204,22 +6900,14 @@ type FileAggregations {
   cases__diagnoses__treatments__days_to_treatment_end: NumericAggregations
   cases__diagnoses__treatments__treatment_or_therapy: Aggregations
   cases__diagnoses__days_to_diagnosis: NumericAggregations
-  cases__diagnoses__days_to_birth: NumericAggregations
-  cases__diagnoses__hpv_status: Aggregations
   cases__diagnoses__ajcc_staging_system_edition: Aggregations
-  cases__diagnoses__new_event_type: Aggregations
   cases__diagnoses__medulloblastoma_molecular_classification: Aggregations
-  cases__diagnoses__ldh_normal_range_upper: NumericAggregations
   cases__diagnoses__cog_renal_stage: Aggregations
   cases__diagnoses__synchronous_malignancy: Aggregations
   cases__diagnoses__metastasis_at_diagnosis_site: Aggregations
   cases__diagnoses__site_of_resection_or_biopsy: Aggregations
-
-  # The text term used to describe the type of malignant disease, as categorized
-  # by the World Health Organization's (WHO) International Classification of
-  # Diseases for Oncology (ICD-O).
-  #
-  cases__disease_type: Aggregations
+  cases__diagnoses__gleason_grade_group: Aggregations
+  cases__diagnosis_ids: Aggregations
   cases__submitter_aliquot_ids: Aggregations
   cases__summary__data_categories__file_count: NumericAggregations
   cases__summary__data_categories__data_category: Aggregations
@@ -6248,6 +6936,7 @@ type FileAggregations {
   # specific primary sites of disease.
   #
   cases__primary_site: Aggregations
+  cases__submitter_diagnosis_ids: Aggregations
   cases__tissue_source_site__project: Aggregations
   cases__tissue_source_site__bcr_id: Aggregations
   cases__tissue_source_site__code: Aggregations
@@ -6256,6 +6945,7 @@ type FileAggregations {
   cases__submitter_slide_ids: Aggregations
   total_reads: NumericAggregations
   state_comment: Aggregations
+  plate_well: Aggregations
   data_format: Aggregations
 
   # Numeric code for the center.
@@ -6273,15 +6963,14 @@ type FileAggregations {
 
   # Type classification of the center (e.g. CGCC).
   center__center_type: Aggregations
-  baseid: Aggregations
   md5sum: Aggregations
-  updated_datetime: Aggregations
+  plate_name: Aggregations
   mean_coverage: NumericAggregations
   analysis__analysis_id: Aggregations
   analysis__updated_datetime: Aggregations
   analysis__created_datetime: Aggregations
+  analysis__input_files__chip_id: Aggregations
   analysis__input_files__proportion_base_mismatch: NumericAggregations
-  analysis__input_files__updated_datetime: Aggregations
   analysis__input_files__file_name: Aggregations
   analysis__input_files__submitter_id: Aggregations
   analysis__input_files__read_pair_number: Aggregations
@@ -6298,14 +6987,21 @@ type FileAggregations {
   analysis__input_files__magnification: NumericAggregations
   analysis__input_files__mean_coverage: NumericAggregations
   analysis__input_files__average_read_length: NumericAggregations
+  analysis__input_files__contamination_error: NumericAggregations
+  analysis__input_files__channel: Aggregations
   analysis__input_files__experimental_strategy: Aggregations
+  analysis__input_files__updated_datetime: Aggregations
   analysis__input_files__data_type: Aggregations
+  analysis__input_files__chip_position: Aggregations
   analysis__input_files__proportion_coverage_10X: NumericAggregations
   analysis__input_files__file_id: Aggregations
+  analysis__input_files__contamination: NumericAggregations
   analysis__input_files__proportion_reads_duplicated: NumericAggregations
   analysis__input_files__total_reads: NumericAggregations
   analysis__input_files__state_comment: Aggregations
+  analysis__input_files__plate_well: Aggregations
   analysis__input_files__md5sum: Aggregations
+  analysis__input_files__plate_name: Aggregations
   analysis__input_files__data_format: Aggregations
   analysis__input_files__proportion_reads_mapped: NumericAggregations
   analysis__input_files__proportion_targets_no_coverage: NumericAggregations
@@ -6601,6 +7297,9 @@ type FileCase implements Node {
   disease_type: String
 
   # keyword
+  diagnosis_ids: String
+
+  # keyword
   submitter_aliquot_ids: String
 
   # keyword
@@ -6613,6 +7312,9 @@ type FileCase implements Node {
   # specific primary sites of disease.
   #
   primary_site: String
+
+  # keyword
+  submitter_diagnosis_ids: String
 
   # keyword
   submitter_slide_ids: String
@@ -6701,6 +7403,204 @@ type FileSize {
 }
 
 scalar FiltersArgument
+
+type FollowUp implements Node {
+  id: ID!
+  molecular_tests: MolecularTests
+  annotations: CaseAnnotations
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # post-bronchodilator.
+  #
+  fev1_ref_post_bronch_percent: Float
+
+  # The weight of the patient measured in kilograms.
+  #
+  weight: Float
+
+  # Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).
+  #
+  reflux_treatment_type: String
+
+  # The text term used to describe the type of progressive or recurrent disease or relapsed disease.
+  #
+  progression_or_recurrence_type: String
+
+  # The height of the patient in centimeters.
+  #
+  height: Float
+
+  # Number of days between the date used for index and the date of the patient's adverse event.
+  #
+  days_to_adverse_event: Float
+
+  # The text term used to describe the suspected cause or reason for the patient disease response.
+  #
+  cause_of_response: String
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.
+  #
+  fev1_fvc_pre_bronch_percent: Float
+
+  # The ECOG functional performance status of the patient/participant.
+  #
+  ecog_performance_status: String
+
+  # Text classification to represent the strain or type of human papillomavirus identified in an individual.
+  #
+  hpv_positive_type: String
+
+  # Number of days between the date used for index and the date the patient's
+  # disease was formally confirmed as progression-free.
+  #
+  days_to_progression_free: Float
+
+  # Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.
+  #
+  days_to_follow_up: Float
+
+  # Percentage value to represent result of Forced Expiratory Volume in 1 second
+  # (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.
+  #
+  fev1_fvc_post_bronch_percent: Float
+
+  # The text term used to describe the method used to diagnose the patient's comorbidity disease.
+  #
+  comorbidity_method_of_diagnosis: String
+
+  # The value, as a percentage of predicted lung volume, measuring the amount of
+  # carbon monoxide detected in a patient's lungs.
+  #
+  dlco_ref_predictive_percent: Float
+
+  # The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.
+  #
+  comorbidity: String
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  updated_datetime: String
+
+  # The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  risk_factor: String
+
+  # The current state of the object.
+  #
+  state: String
+
+  # Number of days between the date used for index and the date the patient's disease progressed.
+  #
+  days_to_progression: Float
+
+  # Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.
+  #
+  adverse_event: String
+
+  # Number of days between the date used for index and the date the patient's disease recurred.
+  #
+  days_to_recurrence: Float
+
+  # A calculated numerical quantity that represents an individual's weight to height ratio.
+  #
+  bmi: Float
+
+  # Text term used to describe the patient's menopause status.
+  #
+  menopause_status: String
+
+  # Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.
+  #
+  progression_or_recurrence: String
+
+  # Text term used to describe the types of treatment used to manage diabetes.
+  #
+  diabetes_treatment_type: String
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  risk_factor_treatment: String
+
+  # The text term used to describe the anatomic site of the progressive or recurrent disease.
+  #
+  progression_or_recurrence_anatomic_site: String
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  submitter_id: String
+
+  # The yes/no/unknown indicator used to describe whether goblet cells were
+  # determined to be present in a patient diagnosed with Barrett's esophagus.
+  #
+  barretts_esophagus_goblet_cells_present: String
+
+  # Code assigned to describe the patient's response or outcome to the disease.
+  #
+  disease_response: String
+
+  # keyword
+  follow_up_id: String
+
+  # Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.
+  #
+  pancreatitis_onset_year: Float
+
+  # Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.
+  #
+  viral_hepatitis_serologies: String
+
+  # The percentage comparison to a normal value reference range of the volume of
+  # air that a patient can forcibly exhale from the lungs in one second
+  # pre-bronchodilator.
+  #
+  fev1_ref_pre_bronch_percent: Float
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  created_datetime: String
+
+  # Text term used to describe the classification used of the functional capabilities of a person.
+  #
+  karnofsky_performance_status: String
+
+  # The yes/no/unknown indicator used to describe whether the patient received
+  # treatment for a risk factor the patient had at the time of or prior to their diagnosis.
+  #
+  hepatitis_sustained_virological_response: String
+
+  # Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.
+  #
+  days_to_comorbidity: Float
+  score: Int
+}
+
+type FollowUpConnection {
+  # The Information to aid in pagination
+  pageInfo: PageInfo!
+
+  # The Information to aid in pagination
+  total: Int!
+
+  # Information to aid in pagination.
+  edges: [FollowUpEdge]
+}
+
+type FollowUpEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: FollowUp
+}
+
+type FollowUps {
+  hits(offset: Int, sort: [Sort], filters: FiltersArgument, before: String, after: String, first: Int, last: Int): FollowUpConnection
+}
 
 type Gene implements Node {
   id: ID!
@@ -6801,9 +7701,8 @@ type GeneAggregations {
   case__diagnoses__tumor_stage: Aggregations
   case__diagnoses__age_at_diagnosis: NumericAggregations
   case__diagnoses__hpv_positive_type: Aggregations
-  case__diagnoses__vital_status: Aggregations
   case__diagnoses__morphology: Aggregations
-  case__diagnoses__days_to_death: NumericAggregations
+  case__diagnoses__ann_arbor_clinical_stage: Aggregations
   case__diagnoses__new_event_anatomic_site: Aggregations
   case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   case__diagnoses__perineural_invasion_present: Aggregations
@@ -6818,7 +7717,7 @@ type GeneAggregations {
   case__diagnoses__ajcc_pathologic_n: Aggregations
   case__diagnoses__vascular_invasion_present: Aggregations
   case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  case__diagnoses__days_to_last_follow_up: NumericAggregations
+  case__diagnoses__created_datetime: Aggregations
   case__diagnoses__residual_disease: Aggregations
   case__diagnoses__days_to_recurrence: NumericAggregations
   case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -6841,7 +7740,6 @@ type GeneAggregations {
   case__diagnoses__treatments__treatment_or_therapy: Aggregations
   case__diagnoses__lymphatic_invasion_present: Aggregations
   case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  case__diagnoses__days_to_birth: NumericAggregations
   case__diagnoses__progression_or_recurrence: Aggregations
   case__diagnoses__hpv_status: Aggregations
   case__diagnoses__prior_malignancy: Aggregations
@@ -6854,9 +7752,8 @@ type GeneAggregations {
   case__diagnoses__ldh_normal_range_upper: NumericAggregations
   case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   case__diagnoses__lymph_nodes_positive: NumericAggregations
-  case__diagnoses__ann_arbor_clinical_stage: Aggregations
   case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  case__diagnoses__created_datetime: Aggregations
+  case__diagnoses__days_to_last_follow_up: NumericAggregations
   case__diagnoses__ajcc_clinical_stage: Aggregations
   case__diagnoses__days_to_new_event: NumericAggregations
   case__diagnoses__hiv_positive: Aggregations
@@ -6872,6 +7769,9 @@ type GeneAggregations {
   case__demographic__demographic_id: Aggregations
   case__demographic__state: Aggregations
   case__demographic__race: Aggregations
+  case__demographic__days_to_birth: NumericAggregations
+  case__demographic__vital_status: Aggregations
+  case__demographic__days_to_death: NumericAggregations
   case__demographic__submitter_id: Aggregations
   case__demographic__ethnicity: Aggregations
   case__demographic__year_of_death: NumericAggregations
@@ -7139,11 +8039,11 @@ type Genes {
 type IndexFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7193,17 +8093,32 @@ type IndexFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7215,7 +8130,13 @@ type IndexFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7272,11 +8193,11 @@ type InputBamFile {
 type InputFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7326,17 +8247,32 @@ type InputFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7348,7 +8284,13 @@ type InputFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7497,6 +8439,210 @@ enum Mode {
   sum
 }
 
+type MolecularTest implements Node {
+  id: ID!
+  annotations: CaseAnnotations
+
+  # The yes/no/unknown indicator used to describe whether the mutation included in
+  # molecular testing was known to have an affect on the mismatch repair process.
+  #
+  mismatch_repair_mutation: String
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  updated_datetime: String
+
+  # The text term used to describe an antigen included in molecular testing.
+  #
+  antigen: String
+
+  # The text term used to describe the biological origin of a specific genetic variant.
+  #
+  variant_origin: String
+
+  # Numeric value used to describe the lower limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  blood_test_normal_range_lower: Float
+
+  # Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.
+  #
+  locus: String
+
+  # The text term or numeric value used to describe a sepcific result of a molecular test.
+  #
+  test_value: Float
+
+  # The text term used to describe a secondary gene targeted or included in
+  # molecular analysis. For rearrangements, this is should represent the location
+  # of the variant.
+  #
+  second_gene_symbol: String
+
+  # Text term used to describe the number of sets of homologous chromosomes.
+  #
+  ploidy: String
+
+  # The text term used to describe a chromosome targeted or included in molecular
+  # testing. If a specific genetic variant is being reported, this property can be
+  # used to capture the chromosome where that variant is located.
+  #
+  chromosome: String
+
+  # Text term used to describe a specific test that is not covered in the list of molecular analysis methods.
+  #
+  specialized_molecular_test: String
+
+  # A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+  #
+  created_datetime: String
+
+  # Intron number targeted or included in molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # intron where that variant is located.
+  #
+  intron: String
+
+  # The text term used to describe a gene targeted or included in molecular
+  # analysis. For rearrangements, this is shold be used to represent the reference gene.
+  #
+  gene_symbol: String
+
+  # The current state of the object.
+  #
+  state: String
+
+  # The text term used to describe a specific histone variants, which are proteins
+  # that substitute for the core canonical histones.
+  #
+  histone_variant: String
+
+  # Numeric value used to describe the number of cells used for molecular testing.
+  #
+  cell_count: Float
+
+  # The text term used to describe the family, or classification of a group of
+  # basic proteins found in chromatin, called histones.
+  #
+  histone_family: String
+
+  # Numeric value used to describe the number of times a section of the genome is
+  # repeated or copied within an insertion, duplication or deletion variant.
+  #
+  copy_number: Float
+
+  # The text term used to describe the type of analyte used for molecular testing.
+  #
+  test_analyte_type: String
+
+  # Exon number targeted or included in a molecular analysis. If a specific
+  # genetic variant is being reported, this property can be used to capture the
+  # exon where that variant is located.
+  #
+  exon: String
+
+  # The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.
+  #
+  laboratory_test: String
+
+  # The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.
+  #
+  test_result: String
+
+  # Alphanumeric value used to describe the transcript of a specific genetic variant.
+  #
+  transcript: String
+
+  # Numeric value used to describe the upper limit of the normal range used to
+  # describe a healthy individual at the institution where the test was completed.
+  #
+  blood_test_normal_range_upper: Float
+
+  # The text term used to describe the units of the test value for a molecular
+  # test. This property is used in conjunction with test_value.
+  #
+  test_units: String
+
+  # The text term used to describe the zygosity of a specific genetic variant.
+  #
+  zygosity: String
+
+  # Alphanumeric value used to describe the cytoband or chromosomal location
+  # targeted or included in molecular analysis. If a specific genetic variant is
+  # being reported, this property can be used to capture the cytoband where the
+  # variant is located. Format: [chromosome][chromosome arm].[band+sub-bands].
+  # Example: 17p13.1.
+  #
+  cytoband: String
+
+  # The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.
+  biospecimen_type: String
+
+  # A project-specific identifier for a node. This property is the calling
+  # card/nickname/alias for a unit of submission. It can be used in place of the
+  # UUID for identifying or recalling a node.
+  #
+  submitter_id: String
+
+  # The second exon number involved in molecular variation. If a specific genetic
+  # variant is being reported, this property can be used to capture the second
+  # exon where that variant is located. This property is typically used for a
+  # translocation where two different locations are involved in the variation.
+  #
+  second_exon: String
+
+  # keyword
+  molecular_test_id: String
+
+  # The text term used to describe the method used for molecular analysis.
+  #
+  molecular_analysis_method: String
+
+  # The text term used to describe the molecular consequence of genetic variation.
+  #
+  molecular_consequence: String
+
+  # The text term used to describe the type of genetic variation.
+  #
+  variant_type: String
+
+  # Numeric value used to describe the number of loci determined to be abnormal.
+  #
+  loci_abnormal_count: Float
+
+  # Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.
+  #
+  aa_change: String
+
+  # Numeric value used to describe the number of loci tested.
+  #
+  loci_count: Float
+  score: Int
+}
+
+type MolecularTestConnection {
+  # The Information to aid in pagination
+  pageInfo: PageInfo!
+
+  # The Information to aid in pagination
+  total: Int!
+
+  # Information to aid in pagination.
+  edges: [MolecularTestEdge]
+}
+
+type MolecularTestEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: MolecularTest
+}
+
+type MolecularTests {
+  hits(offset: Int, sort: [Sort], filters: FiltersArgument, before: String, after: String, first: Int, last: Int): MolecularTestConnection
+}
+
 type Mutation {
   sets(input: RelayIsDumb): Sets
 }
@@ -7509,6 +8655,40 @@ interface Node {
 type NumericAggregations {
   stats: Stats
   histogram(interval: Float): Aggregations
+  percentiles: Percentiles
+
+  #
+  #         Example for correct usage:
+  #         query ...
+  #         aggregations(filters: $filter1) {
+  #           diagnoses__age_at_diagnosis {
+  #             range(ranges: $filter2) {
+  #               buckets {
+  #                 doc_count
+  #                 key
+  #               }
+  #             }
+  #           }
+  #         }
+  #         ...
+  #
+  #         query variables
+  #         {..."filter2":{
+  #             "op":"range",
+  #             "content":[
+  #                 {
+  #                     "ranges":[
+  #                             {"to": 10585},
+  #                             {"from": 10950, "to": 21535},
+  #                             {"from": 21900, "to": 32485},
+  #                             {"from":33000}
+  #                     ]
+  #                 }
+  #             ]
+  #         }...}
+  #
+  #         
+  range(ranges: FiltersArgument): Aggregations
 }
 
 enum Order {
@@ -7519,11 +8699,11 @@ enum Order {
 type OutputFile implements Node {
   id: ID!
 
+  # keyword
+  chip_id: String
+
   # long
   proportion_base_mismatch: Float
-
-  # keyword
-  updated_datetime: String
 
   # keyword
   file_name: String
@@ -7573,17 +8753,32 @@ type OutputFile implements Node {
   # long
   average_read_length: Float
 
+  # long
+  contamination_error: Float
+
+  # keyword
+  channel: String
+
   # keyword
   experimental_strategy: String
 
   # keyword
+  updated_datetime: String
+
+  # keyword
   data_type: String
+
+  # keyword
+  chip_position: String
 
   # long
   proportion_coverage_10X: Float
 
   # keyword
   file_id: String
+
+  # long
+  contamination: Float
 
   # long
   proportion_reads_duplicated: Float
@@ -7595,7 +8790,13 @@ type OutputFile implements Node {
   state_comment: String
 
   # keyword
+  plate_well: String
+
+  # keyword
   md5sum: String
+
+  # keyword
+  plate_name: String
 
   # keyword
   data_format: String
@@ -7652,6 +8853,13 @@ type PageInfo {
 
   # When paginating forwards, the cursor to continue.
   endCursor: String
+}
+
+type Percentiles {
+  quartile_1: Float
+  quartile_3: Float
+  median: Float
+  iqr: Float
 }
 
 type Portion implements Node {
@@ -8229,7 +9437,7 @@ type Sample implements Node {
 
   # Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.
   #
-  time_between_excision_and_freezing: String
+  time_between_excision_and_freezing: Float
 
   # Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.
   #
@@ -8244,7 +9452,7 @@ type Sample implements Node {
   # UUID for identifying or recalling a node.
   #
   submitter_id: String
-  intermediate_dimension: String
+  intermediate_dimension: Float
 
   # keyword
   sample_id: String
@@ -8252,7 +9460,7 @@ type Sample implements Node {
   # Numeric representation of the elapsed time between the surgical clamping of
   # blood supply and freezing of the sample, measured in minutes.
   #
-  time_between_clamping_and_freezing: String
+  time_between_clamping_and_freezing: Float
 
   # UUID of the related pathology report.
   pathology_report_uuid: String
@@ -8301,7 +9509,7 @@ type Sample implements Node {
 
   # Numeric value that represents the shortest dimension of the sample, measured in millimeters.
   #
-  shortest_dimension: String
+  shortest_dimension: Float
 
   # The method used to procure the sample used to extract analyte(s).
   #
@@ -8352,7 +9560,7 @@ type Sample implements Node {
   # Numeric value that represents the initial weight of the sample, measured in milligrams.
   #
   initial_weight: Float
-  longest_dimension: String
+  longest_dimension: Float
   score: Int
 }
 
@@ -8574,9 +9782,8 @@ type SsmAggregations {
   occurrence__case__diagnoses__tumor_stage: Aggregations
   occurrence__case__diagnoses__age_at_diagnosis: NumericAggregations
   occurrence__case__diagnoses__hpv_positive_type: Aggregations
-  occurrence__case__diagnoses__vital_status: Aggregations
   occurrence__case__diagnoses__morphology: Aggregations
-  occurrence__case__diagnoses__days_to_death: NumericAggregations
+  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__new_event_anatomic_site: Aggregations
   occurrence__case__diagnoses__days_to_last_known_disease_status: NumericAggregations
   occurrence__case__diagnoses__perineural_invasion_present: Aggregations
@@ -8591,7 +9798,7 @@ type SsmAggregations {
   occurrence__case__diagnoses__ajcc_pathologic_n: Aggregations
   occurrence__case__diagnoses__vascular_invasion_present: Aggregations
   occurrence__case__diagnoses__ldh_level_at_diagnosis: NumericAggregations
-  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
+  occurrence__case__diagnoses__created_datetime: Aggregations
   occurrence__case__diagnoses__residual_disease: Aggregations
   occurrence__case__diagnoses__days_to_recurrence: NumericAggregations
   occurrence__case__diagnoses__tumor_largest_dimension_diameter: NumericAggregations
@@ -8614,7 +9821,6 @@ type SsmAggregations {
   occurrence__case__diagnoses__treatments__treatment_or_therapy: Aggregations
   occurrence__case__diagnoses__lymphatic_invasion_present: Aggregations
   occurrence__case__diagnoses__tissue_or_organ_of_origin: Aggregations
-  occurrence__case__diagnoses__days_to_birth: NumericAggregations
   occurrence__case__diagnoses__progression_or_recurrence: Aggregations
   occurrence__case__diagnoses__hpv_status: Aggregations
   occurrence__case__diagnoses__prior_malignancy: Aggregations
@@ -8627,9 +9833,8 @@ type SsmAggregations {
   occurrence__case__diagnoses__ldh_normal_range_upper: NumericAggregations
   occurrence__case__diagnoses__ann_arbor_extranodal_involvement: Aggregations
   occurrence__case__diagnoses__lymph_nodes_positive: NumericAggregations
-  occurrence__case__diagnoses__ann_arbor_clinical_stage: Aggregations
   occurrence__case__diagnoses__site_of_resection_or_biopsy: Aggregations
-  occurrence__case__diagnoses__created_datetime: Aggregations
+  occurrence__case__diagnoses__days_to_last_follow_up: NumericAggregations
   occurrence__case__diagnoses__ajcc_clinical_stage: Aggregations
   occurrence__case__diagnoses__days_to_new_event: NumericAggregations
   occurrence__case__diagnoses__hiv_positive: Aggregations
@@ -8645,6 +9850,9 @@ type SsmAggregations {
   occurrence__case__demographic__demographic_id: Aggregations
   occurrence__case__demographic__state: Aggregations
   occurrence__case__demographic__race: Aggregations
+  occurrence__case__demographic__days_to_birth: NumericAggregations
+  occurrence__case__demographic__vital_status: Aggregations
+  occurrence__case__demographic__days_to_death: NumericAggregations
   occurrence__case__demographic__submitter_id: Aggregations
   occurrence__case__demographic__ethnicity: Aggregations
   occurrence__case__demographic__year_of_death: NumericAggregations
@@ -9047,6 +10255,15 @@ type Stats {
   count: Int
   avg: Float
   sum: Float
+  std_deviation: Float
+  sum_of_squares: Float
+  variance: Float
+  std_deviation_bounds: StdDeviationBounds
+}
+
+type StdDeviationBounds {
+  upper: Float
+  lower: Float
 }
 
 type Summary {
@@ -9295,6 +10512,10 @@ type Treatment implements Node {
 
   # keyword
   treatment_id: String
+
+  # The text term used to describe the pathologic effect a treatment(s) had on the tumor.
+  #
+  treatment_effect: String
 
   # The current state of the object.
   #

--- a/data/schema.json
+++ b/data/schema.json
@@ -351,6 +351,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "FollowUp",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MolecularTest",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "File",
               "ofType": null
             },
@@ -1226,7 +1236,7 @@
               "name": "samples__time_between_excision_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1274,7 +1284,7 @@
               "name": "samples__intermediate_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1298,7 +1308,7 @@
               "name": "samples__time_between_clamping_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -1658,7 +1668,7 @@
               "name": "samples__shortest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3530,7 +3540,7 @@
               "name": "samples__longest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3765,18 +3775,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The year in which the participant quit smoking.\n",
-              "isDeprecated": false,
-              "name": "exposures__tobacco_smoking_quit_year",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The weight of the patient measured in kilograms.\n",
               "isDeprecated": false,
               "name": "exposures__weight",
@@ -3795,42 +3793,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
-              "isDeprecated": false,
-              "name": "exposures__alcohol_history",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
-              "isDeprecated": false,
-              "name": "exposures__alcohol_intensity",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
-              "isDeprecated": false,
-              "name": "exposures__bmi",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -3861,21 +3823,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to smoke that is emitted from burning tobacco, including cigarettes, pipes, and cigars. This includes tobacco smoke exhaled by smokers.\n",
               "isDeprecated": false,
-              "name": "exposures__created_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "exposures__state",
+              "name": "exposures__environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -3897,12 +3847,144 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_days_per_week",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "isDeprecated": false,
+              "name": "exposures__pack_years_smoked",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposured to respirable crystalline silica, a widespread, naturally occurring, crystalline metal oxide that consists of different forms including quartz, cristobalite, tridymite, tripoli, ganister, chert and novaculite.\n",
+              "isDeprecated": false,
+              "name": "exposures__respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to fine powder derived by the crushing of coal.\n",
+              "isDeprecated": false,
+              "name": "exposures__coal_dust_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "exposures__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.\n",
+              "isDeprecated": false,
+              "name": "exposures__asbestos_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "exposures__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the specific type of tobacco used by the patient.\n",
+              "isDeprecated": false,
+              "name": "exposures__type_of_tobacco_used",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The year in which the participant began smoking.\n",
               "isDeprecated": false,
               "name": "exposures__tobacco_smoking_onset_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_history",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "exposures__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to generally decribe how often the patient smokes.\n",
+              "isDeprecated": false,
+              "name": "exposures__smoking_frequency",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -3921,21 +4003,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "description": "The text term used to describe the patient's specific type of smoke exposure.\n",
               "isDeprecated": false,
-              "name": "exposures__alcohol_days_per_week",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "exposures__submitter_id",
+              "name": "exposures__type_of_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -3957,9 +4027,57 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
               "isDeprecated": false,
-              "name": "exposures__pack_years_smoked",
+              "name": "exposures__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
+              "isDeprecated": false,
+              "name": "exposures__alcohol_intensity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the approximate amount of time elapsed between the time the patient wakes up in the morning to the time they smoke their first cigarette.\n",
+              "isDeprecated": false,
+              "name": "exposures__time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to radon.\n",
+              "isDeprecated": false,
+              "name": "exposures__radon_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year in which the participant quit smoking.\n",
+              "isDeprecated": false,
+              "name": "exposures__tobacco_smoking_quit_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -3983,10 +4101,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__proportion_base_mismatch",
+              "name": "files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__chip_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -3999,18 +4129,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__index_files__updated_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -4211,6 +4329,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -4223,7 +4365,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4251,6 +4417,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4295,7 +4473,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__index_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__index_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__index_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4523,10 +4725,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__downstream_analyses__output_files__proportion_base_mismatch",
+              "name": "files__downstream_analyses__output_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -4535,10 +4737,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__downstream_analyses__output_files__updated_datetime",
+              "name": "files__downstream_analyses__output_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4739,6 +4941,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -4751,7 +4977,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -4779,6 +5029,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -4823,7 +5085,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__downstream_analyses__output_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__downstream_analyses__output_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5195,18 +5481,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__release_number",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "files__access",
               "type": {
                 "kind": "OBJECT",
@@ -5235,18 +5509,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__version",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -5447,7 +5709,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__channel",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5469,6 +5755,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "files__data_type",
@@ -5484,6 +5782,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "files__tags",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5519,6 +5829,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__proportion_base_mismatch",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__proportion_reads_duplicated",
               "type": {
                 "kind": "OBJECT",
@@ -5544,6 +5878,18 @@
               "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
               "isDeprecated": false,
               "name": "files__state_comment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__plate_well",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5637,18 +5983,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "files__baseid",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.\n",
               "isDeprecated": false,
               "name": "files__md5sum",
@@ -5661,9 +5995,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": null,
               "isDeprecated": false,
-              "name": "files__updated_datetime",
+              "name": "files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5723,10 +6057,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__analysis__input_files__proportion_base_mismatch",
+              "name": "files__analysis__input_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -5735,10 +6069,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files__analysis__input_files__updated_datetime",
+              "name": "files__analysis__input_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -5939,6 +6273,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -5951,7 +6309,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -5979,6 +6361,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -6023,7 +6417,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "files__analysis__input_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "files__analysis__input_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files__analysis__input_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7125,6 +7543,930 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The weight of the patient measured in kilograms.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__weight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).\n",
+              "isDeprecated": false,
+              "name": "follow_ups__reflux_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of progressive or recurrent disease or relapsed disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The height of the patient in centimeters.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__height",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's adverse event.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the suspected cause or reason for the patient disease response.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__cause_of_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The ECOG functional performance status of the patient/participant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__ecog_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__hpv_positive_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease was formally confirmed as progression-free.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_progression_free",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_follow_up",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used to diagnose the patient's comorbidity disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__dlco_ref_predictive_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__risk_factor",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease progressed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_progression",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease recurred.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the mutation included in molecular testing was known to have an affect on the mismatch repair process.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__mismatch_repair_mutation",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe an antigen included in molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__antigen",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological origin of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__variant_origin",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the lower limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__blood_test_normal_range_lower",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__locus",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term or numeric value used to describe a sepcific result of a molecular test.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_value",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a secondary gene targeted or included in molecular analysis. For rearrangements, this is should represent the location of the variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__second_gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the number of sets of homologous chromosomes.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__ploidy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a chromosome targeted or included in molecular testing. If a specific genetic variant is being reported, this property can be used to capture the chromosome where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__chromosome",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe a specific test that is not covered in the list of molecular analysis methods.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__specialized_molecular_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Intron number targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the intron where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__intron",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a gene targeted or included in molecular analysis. For rearrangements, this is shold be used to represent the reference gene.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a specific histone variants, which are proteins that substitute for the core canonical histones.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__histone_variant",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of cells used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__cell_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the family, or classification of a group of basic proteins found in chromatin, called histones.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__histone_family",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of times a section of the genome is repeated or copied within an insertion, duplication or deletion variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__copy_number",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of analyte used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_analyte_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Exon number targeted or included in a molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the exon where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__laboratory_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_result",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the transcript of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__transcript",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the upper limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__blood_test_normal_range_upper",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the units of the test value for a molecular test. This property is used in conjunction with test_value.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__test_units",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the zygosity of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__zygosity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the cytoband or chromosomal location targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the cytoband where the variant is located. Format: [chromosome][chromosome arm].[band+sub-bands]. Example: 17p13.1.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__cytoband",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__biospecimen_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The second exon number involved in molecular variation. If a specific genetic variant is being reported, this property can be used to capture the second exon where that variant is located. This property is typically used for a translocation where two different locations are involved in the variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__second_exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_test_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used for molecular analysis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_analysis_method",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the molecular consequence of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__molecular_consequence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__variant_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci determined to be abnormal.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__loci_abnormal_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci tested.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__molecular_tests__loci_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the patient's menopause status.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__menopause_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage diabetes.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__diabetes_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__risk_factor_treatment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the anatomic site of the progressive or recurrent disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether goblet cells were determined to be present in a patient diagnosed with Barrett's esophagus.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Code assigned to describe the patient's response or outcome to the disease.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__disease_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups__follow_up_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__pancreatitis_onset_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__viral_hepatitis_serologies",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "follow_ups__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the classification used of the functional capabilities of a person.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__karnofsky_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
+              "isDeprecated": false,
+              "name": "follow_ups__days_to_comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "index_date",
@@ -7281,6 +8623,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "disease_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term that represents the type of vascular tumor invasion.\n",
               "isDeprecated": false,
               "name": "diagnoses__vascular_invasion_type",
@@ -7353,9 +8707,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
+              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
               "isDeprecated": false,
-              "name": "diagnoses__vital_status",
+              "name": "diagnoses__metastasis_at_diagnosis",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7371,18 +8725,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_death",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7407,18 +8749,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_hiv_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7485,6 +8815,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall Weiss assessment score, a commonly used assessment describing the malignancy of adrenocortical tumors. The Weiss score is determined based on nine histological criteria including the following: high nuclear grade, mitotic rate greater than five per 50 high power fields (HPF), atypical mitotic figures, eosinophilic tumor cell cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__weiss_assessment_score",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term and code that represents the metastatic stage of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
               "name": "diagnoses__enneking_msts_metastasis",
@@ -7503,6 +8845,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of lymph nodes tested to determine whether lymph nodes were  involved with disease as determined by a pathologic examination.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__lymph_nodes_tested",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -7536,6 +8890,18 @@
               "description": "Text term to specify the location of the supratentorial tumor.\n",
               "isDeprecated": false,
               "name": "diagnoses__supratentorial_localization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the International Germ Cell Cancer Collaborative Group (IGCCCG), a grouping used to further classify metastatic testicular tumors.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__igcccg_stage",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7581,9 +8947,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
-              "name": "diagnoses__cause_of_death",
+              "name": "diagnoses__enneking_msts_tumor_site",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7593,9 +8959,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
+              "description": "A numeric value used to measure therapeutic response of the primary tumor and predict patient outcomes based on a three-point tumor regression grading system.\n",
               "isDeprecated": false,
-              "name": "diagnoses__enneking_msts_tumor_site",
+              "name": "diagnoses__tumor_regression_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7620,18 +8986,6 @@
               "description": "Stage group determined from clinical information on the tumor (T), regional node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hiv_positive",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -7677,18 +9031,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__metastasis_at_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date of the patient was thought to have the best overall response to their disease.\n",
               "isDeprecated": false,
               "name": "diagnoses__days_to_best_overall_response",
@@ -7719,18 +9061,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hpv_positive_type",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -7881,18 +9211,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_new_event",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Numeric value used to describe the non-peritonealised bare area of rectum, comprising anterior and posterior segments, when submitted as a surgical specimen resulting from excision of cancer of the rectum.\n",
               "isDeprecated": false,
               "name": "diagnoses__circumferential_resection_margin",
@@ -7965,12 +9283,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the secondary Gleason score, which describes the pattern of cells making up the second largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
               "isDeprecated": false,
-              "name": "diagnoses__progression_free_survival",
+              "name": "diagnoses__secondary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -8037,6 +9355,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe whether the patient's disease originated in a single location or multiple locations.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__tumor_focality",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The text term used to describe the classification of Wilms tumors distinguishing between favorable and unfavorable histologic groups.\n",
               "isDeprecated": false,
               "name": "diagnoses__wilms_tumor_histologic_subtype",
@@ -8052,18 +9382,6 @@
               "description": "Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_clinical_t",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__colon_polyps_history",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8133,9 +9451,201 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Status of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__legacy_updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "diagnoses__progression_free_survival_event",
+              "name": "diagnoses__annotations__entity_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Top level classification of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__classification",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Name of the person or entity responsible for the creation of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__creator",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__entity_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Open entry for any further description or characterization of the data.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__notes",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__entity_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__legacy_created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__case_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__annotation_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__case_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Top level characterization of the annotation.",
+              "isDeprecated": false,
+              "name": "diagnoses__annotations__category",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8241,12 +9751,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the Masaoka staging system, a classification that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.\n",
               "isDeprecated": false,
-              "name": "diagnoses__overall_survival",
+              "name": "diagnoses__masaoka_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -8313,18 +9823,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__new_event_anatomic_site",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The best improvement achieved throughout the entire course of protocol treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__best_overall_response",
@@ -8364,6 +9862,18 @@
               "description": "Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.\n",
               "isDeprecated": false,
               "name": "diagnoses__tumor_grade",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the primary Gleason score, which describes the pattern of cells making up the largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__primary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8448,6 +9958,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "diagnoses__treatments__treatment_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the pathologic effect a treatment(s) had on the tumor.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__treatments__treatment_effect",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8565,45 +10087,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__hpv_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the version or edition of the American Joint Committee on Cancer Staging Handbooks, a publication by the group formed for the purpose of developing a system of staging for cancer that is acceptable to the American medical profession and is compatible with other accepted classifications.\n",
               "isDeprecated": false,
               "name": "diagnoses__ajcc_staging_system_edition",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__new_event_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8619,18 +10105,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__ldh_normal_range_upper",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -8685,9 +10159,21 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall grouping of grades defined by the Gleason grading classification, which is used to determine the aggressiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "diagnoses__gleason_grade_group",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "disease_type",
+              "name": "diagnosis_ids",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -8949,6 +10435,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Study name of the project.",
               "isDeprecated": false,
               "name": "tissue_source_site__project",
@@ -9137,6 +10635,41 @@
                 "name": "Aggregations",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "percentiles",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Percentiles",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "ranges",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "\n        Example for correct usage:\n        query ...\n        aggregations(filters: $filter1) {\n          diagnoses__age_at_diagnosis {\n            range(ranges: $filter2) {\n              buckets {\n                doc_count\n                key\n              }\n            }\n          }\n        }\n        ...\n\n        query variables\n        {...\"filter2\":{\n            \"op\":\"range\",\n            \"content\":[\n                {\n                    \"ranges\":[\n                            {\"to\": 10585},\n                            {\"from\": 10950, \"to\": 21535},\n                            {\"from\": 21900, \"to\": 32485},\n                            {\"from\":33000}\n                    ]\n                }\n            ]\n        }...}\n\n        ",
+              "isDeprecated": false,
+              "name": "range",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -9208,6 +10741,54 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "std_deviation",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sum_of_squares",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "variance",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "std_deviation_bounds",
+              "type": {
+                "kind": "OBJECT",
+                "name": "StdDeviationBounds",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -9224,6 +10805,100 @@
           "interfaces": null,
           "kind": "SCALAR",
           "name": "Float",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "upper",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "lower",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "StdDeviationBounds",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "quartile_1",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "quartile_3",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "median",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "iqr",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Percentiles",
           "possibleTypes": null
         },
         {
@@ -9768,6 +11443,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "diagnosis_ids",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "submitter_aliquot_ids",
               "type": {
                 "kind": "SCALAR",
@@ -9793,6 +11480,18 @@
               "description": "keyword",
               "isDeprecated": false,
               "name": "primary_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -9928,6 +11627,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TissueSourceSite",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUps",
                 "ofType": null
               }
             },
@@ -10931,9 +12642,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
+              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
               "isDeprecated": false,
-              "name": "vital_status",
+              "name": "metastasis_at_diagnosis",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -10949,18 +12660,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_death",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -10985,18 +12684,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_hiv_diagnosis",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -11063,6 +12750,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the overall Weiss assessment score, a commonly used assessment describing the malignancy of adrenocortical tumors. The Weiss score is determined based on nine histological criteria including the following: high nuclear grade, mitotic rate greater than five per 50 high power fields (HPF), atypical mitotic figures, eosinophilic tumor cell cytoplasm (greater than 75% tumor cells), diffuse architecture (greater than 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular invasion.\n",
+              "isDeprecated": false,
+              "name": "weiss_assessment_score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Text term and code that represents the metastatic stage of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
               "name": "enneking_msts_metastasis",
@@ -11081,6 +12780,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of lymph nodes tested to determine whether lymph nodes were  involved with disease as determined by a pathologic examination.\n",
+              "isDeprecated": false,
+              "name": "lymph_nodes_tested",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -11114,6 +12825,18 @@
               "description": "Text term to specify the location of the supratentorial tumor.\n",
               "isDeprecated": false,
               "name": "supratentorial_localization",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the International Germ Cell Cancer Collaborative Group (IGCCCG), a grouping used to further classify metastatic testicular tumors.\n",
+              "isDeprecated": false,
+              "name": "igcccg_stage",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11159,9 +12882,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
               "isDeprecated": false,
-              "name": "cause_of_death",
+              "name": "enneking_msts_tumor_site",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11171,9 +12894,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Text term and code that represents the tumor site of the musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal Tumor Society (MSTS).\n",
+              "description": "A numeric value used to measure therapeutic response of the primary tumor and predict patient outcomes based on a three-point tumor regression grading system.\n",
               "isDeprecated": false,
-              "name": "enneking_msts_tumor_site",
+              "name": "tumor_regression_grade",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11198,18 +12921,6 @@
               "description": "Stage group determined from clinical information on the tumor (T), regional node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.\n",
               "isDeprecated": false,
               "name": "ajcc_clinical_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hiv_positive",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11255,18 +12966,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the extent of metastatic disease present at diagnosis.\n",
-              "isDeprecated": false,
-              "name": "metastasis_at_diagnosis",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date of the patient was thought to have the best overall response to their disease.\n",
               "isDeprecated": false,
               "name": "days_to_best_overall_response",
@@ -11297,18 +12996,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hpv_positive_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -11459,18 +13146,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_new_event",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Numeric value used to describe the non-peritonealised bare area of rectum, comprising anterior and posterior segments, when submitted as a surgical specimen resulting from excision of cancer of the rectum.\n",
               "isDeprecated": false,
               "name": "circumferential_resection_margin",
@@ -11543,12 +13218,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the secondary Gleason score, which describes the pattern of cells making up the second largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
               "isDeprecated": false,
-              "name": "progression_free_survival",
+              "name": "secondary_gleason_grade",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -11615,6 +13290,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe whether the patient's disease originated in a single location or multiple locations.\n",
+              "isDeprecated": false,
+              "name": "tumor_focality",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The text term used to describe the classification of Wilms tumors distinguishing between favorable and unfavorable histologic groups.\n",
               "isDeprecated": false,
               "name": "wilms_tumor_histologic_subtype",
@@ -11630,18 +13317,6 @@
               "description": "Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
               "isDeprecated": false,
               "name": "ajcc_clinical_t",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "colon_polyps_history",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11702,18 +13377,6 @@
               "description": "The text term used to describe the staging classification of liver tumors, as defined by the Children's Oncology Group (COG). This staging system specifically describes the extent of the primary tumor prior to treatment.\n",
               "isDeprecated": false,
               "name": "cog_liver_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "progression_free_survival_event",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -11819,12 +13482,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the Masaoka staging system, a classification that defines prognostic indicators for thymic malignancies and predicts tumor recurrence.\n",
               "isDeprecated": false,
-              "name": "overall_survival",
+              "name": "masaoka_stage",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -11891,18 +13554,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "new_event_anatomic_site",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The best improvement achieved throughout the entire course of protocol treatment.\n",
               "isDeprecated": false,
               "name": "best_overall_response",
@@ -11951,36 +13602,24 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the primary Gleason score, which describes the pattern of cells making up the largest area of the tumor. The primary and secondary Gleason pattern grades are combined to determine the patient's Gleason grade group, which is used to determine the aggresiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "primary_gleason_grade",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Number of days between the date used for index and the date the patient was diagnosed with the malignant disease.\n",
               "isDeprecated": false,
               "name": "days_to_diagnosis",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_birth",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "hpv_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -11999,36 +13638,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "new_event_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the classification of medulloblastoma tumors based on molecular features.\n",
               "isDeprecated": false,
               "name": "medulloblastoma_molecular_classification",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "ldh_normal_range_upper",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -12074,6 +13689,18 @@
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "site_of_resection_or_biopsy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the overall grouping of grades defined by the Gleason grading classification, which is used to determine the aggressiveness of prostate cancer. Note that this grade describes the entire prostatectomy specimen and is not specific to the sample used for sequencing.\n",
+              "isDeprecated": false,
+              "name": "gleason_grade_group",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12399,6 +14026,18 @@
               "description": "keyword",
               "isDeprecated": false,
               "name": "treatment_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the pathologic effect a treatment(s) had on the tumor.\n",
+              "isDeprecated": false,
+              "name": "treatment_effect",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -12789,12 +14428,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -12935,18 +14574,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "SCALAR",
@@ -12981,12 +14608,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "version",
+              "name": "average_read_length",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -12995,7 +14622,7 @@
               "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
-              "name": "average_read_length",
+              "name": "contamination_error",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -13017,6 +14644,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
               "name": "revision",
@@ -13029,9 +14668,33 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13059,6 +14722,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -13103,7 +14790,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "data_format",
+              "name": "plate_well",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13115,7 +14802,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "baseid",
+              "name": "data_format",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13137,9 +14824,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13474,18 +15161,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The year in which the participant quit smoking.\n",
-              "isDeprecated": false,
-              "name": "tobacco_smoking_quit_year",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The weight of the patient measured in kilograms.\n",
               "isDeprecated": false,
               "name": "weight",
@@ -13504,42 +15179,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
-              "isDeprecated": false,
-              "name": "alcohol_history",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
-              "isDeprecated": false,
-              "name": "alcohol_intensity",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
-              "isDeprecated": false,
-              "name": "bmi",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -13570,21 +15209,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to smoke that is emitted from burning tobacco, including cigarettes, pipes, and cigars. This includes tobacco smoke exhaled by smokers.\n",
               "isDeprecated": false,
-              "name": "created_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "state",
+              "name": "environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13606,12 +15233,144 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "isDeprecated": false,
+              "name": "alcohol_days_per_week",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "isDeprecated": false,
+              "name": "pack_years_smoked",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposured to respirable crystalline silica, a widespread, naturally occurring, crystalline metal oxide that consists of different forms including quartz, cristobalite, tridymite, tripoli, ganister, chert and novaculite.\n",
+              "isDeprecated": false,
+              "name": "respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether a patient was exposed to fine powder derived by the crushing of coal.\n",
+              "isDeprecated": false,
+              "name": "coal_dust_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to asbestos.\n",
+              "isDeprecated": false,
+              "name": "asbestos_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the specific type of tobacco used by the patient.\n",
+              "isDeprecated": false,
+              "name": "type_of_tobacco_used",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The year in which the participant began smoking.\n",
               "isDeprecated": false,
               "name": "tobacco_smoking_onset_year",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A response to a question that asks whether the participant has consumed at least 12 drinks of any kind of alcoholic beverage in their lifetime.\n",
+              "isDeprecated": false,
+              "name": "alcohol_history",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "bmi",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to generally decribe how often the patient smokes.\n",
+              "isDeprecated": false,
+              "name": "smoking_frequency",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -13630,21 +15389,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric value used to describe the average number of days each week that a person consumes an alcoholic beverage.\n",
+              "description": "The text term used to describe the patient's specific type of smoke exposure.\n",
               "isDeprecated": false,
-              "name": "alcohol_days_per_week",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "submitter_id",
+              "name": "type_of_smoke_exposure",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -13666,9 +15413,57 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
               "isDeprecated": false,
-              "name": "pack_years_smoked",
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Category to describe the patient's current level of alcohol use as self-reported by the patient.\n",
+              "isDeprecated": false,
+              "name": "alcohol_intensity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the approximate amount of time elapsed between the time the patient wakes up in the morning to the time they smoke their first cigarette.\n",
+              "isDeprecated": false,
+              "name": "time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient was exposed to radon.\n",
+              "isDeprecated": false,
+              "name": "radon_exposure",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year in which the participant quit smoking.\n",
+              "isDeprecated": false,
+              "name": "tobacco_smoking_quit_year",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -14798,7 +16593,7 @@
               "name": "time_between_excision_and_freezing",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -14846,7 +16641,7 @@
               "name": "intermediate_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -14870,7 +16665,7 @@
               "name": "time_between_clamping_and_freezing",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -15026,7 +16821,7 @@
               "name": "shortest_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -15182,7 +16977,7 @@
               "name": "longest_dimension",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -17226,6 +19021,1448 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sort",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "Sort",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "filters",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hits",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUpConnection",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUps",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FollowUpEdge",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUpConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUp",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUpEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "molecular_tests",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTests",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "annotations",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseAnnotations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The weight of the patient measured in kilograms.\n",
+              "isDeprecated": false,
+              "name": "weight",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).\n",
+              "isDeprecated": false,
+              "name": "reflux_treatment_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of progressive or recurrent disease or relapsed disease.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The height of the patient in centimeters.\n",
+              "isDeprecated": false,
+              "name": "height",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's adverse event.\n",
+              "isDeprecated": false,
+              "name": "days_to_adverse_event",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the suspected cause or reason for the patient disease response.\n",
+              "isDeprecated": false,
+              "name": "cause_of_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The ECOG functional performance status of the patient/participant.\n",
+              "isDeprecated": false,
+              "name": "ecog_performance_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
+              "isDeprecated": false,
+              "name": "hpv_positive_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease was formally confirmed as progression-free.\n",
+              "isDeprecated": false,
+              "name": "days_to_progression_free",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.\n",
+              "isDeprecated": false,
+              "name": "days_to_follow_up",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used to diagnose the patient's comorbidity disease.\n",
+              "isDeprecated": false,
+              "name": "comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
+              "isDeprecated": false,
+              "name": "dlco_ref_predictive_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.\n",
+              "isDeprecated": false,
+              "name": "comorbidity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "risk_factor",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease progressed.\n",
+              "isDeprecated": false,
+              "name": "days_to_progression",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.\n",
+              "isDeprecated": false,
+              "name": "adverse_event",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease recurred.\n",
+              "isDeprecated": false,
+              "name": "days_to_recurrence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "bmi",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the patient's menopause status.\n",
+              "isDeprecated": false,
+              "name": "menopause_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage diabetes.\n",
+              "isDeprecated": false,
+              "name": "diabetes_treatment_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "risk_factor_treatment",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the anatomic site of the progressive or recurrent disease.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether goblet cells were determined to be present in a patient diagnosed with Barrett's esophagus.\n",
+              "isDeprecated": false,
+              "name": "barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Code assigned to describe the patient's response or outcome to the disease.\n",
+              "isDeprecated": false,
+              "name": "disease_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "follow_up_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.\n",
+              "isDeprecated": false,
+              "name": "pancreatitis_onset_year",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.\n",
+              "isDeprecated": false,
+              "name": "viral_hepatitis_serologies",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the classification used of the functional capabilities of a person.\n",
+              "isDeprecated": false,
+              "name": "karnofsky_performance_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
+              "isDeprecated": false,
+              "name": "days_to_comorbidity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "FollowUp",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sort",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "Sort",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "filters",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hits",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTestConnection",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTests",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MolecularTestEdge",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTestConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTest",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTestEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "annotations",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseAnnotations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the mutation included in molecular testing was known to have an affect on the mismatch repair process.\n",
+              "isDeprecated": false,
+              "name": "mismatch_repair_mutation",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe an antigen included in molecular testing.\n",
+              "isDeprecated": false,
+              "name": "antigen",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological origin of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "variant_origin",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the lower limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "blood_test_normal_range_lower",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.\n",
+              "isDeprecated": false,
+              "name": "locus",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term or numeric value used to describe a sepcific result of a molecular test.\n",
+              "isDeprecated": false,
+              "name": "test_value",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a secondary gene targeted or included in molecular analysis. For rearrangements, this is should represent the location of the variant.\n",
+              "isDeprecated": false,
+              "name": "second_gene_symbol",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the number of sets of homologous chromosomes.\n",
+              "isDeprecated": false,
+              "name": "ploidy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a chromosome targeted or included in molecular testing. If a specific genetic variant is being reported, this property can be used to capture the chromosome where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "chromosome",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe a specific test that is not covered in the list of molecular analysis methods.\n",
+              "isDeprecated": false,
+              "name": "specialized_molecular_test",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Intron number targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the intron where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "intron",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a gene targeted or included in molecular analysis. For rearrangements, this is shold be used to represent the reference gene.\n",
+              "isDeprecated": false,
+              "name": "gene_symbol",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a specific histone variants, which are proteins that substitute for the core canonical histones.\n",
+              "isDeprecated": false,
+              "name": "histone_variant",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of cells used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "cell_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the family, or classification of a group of basic proteins found in chromatin, called histones.\n",
+              "isDeprecated": false,
+              "name": "histone_family",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of times a section of the genome is repeated or copied within an insertion, duplication or deletion variant.\n",
+              "isDeprecated": false,
+              "name": "copy_number",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of analyte used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "test_analyte_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Exon number targeted or included in a molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the exon where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "exon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.\n",
+              "isDeprecated": false,
+              "name": "laboratory_test",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.\n",
+              "isDeprecated": false,
+              "name": "test_result",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the transcript of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "transcript",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the upper limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "blood_test_normal_range_upper",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the units of the test value for a molecular test. This property is used in conjunction with test_value.\n",
+              "isDeprecated": false,
+              "name": "test_units",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the zygosity of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "zygosity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the cytoband or chromosomal location targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the cytoband where the variant is located. Format: [chromosome][chromosome arm].[band+sub-bands]. Example: 17p13.1.\n",
+              "isDeprecated": false,
+              "name": "cytoband",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.",
+              "isDeprecated": false,
+              "name": "biospecimen_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The second exon number involved in molecular variation. If a specific genetic variant is being reported, this property can be used to capture the second exon where that variant is located. This property is typically used for a translocation where two different locations are involved in the variation.\n",
+              "isDeprecated": false,
+              "name": "second_exon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "molecular_test_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used for molecular analysis.\n",
+              "isDeprecated": false,
+              "name": "molecular_analysis_method",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the molecular consequence of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "molecular_consequence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "variant_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci determined to be abnormal.\n",
+              "isDeprecated": false,
+              "name": "loci_abnormal_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.\n",
+              "isDeprecated": false,
+              "name": "aa_change",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci tested.\n",
+              "isDeprecated": false,
+              "name": "loci_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "MolecularTest",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "filters",
                   "type": {
                     "kind": "SCALAR",
@@ -17430,10 +20667,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__chip_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17446,18 +20695,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "index_files__updated_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17658,6 +20895,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -17670,7 +20931,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -17698,6 +20983,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -17742,7 +21039,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "index_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "index_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "index_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -17970,10 +21291,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "downstream_analyses__output_files__proportion_base_mismatch",
+              "name": "downstream_analyses__output_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -17982,10 +21303,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "downstream_analyses__output_files__updated_datetime",
+              "name": "downstream_analyses__output_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -18186,6 +21507,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -18198,7 +21543,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -18226,6 +21595,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -18270,7 +21651,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "downstream_analyses__output_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "downstream_analyses__output_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "downstream_analyses__output_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -18642,18 +22047,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "OBJECT",
@@ -18682,18 +22075,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "version",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -18883,6 +22264,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "average_read_length",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contamination_error",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -19110,10 +22503,34 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "revision",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -19146,6 +22563,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "chip_position",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "proportion_coverage_10X",
               "type": {
                 "kind": "OBJECT",
@@ -19162,6 +22591,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19569,7 +23022,7 @@
               "name": "cases__samples__time_between_excision_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19617,7 +23070,7 @@
               "name": "cases__samples__intermediate_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -19641,7 +23094,7 @@
               "name": "cases__samples__time_between_clamping_and_freezing",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -20001,7 +23454,7 @@
               "name": "cases__samples__shortest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -21873,7 +25326,7 @@
               "name": "cases__samples__longest_dimension",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22110,18 +25563,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__tobacco_smoking_quit_year",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__exposures__weight",
               "type": {
                 "kind": "OBJECT",
@@ -22138,42 +25579,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__alcohol_history",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__alcohol_intensity",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__bmi",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22206,19 +25611,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__created_datetime",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__state",
+              "name": "cases__exposures__environmental_tobacco_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22242,10 +25635,142 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__exposures__alcohol_days_per_week",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__pack_years_smoked",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__respirable_crystalline_silica_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__coal_dust_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__asbestos_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__type_of_tobacco_used",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__exposures__tobacco_smoking_onset_year",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__alcohol_history",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__smoking_frequency",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -22266,19 +25791,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__alcohol_days_per_week",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__exposures__submitter_id",
+              "name": "cases__exposures__type_of_smoke_exposure",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22302,7 +25815,979 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__exposures__pack_years_smoked",
+              "name": "cases__exposures__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__alcohol_intensity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__time_between_waking_and_first_smoke",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__radon_exposure",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__exposures__tobacco_smoking_quit_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__weight",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__reflux_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__height",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__cause_of_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__ecog_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__hpv_positive_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_progression_free",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_follow_up",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__dlco_ref_predictive_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__comorbidity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__risk_factor",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_progression",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__adverse_event",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__mismatch_repair_mutation",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__antigen",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__variant_origin",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__blood_test_normal_range_lower",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__locus",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_value",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__second_gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__ploidy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__chromosome",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__specialized_molecular_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__intron",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__gene_symbol",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__histone_variant",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__cell_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__histone_family",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__copy_number",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_analyte_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__laboratory_test",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_result",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__transcript",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__blood_test_normal_range_upper",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__test_units",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__zygosity",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__cytoband",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__biospecimen_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__second_exon",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_test_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_analysis_method",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__molecular_consequence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__variant_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__loci_abnormal_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__molecular_tests__loci_count",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__bmi",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__menopause_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__diabetes_treatment_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__risk_factor_treatment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__disease_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__follow_up_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__pancreatitis_onset_year",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__viral_hepatitis_serologies",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__karnofsky_performance_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__follow_ups__days_to_comorbidity",
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
@@ -22456,6 +26941,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
+              "isDeprecated": false,
+              "name": "cases__disease_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__vascular_invasion_type",
@@ -22530,7 +27027,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__vital_status",
+              "name": "cases__diagnoses__metastasis_at_diagnosis",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22546,18 +27043,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_death",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22582,18 +27067,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_hiv_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22662,6 +27135,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__diagnoses__weiss_assessment_score",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__diagnoses__enneking_msts_metastasis",
               "type": {
                 "kind": "OBJECT",
@@ -22678,6 +27163,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__lymph_nodes_tested",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -22711,6 +27208,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__supratentorial_localization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__igcccg_stage",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22758,7 +27267,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__cause_of_death",
+              "name": "cases__diagnoses__enneking_msts_tumor_site",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22770,7 +27279,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__enneking_msts_tumor_site",
+              "name": "cases__diagnoses__tumor_regression_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22795,18 +27304,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hiv_positive",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -22854,18 +27351,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__metastasis_at_diagnosis",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__days_to_best_overall_response",
               "type": {
                 "kind": "OBJECT",
@@ -22894,18 +27379,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hpv_positive_type",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23058,18 +27531,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_new_event",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__circumferential_resection_margin",
               "type": {
                 "kind": "OBJECT",
@@ -23142,10 +27603,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__progression_free_survival",
+              "name": "cases__diagnoses__secondary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23214,6 +27675,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__diagnoses__tumor_focality",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__diagnoses__wilms_tumor_histologic_subtype",
               "type": {
                 "kind": "OBJECT",
@@ -23227,18 +27700,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_clinical_t",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__colon_polyps_history",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23310,7 +27771,199 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__progression_free_survival_event",
+              "name": "cases__diagnoses__annotations__status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__legacy_updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__classification",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__creator",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__notes",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__entity_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__legacy_created_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__state",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__case_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__annotation_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__case_submitter_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__annotations__category",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23418,10 +28071,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__overall_survival",
+              "name": "cases__diagnoses__masaoka_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -23490,18 +28143,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__new_event_anatomic_site",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__best_overall_response",
               "type": {
                 "kind": "OBJECT",
@@ -23539,6 +28180,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__tumor_grade",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__primary_gleason_grade",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23623,6 +28276,18 @@
               "description": null,
               "isDeprecated": false,
               "name": "cases__diagnoses__treatments__treatment_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnoses__treatments__treatment_effect",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23742,43 +28407,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cases__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__hpv_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "cases__diagnoses__ajcc_staging_system_edition",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__new_event_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -23794,18 +28423,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cases__diagnoses__ldh_normal_range_upper",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -23860,9 +28477,21 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the type of malignant disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
+              "description": null,
               "isDeprecated": false,
-              "name": "cases__disease_type",
+              "name": "cases__diagnoses__gleason_grade_group",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cases__diagnosis_ids",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24126,6 +28755,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "cases__submitter_diagnosis_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "cases__tissue_source_site__project",
               "type": {
                 "kind": "OBJECT",
@@ -24222,6 +28863,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "data_format",
               "type": {
                 "kind": "OBJECT",
@@ -24306,18 +28959,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "baseid",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "md5sum",
               "type": {
                 "kind": "OBJECT",
@@ -24330,7 +28971,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24390,10 +29031,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "analysis__input_files__proportion_base_mismatch",
+              "name": "analysis__input_files__chip_id",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -24402,10 +29043,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "analysis__input_files__updated_datetime",
+              "name": "analysis__input_files__proportion_base_mismatch",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -24606,6 +29247,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__contamination_error",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__channel",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__experimental_strategy",
               "type": {
                 "kind": "OBJECT",
@@ -24618,7 +29283,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__updated_datetime",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__data_type",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__chip_position",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -24646,6 +29335,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__contamination",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -24690,7 +29391,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "analysis__input_files__plate_well",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "analysis__input_files__md5sum",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "analysis__input_files__plate_name",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -25989,12 +30714,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -26135,18 +30860,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "release_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "access",
               "type": {
                 "kind": "SCALAR",
@@ -26181,18 +30894,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "version",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "long",
               "isDeprecated": false,
               "name": "average_read_length",
@@ -26205,9 +30906,33 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26231,7 +30956,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26259,6 +31008,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -26303,7 +31076,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "data_format",
+              "name": "plate_well",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26315,7 +31088,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "baseid",
+              "name": "data_format",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26339,7 +31112,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26993,24 +31766,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -27209,6 +31982,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -27223,7 +32020,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -27251,6 +32072,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -27295,7 +32128,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -29853,6 +34710,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "diagnosis_ids",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "submitter_aliquot_ids",
               "type": {
                 "kind": "SCALAR",
@@ -29878,6 +34747,18 @@
               "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories. Reference tissue_or_organ_of_origin on the diagnosis node for more specific primary sites of disease.\n",
               "isDeprecated": false,
               "name": "primary_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "submitter_diagnosis_ids",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -30814,24 +35695,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31030,6 +35911,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -31044,7 +35949,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31072,6 +36001,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31116,7 +36057,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31439,24 +36404,24 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "keyword",
               "isDeprecated": false,
-              "name": "proportion_base_mismatch",
+              "name": "chip_id",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": "keyword",
+              "description": "long",
               "isDeprecated": false,
-              "name": "updated_datetime",
+              "name": "proportion_base_mismatch",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31655,6 +36620,30 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
               "name": "experimental_strategy",
@@ -31669,7 +36658,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -31697,6 +36710,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -31741,7 +36766,31 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -32872,18 +37921,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
               "isDeprecated": false,
               "name": "diagnoses__morphology",
@@ -32896,12 +37933,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
               "isDeprecated": false,
-              "name": "diagnoses__days_to_death",
+              "name": "diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -33076,12 +38113,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
               "isDeprecated": false,
-              "name": "diagnoses__days_to_last_follow_up",
+              "name": "diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -33352,18 +38389,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
               "isDeprecated": false,
               "name": "diagnoses__progression_or_recurrence",
@@ -33508,18 +38533,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
-              "isDeprecated": false,
-              "name": "diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "diagnoses__site_of_resection_or_biopsy",
@@ -33532,12 +38545,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
               "isDeprecated": false,
-              "name": "diagnoses__created_datetime",
+              "name": "diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -36313,18 +41326,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The survival state of the person registered on the protocol.\n",
-              "isDeprecated": false,
-              "name": "vital_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
               "isDeprecated": false,
               "name": "morphology",
@@ -36337,12 +41338,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "long",
+              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
               "isDeprecated": false,
-              "name": "days_to_death",
+              "name": "ann_arbor_clinical_stage",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -36517,12 +41518,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
               "isDeprecated": false,
-              "name": "days_to_last_follow_up",
+              "name": "created_datetime",
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -36631,18 +41632,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "days_to_birth",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
                 "ofType": null
               }
             },
@@ -36793,18 +41782,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The text term used to describe the clinical classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.\n",
-              "isDeprecated": false,
-              "name": "ann_arbor_clinical_stage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The text term used to describe the anatomic site of origin, of the patient's malignant disease, as described by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O).\n",
               "isDeprecated": false,
               "name": "site_of_resection_or_biopsy",
@@ -36817,12 +41794,12 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
               "isDeprecated": false,
-              "name": "created_datetime",
+              "name": "days_to_last_follow_up",
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -38878,18 +43855,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -38902,10 +43867,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_death",
+              "name": "case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -39082,10 +44047,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_last_follow_up",
+              "name": "case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -39358,18 +44323,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -39514,18 +44467,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -39538,10 +44479,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "case__diagnoses__created_datetime",
+              "name": "case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -39722,6 +44663,42 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -43935,18 +48912,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -43959,10 +48924,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_death",
+              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -44139,10 +49104,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
+              "name": "occurrence__case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -44415,18 +49380,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -44571,18 +49524,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -44595,10 +49536,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__created_datetime",
+              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -44779,6 +49720,42 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -49649,18 +54626,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__vital_status",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__morphology",
               "type": {
                 "kind": "OBJECT",
@@ -49673,10 +54638,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_death",
+              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -49853,10 +54818,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
+              "name": "occurrence__case__diagnoses__created_datetime",
               "type": {
                 "kind": "OBJECT",
-                "name": "NumericAggregations",
+                "name": "Aggregations",
                 "ofType": null
               }
             },
@@ -50129,18 +55094,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__days_to_birth",
-              "type": {
-                "kind": "OBJECT",
-                "name": "NumericAggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__progression_or_recurrence",
               "type": {
                 "kind": "OBJECT",
@@ -50285,18 +55238,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__ann_arbor_clinical_stage",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Aggregations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "occurrence__case__diagnoses__site_of_resection_or_biopsy",
               "type": {
                 "kind": "OBJECT",
@@ -50309,10 +55250,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "occurrence__case__diagnoses__created_datetime",
+              "name": "occurrence__case__diagnoses__days_to_last_follow_up",
               "type": {
                 "kind": "OBJECT",
-                "name": "Aggregations",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },
@@ -50493,6 +55434,42 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_birth",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__vital_status",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence__case__demographic__days_to_death",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NumericAggregations",
                 "ofType": null
               }
             },

--- a/data/schema.json
+++ b/data/schema.json
@@ -306,17 +306,27 @@
             },
             {
               "kind": "OBJECT",
-              "name": "CaseFile",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
               "name": "Exposure",
               "ofType": null
             },
             {
               "kind": "OBJECT",
               "name": "FamilyHistory",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CaseFile",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "FollowUp",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MolecularTest",
               "ofType": null
             },
             {
@@ -347,16 +357,6 @@
             {
               "kind": "OBJECT",
               "name": "Slide",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "FollowUp",
-              "ofType": null
-            },
-            {
-              "kind": "OBJECT",
-              "name": "MolecularTest",
               "ofType": null
             },
             {
@@ -10662,7 +10662,7 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "\n        Example for correct usage:\n        query ...\n        aggregations(filters: $filter1) {\n          diagnoses__age_at_diagnosis {\n            range(ranges: $filter2) {\n              buckets {\n                doc_count\n                key\n              }\n            }\n          }\n        }\n        ...\n\n        query variables\n        {...\"filter2\":{\n            \"op\":\"range\",\n            \"content\":[\n                {\n                    \"ranges\":[\n                            {\"to\": 10585},\n                            {\"from\": 10950, \"to\": 21535},\n                            {\"from\": 21900, \"to\": 32485},\n                            {\"from\":33000}\n                    ]\n                }\n            ]\n        }...}\n\n        ",
+              "description": null,
               "isDeprecated": false,
               "name": "range",
               "type": {
@@ -11551,18 +11551,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "files",
-              "type": {
-                "kind": "OBJECT",
-                "name": "CaseFiles",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "exposures",
               "type": {
                 "kind": "OBJECT",
@@ -11579,6 +11567,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "FamilyHistories",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "files",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseFiles",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "follow_ups",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUps",
                 "ofType": null
               }
             },
@@ -11627,18 +11639,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TissueSourceSite",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "follow_ups",
-              "type": {
-                "kind": "OBJECT",
-                "name": "FollowUps",
                 "ofType": null
               }
             },
@@ -14252,771 +14252,6 @@
               "name": "hits",
               "type": {
                 "kind": "OBJECT",
-                "name": "CaseFileConnection",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "CaseFiles",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "pageInfo",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "total",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
-              "name": "edges",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CaseFileEdge",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "CaseFileConnection",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
-              "name": "cursor",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
-              "name": "node",
-              "type": {
-                "kind": "OBJECT",
-                "name": "CaseFile",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "CaseFileEdge",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "acl",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "tags",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "origin",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "chip_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The name (or part of a name) of a file (of any type).\n",
-              "isDeprecated": false,
-              "name": "file_name",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "submitter_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "read_pair_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The size of the data file (object) in bytes.\n",
-              "isDeprecated": false,
-              "name": "file_size",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_coverage_30X",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "pairs_on_diff_chr",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "average_base_quality",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "created_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "imaging_date",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Type of error for the data file object.\n",
-              "isDeprecated": false,
-              "name": "error_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "state",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "access",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "platform",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "magnification",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "average_read_length",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "contamination_error",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "channel",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "revision",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "updated_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "data_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "chip_position",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_coverage_10X",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "file_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "contamination",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_base_mismatch",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_reads_duplicated",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "total_reads",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
-              "isDeprecated": false,
-              "name": "state_comment",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "plate_well",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "data_format",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.\n",
-              "isDeprecated": false,
-              "name": "md5sum",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "plate_name",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "mean_coverage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_reads_mapped",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "proportion_targets_no_coverage",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "data_category",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "experimental_strategy",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "long",
-              "isDeprecated": false,
-              "name": "average_insert_size",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "score",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "kind": "OBJECT",
-          "name": "CaseFile",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "offset",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "sort",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "Sort",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "filters",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "FiltersArgument",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "before",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "after",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "first",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "last",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hits",
-              "type": {
-                "kind": "OBJECT",
                 "name": "ExposureConnection",
                 "ofType": null
               }
@@ -15854,6 +15089,2213 @@
           ],
           "kind": "OBJECT",
           "name": "FamilyHistory",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sort",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "Sort",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "filters",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hits",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseFileConnection",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "CaseFiles",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CaseFileEdge",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "CaseFileConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseFile",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "CaseFileEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "acl",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tags",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "origin",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name (or part of a name) of a file (of any type).\n",
+              "isDeprecated": false,
+              "name": "file_name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "read_pair_number",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The size of the data file (object) in bytes.\n",
+              "isDeprecated": false,
+              "name": "file_size",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_coverage_30X",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "pairs_on_diff_chr",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "average_base_quality",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "imaging_date",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Type of error for the data file object.\n",
+              "isDeprecated": false,
+              "name": "error_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "access",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "platform",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "magnification",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "average_read_length",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination_error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "channel",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "revision",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "data_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "chip_position",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_coverage_10X",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "file_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "contamination",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_base_mismatch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_reads_duplicated",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "total_reads",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+              "isDeprecated": false,
+              "name": "state_comment",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_well",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "data_format",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number (in lower case) used as a file's digital fingerprint.\n",
+              "isDeprecated": false,
+              "name": "md5sum",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "plate_name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "mean_coverage",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_reads_mapped",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "proportion_targets_no_coverage",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "data_category",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "experimental_strategy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "long",
+              "isDeprecated": false,
+              "name": "average_insert_size",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "CaseFile",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sort",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "Sort",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "filters",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hits",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUpConnection",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUps",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FollowUpEdge",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUpConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "FollowUp",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "FollowUpEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "annotations",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseAnnotations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "molecular_tests",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTests",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_ref_post_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The weight of the patient measured in kilograms.\n",
+              "isDeprecated": false,
+              "name": "weight",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).\n",
+              "isDeprecated": false,
+              "name": "reflux_treatment_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of progressive or recurrent disease or relapsed disease.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The height of the patient in centimeters.\n",
+              "isDeprecated": false,
+              "name": "height",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's adverse event.\n",
+              "isDeprecated": false,
+              "name": "days_to_adverse_event",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the suspected cause or reason for the patient disease response.\n",
+              "isDeprecated": false,
+              "name": "cause_of_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_fvc_pre_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The ECOG functional performance status of the patient/participant.\n",
+              "isDeprecated": false,
+              "name": "ecog_performance_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
+              "isDeprecated": false,
+              "name": "hpv_positive_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease was formally confirmed as progression-free.\n",
+              "isDeprecated": false,
+              "name": "days_to_progression_free",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.\n",
+              "isDeprecated": false,
+              "name": "days_to_follow_up",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_fvc_post_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used to diagnose the patient's comorbidity disease.\n",
+              "isDeprecated": false,
+              "name": "comorbidity_method_of_diagnosis",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
+              "isDeprecated": false,
+              "name": "dlco_ref_predictive_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.\n",
+              "isDeprecated": false,
+              "name": "comorbidity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "risk_factor",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease progressed.\n",
+              "isDeprecated": false,
+              "name": "days_to_progression",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.\n",
+              "isDeprecated": false,
+              "name": "adverse_event",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient's disease recurred.\n",
+              "isDeprecated": false,
+              "name": "days_to_recurrence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
+              "isDeprecated": false,
+              "name": "bmi",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the patient's menopause status.\n",
+              "isDeprecated": false,
+              "name": "menopause_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the types of treatment used to manage diabetes.\n",
+              "isDeprecated": false,
+              "name": "diabetes_treatment_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "risk_factor_treatment",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the anatomic site of the progressive or recurrent disease.\n",
+              "isDeprecated": false,
+              "name": "progression_or_recurrence_anatomic_site",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether goblet cells were determined to be present in a patient diagnosed with Barrett's esophagus.\n",
+              "isDeprecated": false,
+              "name": "barretts_esophagus_goblet_cells_present",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Code assigned to describe the patient's response or outcome to the disease.\n",
+              "isDeprecated": false,
+              "name": "disease_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "follow_up_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.\n",
+              "isDeprecated": false,
+              "name": "pancreatitis_onset_year",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.\n",
+              "isDeprecated": false,
+              "name": "viral_hepatitis_serologies",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
+              "isDeprecated": false,
+              "name": "fev1_ref_pre_bronch_percent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the classification used of the functional capabilities of a person.\n",
+              "isDeprecated": false,
+              "name": "karnofsky_performance_status",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
+              "isDeprecated": false,
+              "name": "hepatitis_sustained_virological_response",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
+              "isDeprecated": false,
+              "name": "days_to_comorbidity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "FollowUp",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sort",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "Sort",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "filters",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FiltersArgument",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hits",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTestConnection",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTests",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The Information to aid in pagination",
+              "isDeprecated": false,
+              "name": "total",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information to aid in pagination.",
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MolecularTestEdge",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTestConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A cursor for use in pagination",
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The item at the end of the edge",
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MolecularTest",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "MolecularTestEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "annotations",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CaseAnnotations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The yes/no/unknown indicator used to describe whether the mutation included in molecular testing was known to have an affect on the mismatch repair process.\n",
+              "isDeprecated": false,
+              "name": "mismatch_repair_mutation",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "updated_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe an antigen included in molecular testing.\n",
+              "isDeprecated": false,
+              "name": "antigen",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological origin of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "variant_origin",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the lower limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "blood_test_normal_range_lower",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.\n",
+              "isDeprecated": false,
+              "name": "locus",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term or numeric value used to describe a sepcific result of a molecular test.\n",
+              "isDeprecated": false,
+              "name": "test_value",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a secondary gene targeted or included in molecular analysis. For rearrangements, this is should represent the location of the variant.\n",
+              "isDeprecated": false,
+              "name": "second_gene_symbol",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe the number of sets of homologous chromosomes.\n",
+              "isDeprecated": false,
+              "name": "ploidy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a chromosome targeted or included in molecular testing. If a specific genetic variant is being reported, this property can be used to capture the chromosome where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "chromosome",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Text term used to describe a specific test that is not covered in the list of molecular analysis methods.\n",
+              "isDeprecated": false,
+              "name": "specialized_molecular_test",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
+              "isDeprecated": false,
+              "name": "created_datetime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Intron number targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the intron where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "intron",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a gene targeted or included in molecular analysis. For rearrangements, this is shold be used to represent the reference gene.\n",
+              "isDeprecated": false,
+              "name": "gene_symbol",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The current state of the object.\n",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe a specific histone variants, which are proteins that substitute for the core canonical histones.\n",
+              "isDeprecated": false,
+              "name": "histone_variant",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of cells used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "cell_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the family, or classification of a group of basic proteins found in chromatin, called histones.\n",
+              "isDeprecated": false,
+              "name": "histone_family",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of times a section of the genome is repeated or copied within an insertion, duplication or deletion variant.\n",
+              "isDeprecated": false,
+              "name": "copy_number",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of analyte used for molecular testing.\n",
+              "isDeprecated": false,
+              "name": "test_analyte_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Exon number targeted or included in a molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the exon where that variant is located.\n",
+              "isDeprecated": false,
+              "name": "exon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.\n",
+              "isDeprecated": false,
+              "name": "laboratory_test",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.\n",
+              "isDeprecated": false,
+              "name": "test_result",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the transcript of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "transcript",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the upper limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
+              "isDeprecated": false,
+              "name": "blood_test_normal_range_upper",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the units of the test value for a molecular test. This property is used in conjunction with test_value.\n",
+              "isDeprecated": false,
+              "name": "test_units",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the zygosity of a specific genetic variant.\n",
+              "isDeprecated": false,
+              "name": "zygosity",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the cytoband or chromosomal location targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the cytoband where the variant is located. Format: [chromosome][chromosome arm].[band+sub-bands]. Example: 17p13.1.\n",
+              "isDeprecated": false,
+              "name": "cytoband",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.",
+              "isDeprecated": false,
+              "name": "biospecimen_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+              "isDeprecated": false,
+              "name": "submitter_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The second exon number involved in molecular variation. If a specific genetic variant is being reported, this property can be used to capture the second exon where that variant is located. This property is typically used for a translocation where two different locations are involved in the variation.\n",
+              "isDeprecated": false,
+              "name": "second_exon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "molecular_test_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the method used for molecular analysis.\n",
+              "isDeprecated": false,
+              "name": "molecular_analysis_method",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the molecular consequence of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "molecular_consequence",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text term used to describe the type of genetic variation.\n",
+              "isDeprecated": false,
+              "name": "variant_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci determined to be abnormal.\n",
+              "isDeprecated": false,
+              "name": "loci_abnormal_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.\n",
+              "isDeprecated": false,
+              "name": "aa_change",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Numeric value used to describe the number of loci tested.\n",
+              "isDeprecated": false,
+              "name": "loci_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "MolecularTest",
           "possibleTypes": null
         },
         {
@@ -19010,1448 +20452,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "TissueSourceSite",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "offset",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "sort",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "Sort",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "filters",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "FiltersArgument",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "before",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "after",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "first",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "last",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hits",
-              "type": {
-                "kind": "OBJECT",
-                "name": "FollowUpConnection",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FollowUps",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "pageInfo",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "total",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
-              "name": "edges",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "FollowUpEdge",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FollowUpConnection",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
-              "name": "cursor",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
-              "name": "node",
-              "type": {
-                "kind": "OBJECT",
-                "name": "FollowUp",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "FollowUpEdge",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "molecular_tests",
-              "type": {
-                "kind": "OBJECT",
-                "name": "MolecularTests",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "annotations",
-              "type": {
-                "kind": "OBJECT",
-                "name": "CaseAnnotations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
-              "isDeprecated": false,
-              "name": "fev1_ref_post_bronch_percent",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The weight of the patient measured in kilograms.\n",
-              "isDeprecated": false,
-              "name": "weight",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe the types of treatment used to manage gastroesophageal reflux disease (GERD).\n",
-              "isDeprecated": false,
-              "name": "reflux_treatment_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the type of progressive or recurrent disease or relapsed disease.\n",
-              "isDeprecated": false,
-              "name": "progression_or_recurrence_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The height of the patient in centimeters.\n",
-              "isDeprecated": false,
-              "name": "height",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date of the patient's adverse event.\n",
-              "isDeprecated": false,
-              "name": "days_to_adverse_event",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the suspected cause or reason for the patient disease response.\n",
-              "isDeprecated": false,
-              "name": "cause_of_response",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
-              "isDeprecated": false,
-              "name": "fev1_fvc_pre_bronch_percent",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The ECOG functional performance status of the patient/participant.\n",
-              "isDeprecated": false,
-              "name": "ecog_performance_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
-              "isDeprecated": false,
-              "name": "hpv_positive_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date the patient's disease was formally confirmed as progression-free.\n",
-              "isDeprecated": false,
-              "name": "days_to_progression_free",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date of the patient's last follow-up appointment or contact.\n",
-              "isDeprecated": false,
-              "name": "days_to_follow_up",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
-              "isDeprecated": false,
-              "name": "fev1_fvc_post_bronch_percent",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the method used to diagnose the patient's comorbidity disease.\n",
-              "isDeprecated": false,
-              "name": "comorbidity_method_of_diagnosis",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
-              "isDeprecated": false,
-              "name": "dlco_ref_predictive_percent",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a comorbidity disease, which coexists with the patient's malignant disease.\n",
-              "isDeprecated": false,
-              "name": "comorbidity",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "updated_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a risk factor the patient had at the time of or prior to their diagnosis.\n",
-              "isDeprecated": false,
-              "name": "risk_factor",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "state",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date the patient's disease progressed.\n",
-              "isDeprecated": false,
-              "name": "days_to_progression",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.\n",
-              "isDeprecated": false,
-              "name": "adverse_event",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date the patient's disease recurred.\n",
-              "isDeprecated": false,
-              "name": "days_to_recurrence",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A calculated numerical quantity that represents an individual's weight to height ratio.\n",
-              "isDeprecated": false,
-              "name": "bmi",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe the patient's menopause status.\n",
-              "isDeprecated": false,
-              "name": "menopause_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
-              "isDeprecated": false,
-              "name": "progression_or_recurrence",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe the types of treatment used to manage diabetes.\n",
-              "isDeprecated": false,
-              "name": "diabetes_treatment_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
-              "isDeprecated": false,
-              "name": "risk_factor_treatment",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the anatomic site of the progressive or recurrent disease.\n",
-              "isDeprecated": false,
-              "name": "progression_or_recurrence_anatomic_site",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "submitter_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The yes/no/unknown indicator used to describe whether goblet cells were determined to be present in a patient diagnosed with Barrett's esophagus.\n",
-              "isDeprecated": false,
-              "name": "barretts_esophagus_goblet_cells_present",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Code assigned to describe the patient's response or outcome to the disease.\n",
-              "isDeprecated": false,
-              "name": "disease_response",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "follow_up_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value to represent the year that the patient was diagnosed with clinical chronic pancreatitis.\n",
-              "isDeprecated": false,
-              "name": "pancreatitis_onset_year",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term that describes the kind of serological laboratory test used to determine the patient's hepatitus status.\n",
-              "isDeprecated": false,
-              "name": "viral_hepatitis_serologies",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
-              "isDeprecated": false,
-              "name": "fev1_ref_pre_bronch_percent",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "created_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe the classification used of the functional capabilities of a person.\n",
-              "isDeprecated": false,
-              "name": "karnofsky_performance_status",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The yes/no/unknown indicator used to describe whether the patient received treatment for a risk factor the patient had at the time of or prior to their diagnosis.\n",
-              "isDeprecated": false,
-              "name": "hepatitis_sustained_virological_response",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
-              "isDeprecated": false,
-              "name": "days_to_comorbidity",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "score",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "kind": "OBJECT",
-          "name": "FollowUp",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "offset",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "sort",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "Sort",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "filters",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "FiltersArgument",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "before",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "after",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "first",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "last",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hits",
-              "type": {
-                "kind": "OBJECT",
-                "name": "MolecularTestConnection",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "MolecularTests",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "pageInfo",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "total",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination.",
-              "isDeprecated": false,
-              "name": "edges",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MolecularTestEdge",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "MolecularTestConnection",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A cursor for use in pagination",
-              "isDeprecated": false,
-              "name": "cursor",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The item at the end of the edge",
-              "isDeprecated": false,
-              "name": "node",
-              "type": {
-                "kind": "OBJECT",
-                "name": "MolecularTest",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "MolecularTestEdge",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "annotations",
-              "type": {
-                "kind": "OBJECT",
-                "name": "CaseAnnotations",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The yes/no/unknown indicator used to describe whether the mutation included in molecular testing was known to have an affect on the mismatch repair process.\n",
-              "isDeprecated": false,
-              "name": "mismatch_repair_mutation",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "updated_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe an antigen included in molecular testing.\n",
-              "isDeprecated": false,
-              "name": "antigen",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the biological origin of a specific genetic variant.\n",
-              "isDeprecated": false,
-              "name": "variant_origin",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the lower limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
-              "isDeprecated": false,
-              "name": "blood_test_normal_range_lower",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Alphanumeric value used to describe the locus of a specific genetic variant. Example: NM_001126114.\n",
-              "isDeprecated": false,
-              "name": "locus",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term or numeric value used to describe a sepcific result of a molecular test.\n",
-              "isDeprecated": false,
-              "name": "test_value",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a secondary gene targeted or included in molecular analysis. For rearrangements, this is should represent the location of the variant.\n",
-              "isDeprecated": false,
-              "name": "second_gene_symbol",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe the number of sets of homologous chromosomes.\n",
-              "isDeprecated": false,
-              "name": "ploidy",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a chromosome targeted or included in molecular testing. If a specific genetic variant is being reported, this property can be used to capture the chromosome where that variant is located.\n",
-              "isDeprecated": false,
-              "name": "chromosome",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Text term used to describe a specific test that is not covered in the list of molecular analysis methods.\n",
-              "isDeprecated": false,
-              "name": "specialized_molecular_test",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n",
-              "isDeprecated": false,
-              "name": "created_datetime",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Intron number targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the intron where that variant is located.\n",
-              "isDeprecated": false,
-              "name": "intron",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a gene targeted or included in molecular analysis. For rearrangements, this is shold be used to represent the reference gene.\n",
-              "isDeprecated": false,
-              "name": "gene_symbol",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The current state of the object.\n",
-              "isDeprecated": false,
-              "name": "state",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe a specific histone variants, which are proteins that substitute for the core canonical histones.\n",
-              "isDeprecated": false,
-              "name": "histone_variant",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the number of cells used for molecular testing.\n",
-              "isDeprecated": false,
-              "name": "cell_count",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the family, or classification of a group of basic proteins found in chromatin, called histones.\n",
-              "isDeprecated": false,
-              "name": "histone_family",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the number of times a section of the genome is repeated or copied within an insertion, duplication or deletion variant.\n",
-              "isDeprecated": false,
-              "name": "copy_number",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the type of analyte used for molecular testing.\n",
-              "isDeprecated": false,
-              "name": "test_analyte_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Exon number targeted or included in a molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the exon where that variant is located.\n",
-              "isDeprecated": false,
-              "name": "exon",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the medical testing used to diagnose, treat or further understand a patient's disease.\n",
-              "isDeprecated": false,
-              "name": "laboratory_test",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the result of the molecular test. If the test result was a numeric value see test_value.\n",
-              "isDeprecated": false,
-              "name": "test_result",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Alphanumeric value used to describe the transcript of a specific genetic variant.\n",
-              "isDeprecated": false,
-              "name": "transcript",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the upper limit of the normal range used to describe a healthy individual at the institution where the test was completed.\n",
-              "isDeprecated": false,
-              "name": "blood_test_normal_range_upper",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the units of the test value for a molecular test. This property is used in conjunction with test_value.\n",
-              "isDeprecated": false,
-              "name": "test_units",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the zygosity of a specific genetic variant.\n",
-              "isDeprecated": false,
-              "name": "zygosity",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Alphanumeric value used to describe the cytoband or chromosomal location targeted or included in molecular analysis. If a specific genetic variant is being reported, this property can be used to capture the cytoband where the variant is located. Format: [chromosome][chromosome arm].[band+sub-bands]. Example: 17p13.1.\n",
-              "isDeprecated": false,
-              "name": "cytoband",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the biological material used for testing, diagnostic, treatment or research purposes.",
-              "isDeprecated": false,
-              "name": "biospecimen_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-              "isDeprecated": false,
-              "name": "submitter_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The second exon number involved in molecular variation. If a specific genetic variant is being reported, this property can be used to capture the second exon where that variant is located. This property is typically used for a translocation where two different locations are involved in the variation.\n",
-              "isDeprecated": false,
-              "name": "second_exon",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
-              "name": "molecular_test_id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the method used for molecular analysis.\n",
-              "isDeprecated": false,
-              "name": "molecular_analysis_method",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the molecular consequence of genetic variation.\n",
-              "isDeprecated": false,
-              "name": "molecular_consequence",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The text term used to describe the type of genetic variation.\n",
-              "isDeprecated": false,
-              "name": "variant_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the number of loci determined to be abnormal.\n",
-              "isDeprecated": false,
-              "name": "loci_abnormal_count",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Alphanumeric value used to describe the amino acid change for a specific genetic variant. Example: R116Q.\n",
-              "isDeprecated": false,
-              "name": "aa_change",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Numeric value used to describe the number of loci tested.\n",
-              "isDeprecated": false,
-              "name": "loci_count",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "score",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "kind": "OBJECT",
-          "name": "MolecularTest",
           "possibleTypes": null
         },
         {
@@ -38847,6 +38847,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "gene__ssm__clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "gene__ssm__clinical_annotations__civic__variant_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "gene__ssm__observation__src_vcf_id",
               "type": {
                 "kind": "OBJECT",
@@ -44767,6 +44791,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "case__ssm__clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "case__ssm__clinical_annotations__civic__variant_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "case__ssm__observation__src_vcf_id",
               "type": {
                 "kind": "OBJECT",
@@ -48552,7 +48600,19 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "mutation_type",
+              "name": "clinical_annotations__civic__gene_id",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clinical_annotations__civic__variant_id",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -50580,6 +50640,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "gene_aa_change",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Aggregations",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "mutation_subtype",
               "type": {
                 "kind": "OBJECT",
@@ -51288,7 +51360,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "gene_aa_change",
+              "name": "mutation_type",
               "type": {
                 "kind": "OBJECT",
                 "name": "Aggregations",
@@ -51461,18 +51533,6 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "mutation_type",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "keyword",
-              "isDeprecated": false,
               "name": "mutation_subtype",
               "type": {
                 "kind": "SCALAR",
@@ -51557,6 +51617,18 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
+              "name": "mutation_type",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
               "name": "chromosome",
               "type": {
                 "kind": "SCALAR",
@@ -51581,10 +51653,10 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "external_db_ids",
+              "name": "clinical_annotations",
               "type": {
                 "kind": "OBJECT",
-                "name": "SsmGeneExternalDbIds",
+                "name": "ClinicalAnnotations",
                 "ofType": null
               }
             },
@@ -51597,18 +51669,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "SSMConsequences",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "occurrence",
-              "type": {
-                "kind": "OBJECT",
-                "name": "SSMOccurrences",
                 "ofType": null
               }
             },
@@ -51633,6 +51693,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "external_db_ids",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SsmGeneExternalDbIds",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "gene_aa_change",
               "type": {
                 "kind": "LIST",
@@ -51642,6 +51714,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "occurrence",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SSMOccurrences",
+                "ofType": null
               }
             },
             {
@@ -51678,15 +51762,11 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "entrez_ssm",
+              "name": "civic",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "CivicAnnotation",
+                "ofType": null
               }
             },
             {
@@ -51694,55 +51774,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "hgnc",
+              "name": "id",
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "omim_ssm",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "uniprotkb_swissprot",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ClinicalAnnotations",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
             {
               "args": [],
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "entrez_gene",
+              "name": "gene_id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -51754,7 +51809,7 @@
               "deprecationReason": null,
               "description": "keyword",
               "isDeprecated": false,
-              "name": "omim_gene",
+              "name": "variant_id",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -51777,7 +51832,7 @@
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "SsmGeneExternalDbIds",
+          "name": "CivicAnnotation",
           "possibleTypes": null
         },
         {
@@ -52700,6 +52755,117 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "SsmGene",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "entrez_ssm",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hgnc",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "omim_ssm",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "uniprotkb_swissprot",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "entrez_gene",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "keyword",
+              "isDeprecated": false,
+              "name": "omim_gene",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SsmGeneExternalDbIds",
           "possibleTypes": null
         },
         {

--- a/src/packages/@ncigdc/components/EntityPageHorizontalTable.js
+++ b/src/packages/@ncigdc/components/EntityPageHorizontalTable.js
@@ -101,7 +101,7 @@ const EntityPageHorizontalTable = ({
                             />
                         )}
 
-                        {v}
+                        {v || '--'}
                       </Td>
                     )))}
                   </Tr>

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -78,7 +78,6 @@ export default compose(
       project: { project_id: projectId = {} },
     } = edges[0].node;
     const familyHistory = familyHistories.map(history => history.node);
-    console.log('followUps: ', followUps);
 
     const caseFilter = makeFilter([
       {
@@ -86,6 +85,7 @@ export default compose(
         value: [caseId],
       },
     ]);
+
     return (
       <Card
         className="test-clinical-card"
@@ -124,9 +124,7 @@ export default compose(
           ]}
           tabStyle={{
             padding: '1rem 1.2rem',
-            // width: 150,
             whiteSpace: 'nowrap',
-            // textOverflow: 'ellipsis',
           }}
           >
           {activeTab === 0 && (
@@ -268,32 +266,32 @@ export default compose(
                         !!x.treatments.hits.edges.length && (
                           <EntityPageHorizontalTable
                             data={x.treatments.hits.edges.map(({ node }) => ({
-                              treatment_id: node.treatment_id || '--',
-                              therapeutic_agents: node.therapeutic_agents || '--',
-                              treatment_intent_type: node.treatment_intent_type || '--',
-                              treatment_or_therapy: node.treatment_or_therapy || '--',
-                              days_to_treatment_start: node.days_to_treatment_start || '--',
+                              daysToTreatmentStart: node.days_to_treatment_start,
+                              therapeuticAgents: node.therapeutic_agents,
+                              treatmentId: node.treatment_id,
+                              treatmentIntentType: node.treatment_intent_type,
+                              treatmentOrTherapy: node.treatment_or_therapy,
                             }))
                             }
                             headings={[
                               {
-                                key: 'treatment_id',
+                                key: 'treatmentId',
                                 title: 'UUID',
                               },
                               {
-                                key: 'therapeutic_agents',
+                                key: 'therapeuticAgents',
                                 title: 'Therapeutic Agents',
                               },
                               {
-                                key: 'treatment_intent_type',
+                                key: 'treatmentIntentType',
                                 title: 'Treatment Intent Type',
                               },
                               {
-                                key: 'treatment_or_therapy',
+                                key: 'treatmentOrTherapy',
                                 title: 'Treatment or Therapy',
                               },
                               {
-                                key: 'days_to_treatment_start',
+                                key: 'daysToTreatmentStart',
                                 style: { textAlign: 'right' },
                                 title: 'Days to Treatment Start',
                               },
@@ -529,13 +527,7 @@ export default compose(
                             laboratoryTest: node.laboratory_test,
                             molecularAnalysisMethod: node.molecular_analysis_method,
                             molecularTestId: node.molecular_test_id,
-                            testValue: `${node.test_value} ${node.test_units}`,
-                            // aa_change: node.aa_change || '--',
-                            // antigen: node.antigen,
-                            // mismatch_repair_mutation: node.mismatch_repair_mutation,
-                            // second_gene_symbol: node.second_gene_symbol,
-                            // variant_type: node.variant_type,
-                            // chromosome: node.chromosome,
+                            testValue: node.test_value && node.test_units ? `${node.test_value} ${node.test_units}` : node.test_value,
                           }))}
                           headings={[
                             {
@@ -566,30 +558,6 @@ export default compose(
                               key: 'testValue',
                               title: 'Test Value',
                             },
-                            // {
-                            //   title: 'AA Change',
-                            //   key: 'aa_change',
-                            // },
-                            // {
-                            //   title: 'Antigen',
-                            //   key: 'antigen',
-                            // },
-                            // {
-                            //   title: 'Mismatch Repair Mutation',
-                            //   key: 'mismatch_repair_mutation',
-                            // },
-                            // {
-                            //   title: 'Second Gene Symbol',
-                            //   key: 'second_gene_symbol',
-                            // },
-                            // {
-                            //   title: 'Variant Type',
-                            //   key: 'variant_type',
-                            // },
-                            // {
-                            //   title: 'Chromosome',
-                            //   key: 'chromosome',
-                            // },
                           ]}
                           />
                     )}
@@ -617,68 +585,6 @@ export default compose(
             )}
           </div>
           )}
-          {/* <EntityPageHorizontalTable
-                  data={}
-                  key={mTest.molecular_test_id}
-                  thToTd={[
-                    {
-                      th: 'UUID',
-                      td: mTest.molecular_test_id,
-                    },
-                    {
-                      th: 'Gene Symbol',
-                      td: mTest.gene_symbol,
-                    },
-                    {
-                      th: 'Molecular Analysis Method',
-                      td: mTest.molecular_analysis_method,
-                    },
-                    {
-                      th: 'Test Result',
-                      td: mTest.test_result,
-                    },
-                    {
-                      th: 'AA Change',
-                      td: mTest.aa_change,
-                    },
-                    {
-                      th: 'Antigen',
-                      td: mTest.antigen,
-                    },
-                    {
-                      th: 'Mismatch Repair Mutation',
-                      td: mTest.mismatch_repair_mutation,
-                    },
-                    {
-                      th: 'Second Gene Symbol',
-                      td: mTest.second_gene_symbol,
-                    },
-                    {
-                      th: 'Test Value',
-                      td: mTest.test_value,
-                    },
-                    {
-                      th: 'Variant Type',
-                      td: mTest.variant_type,
-                    },
-                    {
-                      th: 'Chromosome',
-                      td: mTest.chromosome,
-                    },
-                    {
-                      th: 'Laboratory Test',
-                      td: mTest.laboratory_test,
-                    },
-                    {
-                      th: 'Biospecimen Type',
-                      td: mTest.biospecimen_type,
-                    },
-                    {
-                      th: 'Test Units',
-                      td: mTest.test_units,
-                    },
-                  ]}
-              /> */}
 
         </Tabs>
         {clinicalFiles.length > 0 && (

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -77,15 +77,6 @@ export default compose(
     } = edges[0].node;
     const familyHistory = familyHistories.map(history => history.node);
     console.log('followUps: ', followUps);
-    const molecularTests = followUps.reduce((acc, f) => {
-      const mTests = (f.node.molecular_tests.hits.edges || []).map(mTest => {
-        return ({
-          followUpId: f.node.follow_up_id,
-          ...mTest.node,
-        });
-      });
-      return [...acc, ...mTests];
-    }, []);
 
     const caseFilter = makeFilter([
       {
@@ -127,9 +118,6 @@ export default compose(
             </p>,
             <p key="FollowUps" style={styles.tabTitle}>
               {`Follow-Ups (${followUps.length})`}
-            </p>,
-            <p key="MolecularTests" style={styles.tabTitle}>
-              {`Molecular Tests (${molecularTests.length})`}
             </p>,
           ]}
           tabStyle={{
@@ -445,70 +433,176 @@ export default compose(
           <div>
             {followUps.length && (
             <SideTabs
-                containerStyle={{ display: 'block' }}
+                containerStyle={{
+                  display: 'block',
+                }}
                 contentStyle={{ border: 'none' }}
+                tabContainerStyle={{
+                  maxHeight: 900,
+                  minWidth: 100,
+                }}
                 tabContent={followUps.map(followUp => (
-                  <EntityPageVerticalTable
-                    key={followUp.node.follow_up_id}
-                    thToTd={[
-                      {
-                        td: followUp.node.follow_up_id,
-                        th: 'UUID',
-                      },
-                      {
-                        td: followUp.node.days_to_follow_up,
-                        th: 'Days to Follow Up',
-                      },
-                      {
-                        td: followUp.node.comorbidity,
-                        th: 'Comorbidity',
-                      },
-                      {
-                        td: followUp.node.risk_factor,
-                        th: 'Risk Factor',
-                      },
-                      {
-                        td: followUp.node.progression_or_recurrence_type,
-                        th: 'Progression or Recurrence Type',
-                      },
-                      {
-                        td: followUp.node.progression_or_recurrence,
-                        th: 'Progression or Recurrence',
-                      },
-                      {
-                        td: followUp.node.disease_response,
-                        th: 'Disease Response',
-                      },
-                      {
-                        td: followUp.node.bmi,
-                        th: 'BMI',
-                      },
-                      {
-                        td: followUp.node.height,
-                        th: 'Height',
-                      },
-                      {
-                        td: followUp.node.weight,
-                        th: 'Weight',
-                      },
-                      {
-                        td: followUp.node.ecog_performance_status,
-                        th: 'Ecog Performance Status',
-                      },
-                      {
-                        td: followUp.node.karnofsky_performance_status,
-                        th: 'Karnofsky Performance Status',
-                      },
-                      {
-                        td: followUp.node.progression_or_recurrence_anatomic_site,
-                        th: 'Progression Or Recurrence Anatomic Site',
-                      },
-                      {
-                        td: followUp.node.reflux_treatment_type,
-                        th: 'Reflux Treatment Type',
-                      },
-                    ]}
-                    />
+                  <React.Fragment key={followUp.node.follow_up_id}>
+                    <EntityPageVerticalTable
+                      thToTd={[
+                        {
+                          td: followUp.node.follow_up_id,
+                          th: 'UUID',
+                        },
+                        {
+                          td: followUp.node.days_to_follow_up,
+                          th: 'Days to Follow Up',
+                        },
+                        {
+                          td: followUp.node.comorbidity,
+                          th: 'Comorbidity',
+                        },
+                        {
+                          td: followUp.node.risk_factor,
+                          th: 'Risk Factor',
+                        },
+                        {
+                          td: followUp.node.progression_or_recurrence_type,
+                          th: 'Progression or Recurrence Type',
+                        },
+                        {
+                          td: followUp.node.progression_or_recurrence,
+                          th: 'Progression or Recurrence',
+                        },
+                        {
+                          td: followUp.node.disease_response,
+                          th: 'Disease Response',
+                        },
+                        {
+                          td: followUp.node.bmi,
+                          th: 'BMI',
+                        },
+                        {
+                          td: followUp.node.height,
+                          th: 'Height',
+                        },
+                        {
+                          td: followUp.node.weight,
+                          th: 'Weight',
+                        },
+                        {
+                          td: followUp.node.ecog_performance_status,
+                          th: 'Ecog Performance Status',
+                        },
+                        {
+                          td: followUp.node.karnofsky_performance_status,
+                          th: 'Karnofsky Performance Status',
+                        },
+                        {
+                          td: followUp.node.progression_or_recurrence_anatomic_site,
+                          th: 'Progression Or Recurrence Anatomic Site',
+                        },
+                        {
+                          td: followUp.node.reflux_treatment_type,
+                          th: 'Reflux Treatment Type',
+                        },
+                      ]}
+                      />
+                    <div
+                      style={{
+                        color: theme.greyScale7,
+                        fontSize: '2rem',
+                        lineHeight: '1.4em',
+                        padding: '1rem',
+                      }}
+                      >
+                      Molecular Tests (
+                      {followUp.node.molecular_tests
+                        ? followUp.node.molecular_tests.hits.edges.length
+                        : 0
+                      }
+                      )
+                    </div>
+                    {followUp.node.molecular_tests &&
+                      followUp.node.molecular_tests.hits.edges.length > 0 && (
+                        <EntityPageHorizontalTable
+                          data={followUp.node.molecular_tests.hits.edges.map(({ node }) => ({
+                            molecular_test_id: truncate(node.molecular_test_id, { length: 11 }) || '--',
+                            gene_symbol: node.gene_symbol || '--',
+                            molecular_analysis_method: node.molecular_analysis_method || '--',
+                            test_result: node.test_result || '--',
+                            aa_change: node.aa_change || '--',
+                            antigen: node.antigen,
+                            mismatch_repair_mutation: node.mismatch_repair_mutation,
+                            second_gene_symbol: node.second_gene_symbol,
+                            test_value: node.test_value,
+                            variant_type: node.variant_type,
+                            chromosome: node.chromosome,
+                            laboratory_test: node.laboratory_test,
+                            biospecimen_type: node.biospecimen_type,
+                            test_units: node.test_units,
+                          }))}
+                          headings={[
+                            {
+                              title: 'UUID',
+                              key: 'molecular_test_id',
+                            },
+                            {
+                              title: 'Gene Symbol',
+                              key: 'gene_symbol',
+                            },
+                            {
+                              title: 'Molecular Analysis Method',
+                              key: 'molecular_analysis_method',
+                            },
+                            {
+                              title: 'Test Result',
+                              key: 'test_result',
+                            },
+                            {
+                              title: 'AA Change',
+                              key: 'aa_change',
+                            },
+                            {
+                              title: 'Antigen',
+                              key: 'antigen',
+                            },
+                            {
+                              title: 'Mismatch Repair Mutation',
+                              key: 'mismatch_repair_mutation',
+                            },
+                            {
+                              title: 'Second Gene Symbol',
+                              key: 'second_gene_symbol',
+                            },
+                            {
+                              title: 'Test Value',
+                              key: 'test_value',
+                            },
+                            {
+                              title: 'Variant Type',
+                              key: 'variant_type',
+                            },
+                            {
+                              title: 'Chromosome',
+                              key: 'chromosome',
+                            },
+                            {
+                              title: 'Laboratory Test',
+                              key: 'laboratory_test',
+                            },
+                            {
+                              title: 'Biospecimen Type',
+                              key: 'biospecimen_type',
+                            },
+                            {
+                              title: 'Test Units',
+                              key: 'test_units',
+                            },
+                          ]}
+                          />
+                    )}
+                    {!(followUp.node.molecular_tests && followUp.node.molecular_tests.hits.edges.length) && (
+                    <div style={{ paddingLeft: '2rem' }}>
+                      No Molecular Tests Found.
+                    </div>
+                    )}
+                  </React.Fragment>
                 ))}
                 tabs={
                   followUps.length > 1
@@ -526,14 +620,8 @@ export default compose(
             )}
           </div>
           )}
-          {activeTab === 5 && (
-          <div>
-            {molecularTests.length && (
-            <SideTabs
-              containerStyle={{ display: 'block' }}
-              contentStyle={{ border: 'none' }}
-              tabContent={molecularTests.map(mTest => (
-                <EntityPageVerticalTable
+          {/* <EntityPageHorizontalTable
+                  data={}
                   key={mTest.molecular_test_id}
                   thToTd={[
                     {
@@ -593,24 +681,8 @@ export default compose(
                       td: mTest.test_units,
                     },
                   ]}
-                  />
-              ))}
-              tabs={
-                molecularTests.length > 1
-                  ? molecularTests.map(mTest => (
-                    <p key={mTest.molecular_test_id}>
-                      {truncate(mTest.molecular_test_id, { length: 11 })}
-                    </p>
-                  ))
-                  : []
-              }
-              />
-            )}
-            {!molecularTests && (
-            <h3 style={{ paddingLeft: '2rem' }}>No Molecular Tests Found.</h3>
-            )}
-          </div>
-          )}
+              /> */}
+
         </Tabs>
         {clinicalFiles.length > 0 && (
           <div

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -79,9 +79,12 @@ export default compose(
       files: { hits: { edges: clinicalFiles = [] } },
       project: { project_id: projectId = {} },
     } = edges[0].node;
-    const familyHistory = familyHistories.map(x => x.node);
-    const { molecular_tests: { hits: { edges: molecularTests = [] } } } = followUps[0].node;
-
+    const familyHistory = familyHistories.map(history => history.node);
+    const molecularTests = followUps.map(followUp => ({
+      followUpId: followUp.node.follow_up_id,
+      mTest: followUp.node.molecular_tests.hits.edges,
+    }));
+    console.log(molecularTests);
     const caseFilter = makeFilter([
       {
         field: 'cases.case_id',
@@ -112,29 +115,19 @@ export default compose(
           tabs={[
             <p key="Demographic">Demographic</p>,
             <p key="Diagnoses / Treatment">
-              Diagnoses / Treatments (
-              {diagnoses.length}
-)
+              {`Diagnoses / Treatments (${diagnoses.length})`}
             </p>,
             <p key="Family Histories">
-              Family Histories (
-              {familyHistory.length}
-)
+              {`Family Histories (${familyHistory.length})`}
             </p>,
             <p key="Exposures">
-Exposures (
-              {totalExposures}
-)
+              {`Exposures (${totalExposures})`}
             </p>,
             <p key="FollowUps">
-Follow-Ups (
-              {followUps.length}
-)
+              {`Follow-Ups (${followUps.length})`}
             </p>,
             <p key="MolecularTests">
-Molecular Tests (
-              {molecularTests.length}
-)
+              {`Molecular Tests (${molecularTests.length})`}
             </p>,
           ]}
           >

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -146,32 +146,32 @@ export default compose(
                   style={{ flex: '1 1 auto' }}
                   thToTd={[
                     {
-                      th: 'UUID',
                       td: demographic.demographic_id,
+                      th: 'UUID',
                     },
                     {
-                      th: 'Ethnicity',
                       td: demographic.ethnicity,
+                      th: 'Ethnicity',
                     },
                     {
-                      th: 'Gender',
                       td: demographic.gender,
+                      th: 'Gender',
                     },
                     {
-                      th: 'Race',
                       td: demographic.race,
+                      th: 'Race',
                     },
                     {
-                      th: 'Days to Birth',
                       td: demographic.days_to_birth,
+                      th: 'Days to Birth',
                     },
                     {
-                      th: 'Days to Death',
                       td: demographic.days_to_death,
+                      th: 'Days to Death',
                     },
                     {
-                      th: 'Vital Status',
                       td: demographic.vital_status,
+                      th: 'Vital Status',
                     },
                   ]}
                   />
@@ -193,82 +193,81 @@ export default compose(
                         style={{ flex: 1 }}
                         thToTd={[
                           {
-                            th: 'UUID',
                             td: x.diagnosis_id,
+                            th: 'UUID',
                           },
                           {
-                            th: 'Classification of Tumor',
                             td: x.classification_of_tumor,
+                            th: 'Classification of Tumor',
                           },
                           {
-                            th: 'Alcohol Intensity',
                             td: x.alcohol_intensity,
+                            th: 'Alcohol Intensity',
                           },
                           {
-                            th: 'Age at Diagnosis',
                             td: ageDisplay(x.age_at_diagnosis),
+                            th: 'Age at Diagnosis',
                           },
-
                           {
-                            th: 'Days to Last Follow Up',
                             td: x.days_to_last_follow_up,
+                            th: 'Days to Last Follow Up',
                           },
                           {
-                            th: 'Days to Last Known Disease Status',
                             td: x.days_to_last_known_disease_status,
+                            th: 'Days to Last Known Disease Status',
                           },
                           {
-                            th: 'Days to Recurrence',
                             td: x.days_to_recurrence,
+                            th: 'Days to Recurrence',
                           },
                           {
-                            th: 'Last Known Disease Status',
                             td: x.last_known_disease_status,
+                            th: 'Last Known Disease Status',
                           },
                           {
-                            th: 'Morphology',
                             td: x.morphology,
+                            th: 'Morphology',
                           },
                           {
-                            th: 'Primary Diagnosis',
                             td: x.primary_diagnosis,
+                            th: 'Primary Diagnosis',
                           },
                           {
-                            th: 'Prior Malignancy',
                             td: x.prior_malignancy,
+                            th: 'Prior Malignancy',
                           },
                           {
-                            th: 'Synchronous Malignancy',
                             td: x.synchronous_malignancy,
+                            th: 'Synchronous Malignancy',
                           },
                           {
-                            th: 'Progression or Recurrence',
                             td: x.progression_or_recurrence,
+                            th: 'Progression or Recurrence',
                           },
                           {
-                            th: 'Site of Resection of Biopsy',
                             td: x.site_of_resection_or_biopsy,
+                            th: 'Site of Resection of Biopsy',
                           },
                           {
-                            th: 'Tissue or Organ of Origin',
                             td: x.tissue_or_organ_of_origin,
+                            th: 'Tissue or Organ of Origin',
                           },
                           {
-                            th: 'Tumor Grade',
                             td: x.tumor_grade,
+                            th: 'Tumor Grade',
                           },
                           {
-                            th: 'Tumor Stage',
                             td: x.tumor_stage,
+                            th: 'Tumor Stage',
                           },
                         ]}
                         />
                       <div
                         style={{
-                          padding: '1rem',
                           color: theme.greyScale7,
                           fontSize: '2rem',
                           lineHeight: '1.4em',
+                          padding: '1rem',
                         }}
                         >
                         Treatments (
@@ -345,28 +344,28 @@ export default compose(
                       key={x.family_history_id}
                       thToTd={[
                         {
-                          th: 'UUID',
                           td: x.family_history_id,
+                          th: 'UUID',
                         },
                         {
-                          th: 'Relationship Age at Diagnosis',
                           td: x.relationship_age_at_diagnosis,
+                          th: 'Relationship Age at Diagnosis',
                         },
                         {
-                          th: 'Relationship Gender',
                           td: x.relationship_gender,
+                          th: 'Relationship Gender',
                         },
                         {
-                          th: 'Relationship Primary Diagnosis',
                           td: x.relationship_primary_diagnosis,
+                          th: 'Relationship Primary Diagnosis',
                         },
                         {
-                          th: 'Relationship Type',
                           td: x.relationship_type,
+                          th: 'Relationship Type',
                         },
                         {
-                          th: 'Relative with Cancer History',
                           td: x.relative_with_cancer_history,
+                          th: 'Relative with Cancer History',
                         },
                       ]}
                       />
@@ -400,28 +399,28 @@ export default compose(
                       key={x.node.exposure_id}
                       thToTd={[
                         {
-                          th: 'UUID',
                           td: x.node.exposure_id,
+                          th: 'UUID',
                         },
                         {
-                          th: 'Alcohol History',
                           td: x.node.alcohol_history,
+                          th: 'Alcohol History',
                         },
                         {
-                          th: 'Height',
                           td: x.node.height,
+                          th: 'Height',
                         },
                         {
-                          th: 'Weight',
                           td: x.node.weight,
+                          th: 'Weight',
                         },
                         {
-                          th: 'Years Smoked',
                           td: x.node.years_smoked,
+                          th: 'Years Smoked',
                         },
                         {
-                          th: 'Pack Years Smoked',
                           td: x.node.pack_years_smoked,
+                          th: 'Pack Years Smoked',
                         },
                       ]}
                       />
@@ -453,60 +452,60 @@ export default compose(
                     key={followUp.node.follow_up_id}
                     thToTd={[
                       {
-                        th: 'UUID',
                         td: followUp.node.follow_up_id,
+                        th: 'UUID',
                       },
                       {
-                        th: 'Days to Follow Up',
                         td: followUp.node.days_to_follow_up,
+                        th: 'Days to Follow Up',
                       },
                       {
-                        th: 'Comorbidity',
                         td: followUp.node.comorbidity,
+                        th: 'Comorbidity',
                       },
                       {
-                        th: 'Risk Factor',
                         td: followUp.node.risk_factor,
+                        th: 'Risk Factor',
                       },
                       {
-                        th: 'Progression or Recurrence Type',
                         td: followUp.node.progression_or_recurrence_type,
+                        th: 'Progression or Recurrence Type',
                       },
                       {
-                        th: 'Progression or Recurrence',
                         td: followUp.node.progression_or_recurrence,
+                        th: 'Progression or Recurrence',
                       },
                       {
-                        th: 'Disease Response',
                         td: followUp.node.disease_response,
+                        th: 'Disease Response',
                       },
                       {
-                        th: 'BMI',
                         td: followUp.node.bmi,
+                        th: 'BMI',
                       },
                       {
-                        th: 'Height',
                         td: followUp.node.height,
+                        th: 'Height',
                       },
                       {
-                        th: 'Weight',
                         td: followUp.node.weight,
+                        th: 'Weight',
                       },
                       {
-                        th: 'Ecog Performance Status',
                         td: followUp.node.ecog_performance_status,
+                        th: 'Ecog Performance Status',
                       },
                       {
-                        th: 'Karnofsky Performance Status',
                         td: followUp.node.karnofsky_performance_status,
+                        th: 'Karnofsky Performance Status',
                       },
                       {
-                        th: 'Progression Or Recurrence Anatomic Site',
                         td: followUp.node.progression_or_recurrence_anatomic_site,
+                        th: 'Progression Or Recurrence Anatomic Site',
                       },
                       {
-                        th: 'Reflux Treatment Type',
                         td: followUp.node.reflux_treatment_type,
+                        th: 'Reflux Treatment Type',
                       },
                     ]}
                     />

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -58,13 +58,8 @@ export default compose(
   withTheme,
 )(
   ({
-    active,
     activeTab,
-    dropdownStyle,
-    requests,
-    setState,
     setTab,
-    state,
     theme,
     viewer: { repository: { cases: { hits: { edges } } } },
   }) => {
@@ -80,11 +75,17 @@ export default compose(
       project: { project_id: projectId = {} },
     } = edges[0].node;
     const familyHistory = familyHistories.map(history => history.node);
-    const molecularTests = followUps.map(followUp => ({
-      followUpId: followUp.node.follow_up_id,
-      mTest: followUp.node.molecular_tests.hits.edges,
-    }));
-    console.log(molecularTests);
+    console.log('followUps: ', followUps);
+    const molecularTests = followUps.reduce((acc, f) => {
+      const mTests = (f.node.molecular_tests.hits.edges || []).map(mTest => {
+        return ({
+          followUpId: f.node.follow_up_id,
+          ...mTest.node,
+        });
+      });
+      return [...acc, ...mTests];
+    }, []);
+
     const caseFilter = makeFilter([
       {
         field: 'cases.case_id',
@@ -520,63 +521,63 @@ export default compose(
               contentStyle={{ border: 'none' }}
               tabContent={molecularTests.map(mTest => (
                 <EntityPageVerticalTable
-                  key={mTest.node.molecular_test_id}
+                  key={mTest.molecular_test_id}
                   thToTd={[
                     {
                       th: 'UUID',
-                      td: mTest.node.molecular_test_id,
+                      td: mTest.molecular_test_id,
                     },
                     {
                       th: 'Gene Symbol',
-                      td: mTest.node.gene_symbol,
+                      td: mTest.gene_symbol,
                     },
                     {
                       th: 'Molecular Analysis Method',
-                      td: mTest.node.molecular_analysis_method,
+                      td: mTest.molecular_analysis_method,
                     },
                     {
                       th: 'Test Result',
-                      td: mTest.node.test_result,
+                      td: mTest.test_result,
                     },
                     {
                       th: 'AA Change',
-                      td: mTest.node.aa_change,
+                      td: mTest.aa_change,
                     },
                     {
                       th: 'Antigen',
-                      td: mTest.node.antigen,
+                      td: mTest.antigen,
                     },
                     {
                       th: 'Mismatch Repair Mutation',
-                      td: mTest.node.mismatch_repair_mutation,
+                      td: mTest.mismatch_repair_mutation,
                     },
                     {
                       th: 'Second Gene Symbol',
-                      td: mTest.node.second_gene_symbol,
+                      td: mTest.second_gene_symbol,
                     },
                     {
                       th: 'Test Value',
-                      td: mTest.node.test_value,
+                      td: mTest.test_value,
                     },
                     {
                       th: 'Variant Type',
-                      td: mTest.node.variant_type,
+                      td: mTest.variant_type,
                     },
                     {
                       th: 'Chromosome',
-                      td: mTest.node.chromosome,
+                      td: mTest.chromosome,
                     },
                     {
                       th: 'Laboratory Test',
-                      td: mTest.node.laboratory_test,
+                      td: mTest.laboratory_test,
                     },
                     {
                       th: 'Biospecimen Type',
-                      td: mTest.node.biospecimen_type,
+                      td: mTest.biospecimen_type,
                     },
                     {
                       th: 'Test Units',
-                      td: mTest.node.test_units,
+                      td: mTest.test_units,
                     },
                   ]}
                   />
@@ -584,8 +585,8 @@ export default compose(
               tabs={
                 molecularTests.length > 1
                   ? molecularTests.map(mTest => (
-                    <p key={mTest.node.molecular_test_id}>
-                      {truncate(mTest.node.molecular_test_id, { length: 11 })}
+                    <p key={mTest.molecular_test_id}>
+                      {truncate(mTest.molecular_test_id, { length: 11 })}
                     </p>
                   ))
                   : []

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -41,6 +41,7 @@ const styles = {
     border: `1px solid ${theme.greyScale4}`,
     padding: '3px 5px',
   }),
+  tabTitle: { margin: 0 },
 };
 
 export default compose(
@@ -114,23 +115,29 @@ export default compose(
           contentStyle={{ border: 'none' }}
           onTabClick={i => setTab(() => i)}
           tabs={[
-            <p key="Demographic">Demographic</p>,
-            <p key="Diagnoses / Treatment">
+            <p key="Demographic" style={styles.tabTitle}>Demographic</p>,
+            <p key="Diagnoses / Treatment" style={styles.tabTitle}>
               {`Diagnoses / Treatments (${diagnoses.length})`}
             </p>,
-            <p key="Family Histories">
+            <p key="Family Histories" style={styles.tabTitle}>
               {`Family Histories (${familyHistory.length})`}
             </p>,
-            <p key="Exposures">
+            <p key="Exposures" style={styles.tabTitle}>
               {`Exposures (${totalExposures})`}
             </p>,
-            <p key="FollowUps">
+            <p key="FollowUps" style={styles.tabTitle}>
               {`Follow-Ups (${followUps.length})`}
             </p>,
-            <p key="MolecularTests">
+            <p key="MolecularTests" style={styles.tabTitle}>
               {`Molecular Tests (${molecularTests.length})`}
             </p>,
           ]}
+          tabStyle={{
+            padding: '1rem 1.2rem',
+            // width: 150,
+            whiteSpace: 'nowrap',
+            // textOverflow: 'ellipsis',
+          }}
           >
           {activeTab === 0 && (
             <div>

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -75,10 +75,13 @@ export default compose(
       family_histories: { hits: { edges: familyHistories = [] } },
       demographic = {},
       exposures: { hits: { edges: exposures = [], total: totalExposures } },
+      follow_ups: { hits: { edges: followUps = [] } },
       files: { hits: { edges: clinicalFiles = [] } },
       project: { project_id: projectId = {} },
     } = edges[0].node;
     const familyHistory = familyHistories.map(x => x.node);
+    const { molecular_tests: { hits: { edges: molecularTests = [] } } } = followUps[0].node;
+
     const caseFilter = makeFilter([
       {
         field: 'cases.case_id',
@@ -121,6 +124,16 @@ export default compose(
             <p key="Exposures">
 Exposures (
               {totalExposures}
+)
+            </p>,
+            <p key="FollowUps">
+Follow-Ups (
+              {followUps.length}
+)
+            </p>,
+            <p key="MolecularTests">
+Molecular Tests (
+              {molecularTests.length}
 )
             </p>,
           ]}
@@ -420,6 +433,176 @@ Exposures (
                 <h3 style={{ paddingLeft: '2rem' }}>No Exposures Found.</h3>
               )}
             </div>
+          )}
+          {activeTab === 4 && (
+          <div>
+            {followUps.length && (
+            <SideTabs
+                containerStyle={{ display: 'block' }}
+                contentStyle={{ border: 'none' }}
+                tabContent={followUps.map(followUp => (
+                  <EntityPageVerticalTable
+                    key={followUp.node.follow_up_id}
+                    thToTd={[
+                      {
+                        th: 'UUID',
+                        td: followUp.node.follow_up_id,
+                      },
+                      {
+                        th: 'Days to Follow Up',
+                        td: followUp.node.days_to_follow_up,
+                      },
+                      {
+                        th: 'Comorbidity',
+                        td: followUp.node.comorbidity,
+                      },
+                      {
+                        th: 'Risk Factor',
+                        td: followUp.node.risk_factor,
+                      },
+                      {
+                        th: 'Progression or Recurrence Type',
+                        td: followUp.node.progression_or_recurrence_type,
+                      },
+                      {
+                        th: 'Progression or Recurrence',
+                        td: followUp.node.progression_or_recurrence,
+                      },
+                      {
+                        th: 'Disease Response',
+                        td: followUp.node.disease_response,
+                      },
+                      {
+                        th: 'BMI',
+                        td: followUp.node.bmi,
+                      },
+                      {
+                        th: 'Height',
+                        td: followUp.node.height,
+                      },
+                      {
+                        th: 'Weight',
+                        td: followUp.node.weight,
+                      },
+                      {
+                        th: 'Ecog Performance Status',
+                        td: followUp.node.ecog_performance_status,
+                      },
+                      {
+                        th: 'Karnofsky Performance Status',
+                        td: followUp.node.karnofsky_performance_status,
+                      },
+                      {
+                        th: 'Progression Or Recurrence Anatomic Site',
+                        td: followUp.node.progression_or_recurrence_anatomic_site,
+                      },
+                      {
+                        th: 'Reflux Treatment Type',
+                        td: followUp.node.reflux_treatment_type,
+                      },
+                    ]}
+                    />
+                ))}
+                tabs={
+                  followUps.length > 1
+                    ? followUps.map(followUp => (
+                      <p key={followUp.node.follow_up_id}>
+                        {truncate(followUp.node.follow_up_id, { length: 11 })}
+                      </p>
+                    ))
+                    : []
+                }
+                />
+            )}
+            {!followUps && (
+            <h3 style={{ paddingLeft: '2rem' }}>No Follow Ups Found.</h3>
+            )}
+          </div>
+          )}
+          {activeTab === 5 && (
+          <div>
+            {molecularTests.length && (
+            <SideTabs
+              containerStyle={{ display: 'block' }}
+              contentStyle={{ border: 'none' }}
+              tabContent={molecularTests.map(mTest => (
+                <EntityPageVerticalTable
+                  key={mTest.node.molecular_test_id}
+                  thToTd={[
+                    {
+                      th: 'UUID',
+                      td: mTest.node.molecular_test_id,
+                    },
+                    {
+                      th: 'Gene Symbol',
+                      td: mTest.node.gene_symbol,
+                    },
+                    {
+                      th: 'Molecular Analysis Method',
+                      td: mTest.node.molecular_analysis_method,
+                    },
+                    {
+                      th: 'Test Result',
+                      td: mTest.node.test_result,
+                    },
+                    {
+                      th: 'AA Change',
+                      td: mTest.node.aa_change,
+                    },
+                    {
+                      th: 'Antigen',
+                      td: mTest.node.antigen,
+                    },
+                    {
+                      th: 'Mismatch Repair Mutation',
+                      td: mTest.node.mismatch_repair_mutation,
+                    },
+                    {
+                      th: 'Second Gene Symbol',
+                      td: mTest.node.second_gene_symbol,
+                    },
+                    {
+                      th: 'Test Value',
+                      td: mTest.node.test_value,
+                    },
+                    {
+                      th: 'Variant Type',
+                      td: mTest.node.variant_type,
+                    },
+                    {
+                      th: 'Chromosome',
+                      td: mTest.node.chromosome,
+                    },
+                    {
+                      th: 'Laboratory Test',
+                      td: mTest.node.laboratory_test,
+                    },
+                    {
+                      th: 'Biospecimen Type',
+                      td: mTest.node.biospecimen_type,
+                    },
+                    {
+                      th: 'Test Units',
+                      td: mTest.node.test_units,
+                    },
+                  ]}
+                  />
+              ))}
+              tabs={
+                molecularTests.length > 1
+                  ? molecularTests.map(mTest => (
+                    <p key={mTest.node.molecular_test_id}>
+                      {truncate(mTest.node.molecular_test_id, { length: 11 })}
+                    </p>
+                  ))
+                  : []
+              }
+              />
+            )}
+            {!molecularTests && (
+            <h3 style={{ paddingLeft: '2rem' }}>No Molecular Tests Found.</h3>
+            )}
+          </div>
           )}
         </Tabs>
         {clinicalFiles.length > 0 && (

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -41,6 +41,9 @@ const styles = {
     border: `1px solid ${theme.greyScale4}`,
     padding: '3px 5px',
   }),
+  molecularTestTh: {
+    whiteSpace: 'normal',
+  },
   tabTitle: { margin: 0 },
 };
 
@@ -439,7 +442,7 @@ export default compose(
                 contentStyle={{ border: 'none' }}
                 tabContainerStyle={{
                   maxHeight: 900,
-                  minWidth: 100,
+                  minWidth: 90,
                 }}
                 tabContent={followUps.map(followUp => (
                   <React.Fragment key={followUp.node.follow_up_id}>
@@ -522,78 +525,72 @@ export default compose(
                       followUp.node.molecular_tests.hits.edges.length > 0 && (
                         <EntityPageHorizontalTable
                           data={followUp.node.molecular_tests.hits.edges.map(({ node }) => ({
-                            molecular_test_id: truncate(node.molecular_test_id, { length: 11 }) || '--',
-                            gene_symbol: node.gene_symbol || '--',
-                            molecular_analysis_method: node.molecular_analysis_method || '--',
-                            test_result: node.test_result || '--',
-                            aa_change: node.aa_change || '--',
-                            antigen: node.antigen,
-                            mismatch_repair_mutation: node.mismatch_repair_mutation,
-                            second_gene_symbol: node.second_gene_symbol,
-                            test_value: node.test_value,
-                            variant_type: node.variant_type,
-                            chromosome: node.chromosome,
-                            laboratory_test: node.laboratory_test,
-                            biospecimen_type: node.biospecimen_type,
-                            test_units: node.test_units,
+                            biospecimenType: node.biospecimen_type,
+                            geneSymbol: node.gene_symbol,
+                            laboratoryTest: node.laboratory_test,
+                            molecularAnalysisMethod: node.molecular_analysis_method,
+                            molecularTestId: node.molecular_test_id,
+                            testValue: `${node.test_value} ${node.test_units}`,
+                            // aa_change: node.aa_change || '--',
+                            // antigen: node.antigen,
+                            // mismatch_repair_mutation: node.mismatch_repair_mutation,
+                            // second_gene_symbol: node.second_gene_symbol,
+                            // variant_type: node.variant_type,
+                            // chromosome: node.chromosome,
                           }))}
                           headings={[
                             {
+                              key: 'molecularTestId',
                               title: 'UUID',
-                              key: 'molecular_test_id',
                             },
                             {
-                              title: 'Gene Symbol',
-                              key: 'gene_symbol',
-                            },
-                            {
+                              key: 'molecularAnalysisMethod',
+                              style: styles.molecularTestTh,
                               title: 'Molecular Analysis Method',
-                              key: 'molecular_analysis_method',
                             },
                             {
-                              title: 'Test Result',
-                              key: 'test_result',
+                              key: 'geneSymbol',
+                              style: styles.molecularTestTh,
+                              title: 'Gene Symbol',
                             },
                             {
-                              title: 'AA Change',
-                              key: 'aa_change',
-                            },
-                            {
-                              title: 'Antigen',
-                              key: 'antigen',
-                            },
-                            {
-                              title: 'Mismatch Repair Mutation',
-                              key: 'mismatch_repair_mutation',
-                            },
-                            {
-                              title: 'Second Gene Symbol',
-                              key: 'second_gene_symbol',
-                            },
-                            {
-                              title: 'Test Value',
-                              key: 'test_value',
-                            },
-                            {
-                              title: 'Variant Type',
-                              key: 'variant_type',
-                            },
-                            {
-                              title: 'Chromosome',
-                              key: 'chromosome',
-                            },
-                            {
+                              key: 'laboratoryTest',
+                              style: styles.molecularTestTh,
                               title: 'Laboratory Test',
-                              key: 'laboratory_test',
                             },
                             {
+                              key: 'biospecimenType',
+                              style: styles.molecularTestTh,
                               title: 'Biospecimen Type',
-                              key: 'biospecimen_type',
                             },
                             {
-                              title: 'Test Units',
-                              key: 'test_units',
+                              key: 'testValue',
+                              title: 'Test Value',
                             },
+                            // {
+                            //   title: 'AA Change',
+                            //   key: 'aa_change',
+                            // },
+                            // {
+                            //   title: 'Antigen',
+                            //   key: 'antigen',
+                            // },
+                            // {
+                            //   title: 'Mismatch Repair Mutation',
+                            //   key: 'mismatch_repair_mutation',
+                            // },
+                            // {
+                            //   title: 'Second Gene Symbol',
+                            //   key: 'second_gene_symbol',
+                            // },
+                            // {
+                            //   title: 'Variant Type',
+                            //   key: 'variant_type',
+                            // },
+                            // {
+                            //   title: 'Chromosome',
+                            //   key: 'chromosome',
+                            // },
                           ]}
                           />
                     )}

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -277,30 +277,37 @@ export default compose(
                       </div>
                       {x.treatments &&
                         !!x.treatments.hits.edges.length && (
-                          <Table
-                            body={(
-                              <tbody>
-                                {x.treatments.hits.edges.map(({ node }) => (
-                                  <Tr key={node.treatment_id}>
-                                    <Td>{node.treatment_id || '--'}</Td>
-                                    <Td>{node.therapeutic_agents || '--'}</Td>
-                                    <Td>
-                                      {node.treatment_intent_type || '--'}
-                                    </Td>
-                                    <Td>{node.treatment_or_therapy || '--'}</Td>
-                                    <Td>
-                                      {node.days_to_treatment_start || '--'}
-                                    </Td>
-                                  </Tr>
-                                ))}
-                              </tbody>
-                            )}
+                          <EntityPageHorizontalTable
+                            data={x.treatments.hits.edges.map(({ node }) => ({
+                              treatment_id: node.treatment_id || '--',
+                              therapeutic_agents: node.therapeutic_agents || '--',
+                              treatment_intent_type: node.treatment_intent_type || '--',
+                              treatment_or_therapy: node.treatment_or_therapy || '--',
+                              days_to_treatment_start: node.days_to_treatment_start || '--',
+                            }))
+                            }
                             headings={[
-                              <Th key="id">UUID</Th>,
-                              <Th key="agents">Therapeutic Agents</Th>,
-                              <Th key="intent_type">Treatment Intent Type</Th>,
-                              <Th key="therapy">Treatment or Therapy</Th>,
-                              <Th key="days">Days to Treatment Start</Th>,
+                              {
+                                key: 'treatment_id',
+                                title: 'UUID',
+                              },
+                              {
+                                key: 'therapeutic_agents',
+                                title: 'Therapeutic Agents',
+                              },
+                              {
+                                key: 'treatment_intent_type',
+                                title: 'Treatment Intent Type',
+                              },
+                              {
+                                key: 'treatment_or_therapy',
+                                title: 'Treatment or Therapy',
+                              },
+                              {
+                                key: 'days_to_treatment_start',
+                                style: { textAlign: 'right' },
+                                title: 'Days to Treatment Start',
+                              },
                             ]}
                             />
                       )}
@@ -609,9 +616,9 @@ export default compose(
         {clinicalFiles.length > 0 && (
           <div
             style={{
-              padding: '2px 10px 10px 10px',
               borderTop: `1px solid ${theme.greyScale5}`,
               marginTop: '10px',
+              padding: '2px 10px 10px 10px',
             }}
             >
             <EntityPageHorizontalTable
@@ -672,8 +679,8 @@ export default compose(
                 },
                 {
                   key: 'file_size',
-                  title: 'Size',
                   style: { textAlign: 'right' },
+                  title: 'Size',
                 },
                 {
                   key: 'action',

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.js
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import Card from '@ncigdc/uikit/Card';
 import Tabs from '@ncigdc/uikit/Tabs';
 import SideTabs from '@ncigdc/uikit/SideTabs';
-import Table, { Tr, Td, Th } from '@ncigdc/uikit/Table';
 import { withTheme } from '@ncigdc/theme';
 import { Row } from '@ncigdc/uikit/Flex/';
 import EntityPageVerticalTable from '@ncigdc/components/EntityPageVerticalTable';
@@ -434,7 +433,7 @@ export default compose(
           )}
           {activeTab === 4 && (
           <div>
-            {followUps.length && (
+            {followUps.length > 0 && (
             <SideTabs
                 containerStyle={{
                   display: 'block',
@@ -594,10 +593,11 @@ export default compose(
                           ]}
                           />
                     )}
-                    {!(followUp.node.molecular_tests && followUp.node.molecular_tests.hits.edges.length) && (
-                    <div style={{ paddingLeft: '2rem' }}>
+                    {!(followUp.node.molecular_tests &&
+                      followUp.node.molecular_tests.hits.edges.length) && (
+                      <div style={{ paddingLeft: '2rem' }}>
                       No Molecular Tests Found.
-                    </div>
+                      </div>
                     )}
                   </React.Fragment>
                 ))}
@@ -612,7 +612,7 @@ export default compose(
                 }
                 />
             )}
-            {!followUps && (
+            {followUps.length === 0 && (
             <h3 style={{ paddingLeft: '2rem' }}>No Follow Ups Found.</h3>
             )}
           </div>

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.relay.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.relay.js
@@ -192,14 +192,7 @@ must be provided
                                         molecular_test_id
                                         gene_symbol
                                         molecular_analysis_method
-                                        test_result
-                                        aa_change
-                                        antigen
-                                        mismatch_repair_mutation
-                                        second_gene_symbol
                                         test_value
-                                        variant_type
-                                        chromosome
                                         laboratory_test
                                         biospecimen_type
                                         test_units

--- a/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.relay.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalCard/ClinicalCard.relay.js
@@ -167,6 +167,50 @@ must be provided
                             }
                           }
                         }
+                        follow_ups {
+                          hits(first: 99) {
+                            edges {
+                              node {
+                                follow_up_id
+                                days_to_follow_up
+                                comorbidity
+                                risk_factor
+                                progression_or_recurrence_type
+                                progression_or_recurrence
+                                disease_response
+                                bmi
+                                height
+                                weight
+                                ecog_performance_status
+                                karnofsky_performance_status
+                                progression_or_recurrence_anatomic_site
+                                reflux_treatment_type
+                                molecular_tests {
+                                  hits(first: 99) {
+                                    edges {
+                                      node {
+                                        molecular_test_id
+                                        gene_symbol
+                                        molecular_analysis_method
+                                        test_result
+                                        aa_change
+                                        antigen
+                                        mismatch_repair_mutation
+                                        second_gene_symbol
+                                        test_value
+                                        variant_type
+                                        chromosome
+                                        laboratory_test
+                                        biospecimen_type
+                                        test_units
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }

--- a/src/packages/@ncigdc/uikit/Tabs.js
+++ b/src/packages/@ncigdc/uikit/Tabs.js
@@ -86,11 +86,12 @@ const Tab = ({
 const Tabs = ({
   activeIndex,
   children,
-  contentStyle,
+  contentStyle = {},
   onTabClick,
   side,
-  style,
-  tabStyle,
+  style = {},
+  tabContainerStyle = {},
+  tabStyle = {},
   tabToolbar,
   tabs,
   theme,
@@ -109,6 +110,7 @@ const Tabs = ({
             backgroundColor: 'white',
             position: 'relative',
             left: '1px',
+            ...tabContainerStyle,
           }}
           >
           {Children.map(tabs, (child, i) => (


### PR DESCRIPTION
## Ticket Number

PRTL-2704

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `devmaksim`
- [ ] `qa` (which version?)

## Description of Changes
Adds follow_up and molecular_test nodes to case page. Mol tests are nested under follow_up
Rebuilds schema to include these nodes. Civic schema updates included from `dev-oicr`
Updates treatment table to EntityPageHorizontal component for more consistency with other clinical node tables