### PR TITLE
[PRTL-2770] make x-axis font bold at clinical analysis histogram

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalHistogram.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalHistogram.js
@@ -35,7 +35,10 @@ const ClinicalHistogram = ({
       },
     }}
     xAxis={{
-      style: histogramStyles(theme).axis,
+      style: {
+        ...histogramStyles(theme).axis,
+        fontWeight: '700',
+      },
     }}
     yAxis={{
       style: histogramStyles(theme).axis,


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [] `qa` (which version?)

## Description of Changes
add right `font-weight` in the specific context.