### PR TITLE
[PRTL-2774] Wrong Back Button & Navigation Behaviour on Exploration

### DIFF
--- a/src/packages/@ncigdc/components/PortalContainer.js
+++ b/src/packages/@ncigdc/components/PortalContainer.js
@@ -104,12 +104,17 @@ export default compose(
     componentWillUnmount(): void {
       this.removeListen();
     },
-    shouldComponentUpdate({ notifications: nextNotifications }) {
+    shouldComponentUpdate({
+      location: nextLocation,
+      notifications: nextNotifications,
+    }) {
       const {
+        location,
         notifications,
       } = this.props;
 
       return !(
+        isEqual(nextLocation, location) &&
         isEqual(nextNotifications, notifications)
       );
     },


### PR DESCRIPTION
## Ticket Number

Wrong Back Button & Navigation Behaviour on Exploration

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
The issue is generated by shouldComponentUpdate function in PortalContainer.

When back button is clicked on the browser, the url changes to the previous url.

PortalContainer should refresh the page but it has been restricted by shouldComponentUpdate to only refresh the page when notifications changes.

So the solution is to change shouldComponentUpdate to also listen to changing of location prop which has the information of url.
