### PR TITLE
[PRTL-2847] custom interval validation

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
@@ -145,7 +145,7 @@ class ContinuousCustomBinsModal extends Component {
 
     const emptyOrNaNState = {
       ...intervalErrors,
-      // add emptyOrNaN error, or remove all errors.
+      // add emptyOrNaN error, or clear this field's errors.
       [inputKey]: emptyOrNaNError,
       // if this field is emptyOrNaN,
       // remove comparison errors *that depend on this field's value*.

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
@@ -195,17 +195,17 @@ class ContinuousCustomBinsModal extends Component {
     }
 
     // only do math checks if all fields have valid numbers
-    const isFormValid = ['amount', 'max', 'min']
-      .filter(field => field !== inputKey
-        ? true
-        : field === 'amount'
-          ? testNum(currentAmount)
-          : testNumDash(intervalFields[field]))
-      .length === 3;
+    // const isFormValid = ['amount', 'max', 'min']
+    //   .filter(field => field !== inputKey
+    //     ? true
+    //     : field === 'amount'
+    //       ? testNum(currentAmount)
+    //       : testNumDash(intervalFields[field]))
+    //   .length === 3;
     
-    if (!isFormValid) {
-      return;
-    }
+    // if (!isFormValid) {
+    //   return;
+    // }
 
     const mathErrors = {
       amount: value <= 0
@@ -228,37 +228,23 @@ class ContinuousCustomBinsModal extends Component {
         // if min/max have valid values,
         // and max <= min, 
         // only show the error on the current field
-        ...inputKey === 'max' && mathErrors.max
-            ? { min: '' }
-            : {},
+        ...inputKey === 'max' &&
+          testNumDash(currentMin) &&
+          mathErrors.max &&
+          { min: '' },
         ...inputKey === 'min' &&
-          testNum(numValue) &&
-          testNum(currentMax) &&
-          currentMax <= numValue
-            ? { max: '' }
-            : {},
+          testNumDash(currentMax) &&
+          mathErrors.min &&
+          { max: '' },
         ...inputKey !== 'amount' &&
           testNum(currentAmount) &&
           {
-            amount: inputError === '' && currentAmount > validAmount
-              ? amountError
+            amount: currentAmount > validAmount
+              ? 'test' // TODO: put amount error back
               : '',
           },
         },
-      }, () => {
-      if ((inputKey === 'max' || inputKey === 'min') &&
-        testNumDash(currentAmount)) {
-        this.set({
-          intervalErrors: {
-            ...intervalErrors,
-            amount: inputError === '' &&
-              currentAmount > validAmount
-                ? amountError
-                : '',
-          },
-        });
-      }
-    });
+      });
   };
 
   checkSubmitDisabled = () => {

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
@@ -153,23 +153,14 @@ class ContinuousCustomBinsModal extends Component {
       ...emptyOrNaNError &&
           {
           ...inputKey !== 'amount' &&
-            {
-              amount: testNum(currentAmount)
-                ? ''
-                : intervalErrors.amount,
-            },
+            testNum(currentAmount) &&
+            { amount: '' },
           ...inputKey === 'max' &&
-            {
-              min: testNumDash(currentMin)
-                ? ''
-                : intervalErrors.min,
-            },
+            testNumDash(currentMin) &&
+            { min: '' },
           ...inputKey === 'min' &&
-            {
-              max: testNumDash(currentMax)
-                ? ''
-                : intervalErrors.max,
-            },
+            testNumDash(currentMax) &&
+            { max: '' },
         },
     };
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
@@ -42,10 +42,8 @@ const rangeFieldsOrder = [
   'to',
 ];
 
-const testNumDash = input => (/^(\-?\d+\.?\d*)$/).test(input);
-// positive or negative, optional decimals
-const testNum = input => (/^(\d+\.?\d*)$/).test(input);
-// positive only, optional decimals
+const testNum = input => (/^(\-?\d+\.?\d*)$/).test(input);
+const testNumPositive = input => (/^(\d+\.?\d*)$/).test(input);
 
 const defaultState = {
   binningMethod: 'interval', // interval or range
@@ -138,8 +136,8 @@ class ContinuousCustomBinsModal extends Component {
     const emptyOrNaNError = value === ''
       ? 'Required field.'
       // min/max values can be negative
-      : (inputKey === 'amount' && testNum(value)) ||
-        (inputKey !== 'amount' && testNumDash(value))
+      : (inputKey === 'amount' && testNumPositive(value)) ||
+        (inputKey !== 'amount' && testNum(value))
           ? ''
           : `'${value}' is not a valid number.`;
 
@@ -153,13 +151,13 @@ class ContinuousCustomBinsModal extends Component {
       ...emptyOrNaNError &&
           {
           ...inputKey !== 'amount' &&
-            testNum(currentAmount) &&
+            testNumPositive(currentAmount) &&
             { amount: '' },
           ...inputKey === 'max' &&
-            testNumDash(currentMin) &&
+            testNum(currentMin) &&
             { min: '' },
           ...inputKey === 'min' &&
-            testNumDash(currentMax) &&
+            testNum(currentMax) &&
             { max: '' },
         },
     };
@@ -195,11 +193,11 @@ class ContinuousCustomBinsModal extends Component {
         : value > validAmount && validAmount > 0
           ? amountErrorMsg
           : '',
-      max: testNumDash(currentMin) &&
+      max: testNum(currentMin) &&
         numValue <= currentMin
           ? `Must be greater than ${currentMin}.`
           : '',
-      min: testNumDash(currentMax) &&
+      min: testNum(currentMax) &&
         currentMax <= numValue
           ? `Must be less than ${currentMax}.`
           : ''
@@ -214,14 +212,14 @@ class ContinuousCustomBinsModal extends Component {
         // only show the error on the current field
         ...inputKey === 'max' &&
           (comparisonErrors.max ||
-            testNumDash(currentMin)) &&
+            testNum(currentMin)) &&
           { min: '' },
         ...inputKey === 'min' &&
           (comparisonErrors.min ||
-            testNumDash(currentMax)) &&
+            testNum(currentMax)) &&
           { max: '' },
         ...inputKey !== 'amount' &&
-          testNum(currentAmount) &&
+          testNumPositive(currentAmount) &&
           {
             amount: currentAmount > validAmount &&
               validAmount > 0

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/modals/ContinuousCustomBinsModal/ContinuousCustomBinsModal.js
@@ -133,11 +133,9 @@ class ContinuousCustomBinsModal extends Component {
     const validAmount = currentMax - currentMin;
 
     // EMPTY OR NAN
-    const emptyOrNaNError = value === ''
+    const emptyOrNaNError = value.trim() === ''
       ? 'Required field.'
-      // min/max values can be negative
-      : (inputKey === 'amount' && testNumPositive(value)) ||
-        (inputKey !== 'amount' && testNum(value))
+      : testNum(value)
           ? ''
           : `'${value}' is not a valid number.`;
 
@@ -147,7 +145,7 @@ class ContinuousCustomBinsModal extends Component {
       [inputKey]: emptyOrNaNError,
       // if this field is emptyOrNaN,
       // remove comparison errors *that depend on this field's value*.
-      // only keep emptyOrNaN errors.
+      // only keep emptyOrNaN errors & amount <= 0 error.
       ...emptyOrNaNError &&
           {
           ...inputKey !== 'amount' &&
@@ -223,7 +221,7 @@ class ContinuousCustomBinsModal extends Component {
           {
             amount: currentAmount > validAmount &&
               validAmount > 0
-              // if min >= max, clear amount error because
+              // if max <= min, clear amount error because
               // amount cannot be accurately validated
                 ? amountErrorMsg
                 : '',


### PR DESCRIPTION
## Ticket Number

PRTL-2847

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- rewrote the custom interval validation to use regexes instead of `Number()` and lodash `isFinite`
- added comments and tried to make things clearer overall