### PR TITLE
[PRTL-2831] categorical survival doesn't plot unless fields change

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
@@ -57,7 +57,7 @@ export default compose(
       isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots) &&
       isEqual(props.selectedSurvivalBins, nextProps.selectedSurvivalBins) &&
       isEqual(props.survivalPlotValues, nextProps.survivalPlotValues) &&
-      isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots),
+      isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots) &&
       isEqual(props.filters, nextProps.filters)
     ),
     ({

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
@@ -57,7 +57,8 @@ export default compose(
       isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots) &&
       isEqual(props.selectedSurvivalBins, nextProps.selectedSurvivalBins) &&
       isEqual(props.survivalPlotValues, nextProps.survivalPlotValues) &&
-      isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots)
+      isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots),
+      isEqual(props.filters, nextProps.filters)
     ),
     ({
       dispatch,


### PR DESCRIPTION
## Ticket Number

PRTL-2831

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

listen for `filters` prop changes before running `populateSurvivalData`. it contains the `setId` and is passed to the survival plot. this way the survival plot will update when you change case sets regardless of the values/fields being passed.