### PR TITLE
[PRTL-2779] fix Years of Diagnosis unit

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -249,7 +249,6 @@ export default compose(
       return {
         boxPlotValues: map(
           {
-
             ...rawQueryData.stats,
             ...rawQueryData.percentiles,
           },
@@ -284,8 +283,10 @@ export default compose(
             (value, stat) => {
               switch (dataDimensions[sanitisedId].unit) {
                 case 'Years': {
+                  // TODO ugly hack until API provides units
+                  const converter = sanitisedId === 'year_of_diagnosis' ? 1 : DAYS_IN_YEAR;
                   return ({
-                    [stat]: parseContinuousValue(value / DAYS_IN_YEAR),
+                    [stat]: parseContinuousValue(value / converter),
                   });
                 }
                 default:


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
Calculates the values correctly for Years of Diagnosis.
TODO: Must remove this hack whenever API makes the units available