### PR TITLE
[PRTL-2827] fix survival plot for custom categorical bins

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
@@ -97,7 +97,9 @@ export default compose(
         setSelectedSurvivalLoadingIds(nextSelectedBins);
 
         const nextBinsForPlot = plotTypes === 'categorical'
-          ? nextSelectedBins
+          ? nextSelectedBins.map(nextBin => data.reduce((acc, item) => acc.concat(
+            item.displayName === nextBin ? item.keyArray : []
+          ), []))
           : nextSelectedBins
             .map(nextBin => data.filter(datum => datum.displayName === nextBin)[0])
             .map(nextBin => makeDocCountInteger(nextBin));


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
Restores the survival plot updates for custom categorical bins.