### PR TITLE
[PRTL-2511] make lolliplot backbone work in firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,9 +173,15 @@
       }
     },
     "@oncojs/react-lolliplot": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@oncojs/react-lolliplot/-/react-lolliplot-0.11.4.tgz",
-      "integrity": "sha512-IToOQFGyPiHmSK2SKY2yMHxgK+O1gaoaYIp61CYOiqVbRFxnbthONl0c0yi1zpjcNP47THMUv98GTiMw1dxhXw=="
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@oncojs/react-lolliplot/-/react-lolliplot-0.11.6.tgz",
+      "integrity": "sha512-eyVdIK+XVLevAPwwF2p6tbbk58SHAL0U+g3J1uOJrPdsip8QlLd2GHb23ugdI7mWGjGWBnhxDz/b+/v2NDU54Q==",
+      "requires": {
+        "d3-selection": "^1.0.3",
+        "invariant": "^2.2.2",
+        "lodash.range": "^3.2.0",
+        "react-faux-dom": "^3.0.1"
+      }
     },
     "@oncojs/sapien": {
       "version": "0.5.2",
@@ -9786,6 +9792,11 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
+    },
+    "lodash.range": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
+      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
     },
     "lodash.some": {
       "version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-ui",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -173,15 +173,9 @@
       }
     },
     "@oncojs/react-lolliplot": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@oncojs/react-lolliplot/-/react-lolliplot-0.11.1.tgz",
-      "integrity": "sha512-iZ/oD92W5F5mL8OnZaVltP6/9Kj9hVWcAw9eN7mbqVLnmdyuoXdatzuqo0gXek4+HuQhB/NME4Z6zOJhHLYjVg==",
-      "requires": {
-        "d3-selection": "^1.0.3",
-        "invariant": "^2.2.2",
-        "lodash.range": "^3.2.0",
-        "react-faux-dom": "^3.0.1"
-      }
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@oncojs/react-lolliplot/-/react-lolliplot-0.11.4.tgz",
+      "integrity": "sha512-IToOQFGyPiHmSK2SKY2yMHxgK+O1gaoaYIp61CYOiqVbRFxnbthONl0c0yi1zpjcNP47THMUv98GTiMw1dxhXw=="
     },
     "@oncojs/sapien": {
       "version": "0.5.2",
@@ -9792,11 +9786,6 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
-    },
-    "lodash.range": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
     },
     "lodash.some": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@oncojs/boxplot": "0.3.0",
-    "@oncojs/react-lolliplot": "0.11.4",
+    "@oncojs/react-lolliplot": "0.11.6",
     "@oncojs/sapien": "0.5.2",
     "@oncojs/survivalplot": "0.8.3",
     "@types/d3": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@oncojs/boxplot": "0.3.0",
-    "@oncojs/react-lolliplot": "0.11.1",
+    "@oncojs/react-lolliplot": "0.11.4",
     "@oncojs/sapien": "0.5.2",
     "@oncojs/survivalplot": "0.8.3",
     "@types/d3": "5.0.1",


### PR DESCRIPTION
## Ticket Number

PRTL-2511

## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- update `react-lolliplot` version