### PR TITLE
[PRTL-2843] summary page card cleanup

### DIFF
--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -33,8 +33,6 @@ const PieChart = compose(
     setTooltip,
     width = 160,
   }) => {
-    const dataHasColors = data.every(datum => datum.color !== 'undefined' &&
-      datum.color !== '');
     const color = d3.scaleOrdinal(d3.schemeCategory20);
     const outerRadius = height / 2 + 10;
     const innerRadius = enableInnerRadius ? outerRadius / 2 : 0;
@@ -82,15 +80,11 @@ const PieChart = compose(
     const gPath = g.append('path');
     const gHoverPath = gHover.append('path');
 
-    gPath.attr('d', arc).style('fill', (d, i) => dataHasColors
-      ? data[i].color
-      : color(i));
+    gPath.attr('d', arc).style('fill', (d, i) => data[i].color || color(i));
 
     const fillHover = gHoverPath
       .attr('d', arc)
-      .style('fill', (d, i) => dataHasColors
-        ? data[i].color
-        : color(i))
+      .style('fill', (d, i) => data[i].color || color(i))
       .style('opacity', 0);
 
     fillHover

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -1,6 +1,5 @@
 // @flow
 
-import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import _ from 'lodash';
 import ReactFauxDOM from 'react-faux-dom';
@@ -34,6 +33,8 @@ const PieChart = compose(
     setTooltip,
     width = 160,
   }) => {
+    const dataHasColors = data.every(datum => datum.color !== 'undefined' &&
+      datum.color !== '');
     const color = d3.scaleOrdinal(d3.schemeCategory20);
     const outerRadius = height / 2 + 10;
     const innerRadius = enableInnerRadius ? outerRadius / 2 : 0;
@@ -81,11 +82,15 @@ const PieChart = compose(
     const gPath = g.append('path');
     const gHoverPath = gHover.append('path');
 
-    gPath.attr('d', arc).style('fill', (d, i) => color(i));
+    gPath.attr('d', arc).style('fill', (d, i) => dataHasColors
+      ? data[i].color
+      : color(i));
 
     const fillHover = gHoverPath
       .attr('d', arc)
-      .style('fill', (d, i) => color(i))
+      .style('fill', (d, i) => dataHasColors
+        ? data[i].color
+        : color(i))
       .style('opacity', 0);
 
     fillHover

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -34,9 +34,13 @@ const PieChart = compose(
     setTooltip,
     width = 160,
   }) => {
-    const dataHasColors = data.every(datum => 
+    const dataHasColors = data.every(datum =>
       typeof datum.color !== 'undefined' && datum.color !== '');
     const color = d3.scaleOrdinal(d3.schemeCategory20);
+    const getSliceColor = i => (dataHasColors
+      ? data[i].color
+      : color(i));
+
     const outerRadius = height / 2 + 10;
     const innerRadius = enableInnerRadius ? outerRadius / 2 : 0;
     const node = ReactFauxDOM.createElement('div');
@@ -83,15 +87,11 @@ const PieChart = compose(
     const gPath = g.append('path');
     const gHoverPath = gHover.append('path');
 
-    gPath.attr('d', arc).style('fill', (d, i) => dataHasColors
-      ? data[i].color
-      : color(i));
+    gPath.attr('d', arc).style('fill', (d, i) => getSliceColor(i));
 
     const fillHover = gHoverPath
       .attr('d', arc)
-      .style('fill', (d, i) => dataHasColors
-        ? data[i].color
-        : color(i))
+      .style('fill', (d, i) => getSliceColor(i))
       .style('opacity', 0);
 
     fillHover

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -1,5 +1,6 @@
 // @flow
 
+import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import _ from 'lodash';
 import ReactFauxDOM from 'react-faux-dom';
@@ -33,6 +34,8 @@ const PieChart = compose(
     setTooltip,
     width = 160,
   }) => {
+    const dataHasColors = data.every(datum => 
+      typeof datum.color !== 'undefined' && datum.color !== '');
     const color = d3.scaleOrdinal(d3.schemeCategory20);
     const outerRadius = height / 2 + 10;
     const innerRadius = enableInnerRadius ? outerRadius / 2 : 0;
@@ -80,11 +83,15 @@ const PieChart = compose(
     const gPath = g.append('path');
     const gHoverPath = gHover.append('path');
 
-    gPath.attr('d', arc).style('fill', (d, i) => data[i].color || color(i));
+    gPath.attr('d', arc).style('fill', (d, i) => dataHasColors
+      ? data[i].color
+      : color(i));
 
     const fillHover = gHoverPath
       .attr('d', arc)
-      .style('fill', (d, i) => data[i].color || color(i))
+      .style('fill', (d, i) => dataHasColors
+        ? data[i].color
+        : color(i))
       .style('opacity', 0);
 
     fillHover

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
@@ -16,6 +16,12 @@ const CardWrapper = ({
     maxBy(data
       .map(d => d[subProps.mappingLabel] || ''), (item) => item.length) || ''
   ).length;
+  const downloadData = data.map(datum => pick(datum, [
+    'doc_count',
+    'key',
+    'color',
+  ]));
+
   return (
     <React.Fragment>
       <Row
@@ -29,7 +35,7 @@ const CardWrapper = ({
         >
         <h3>{title}</h3>
         <DownloadVisualizationButton
-          data={data}
+          data={downloadData}
           key="download"
           noText
           onClick={(e) => {
@@ -47,11 +53,7 @@ const CardWrapper = ({
             title,
           })}
           tooltipHTML="Download image or data"
-          tsvData={data.map(datum => pick(datum, [
-            'doc_count',
-            'key',
-            'color',
-          ]))}
+          tsvData={downloadData}
           />
       </Row>
       <div className={className}>

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
@@ -1,9 +1,9 @@
-import { maxBy, pick } from 'lodash';
+import React from 'react';
 
 import DownloadVisualizationButton from '@ncigdc/components/DownloadVisualizationButton';
-import React from 'react';
-import { Row } from '@ncigdc/uikit/Flex';
 import wrapSvg from '@ncigdc/utils/wrapSvg';
+import { Row } from '@ncigdc/uikit/Flex';
+import { maxBy, pick } from 'lodash';
 
 const CardWrapper = ({
   Component,

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
@@ -47,7 +47,11 @@ const CardWrapper = ({
             title,
           })}
           tooltipHTML="Download image or data"
-          tsvData={data.map(datum => pick(datum, ['doc_count', 'key']))}
+          tsvData={data.map(datum => pick(datum, [
+            'doc_count',
+            'key',
+            'color',
+          ]))}
           />
       </Row>
       <div className={className}>

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/CardWrapper.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import { maxBy, pick } from 'lodash';
+
 import DownloadVisualizationButton from '@ncigdc/components/DownloadVisualizationButton';
-import wrapSvg from '@ncigdc/utils/wrapSvg';
+import React from 'react';
 import { Row } from '@ncigdc/uikit/Flex';
-import { maxBy } from 'lodash';
+import wrapSvg from '@ncigdc/utils/wrapSvg';
 
 const CardWrapper = ({
   Component,
@@ -46,7 +47,7 @@ const CardWrapper = ({
             title,
           })}
           tooltipHTML="Download image or data"
-          tsvData={data}
+          tsvData={data.map(datum => pick(datum, ['doc_count', 'key']))}
           />
       </Row>
       <div className={className}>

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/HistogramCard.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/HistogramCard.js
@@ -31,7 +31,7 @@ const HistogramCard = ({
   data,
   mappingLabel,
   mappingValue,
-  xAxisTitle,
+  xAxisTitle = '',
 }) => {
   return (
     <div

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -29,7 +29,7 @@ const SummaryPage = ({
   const color = scaleOrdinal(schemeCategory20);
   const dataDecor = (data, name, setColor = false) => data.map((datum, i) => ({
     ...datum,
-    tooltip: Tooltip(datum.key, datum.count),
+    tooltip: Tooltip(datum.key, datum.doc_count),
     ...setColor && { color: color(i) },
   }));
 

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -8,7 +8,7 @@ import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
 import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import { get } from 'lodash';
 
-const Tooltip = (title, key, count) => (
+const Tooltip = (key, count) => (
   <span>
     <b>{key}</b>
     <br />
@@ -29,7 +29,7 @@ const SummaryPage = ({
   const color = scaleOrdinal(schemeCategory20);
   const dataDecor = (data, name, setColor = false) => data.map((datum, i) => ({
     ...datum,
-    tooltip: Tooltip(name, datum.key, datum.doc_count),
+    tooltip: Tooltip(datum.key, datum.count),
     ...setColor && { color: color(i) },
   }));
 

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -1,11 +1,11 @@
-import { scaleOrdinal, schemeCategory20 } from 'd3';
-
-import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
-import HistogramCard from '@ncigdc/components/Explore/SummaryPage/HistogramCard';
-import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
 import React from 'react';
+
+import { scaleOrdinal, schemeCategory20 } from 'd3';
+import HistogramCard from '@ncigdc/components/Explore/SummaryPage/HistogramCard';
 import SampleTypeCard from '@ncigdc/components/Explore/SummaryPage/SampleTypeCard';
 import SummaryPageQuery from '@ncigdc/components/Explore/SummaryPage/SummaryPage.relay';
+import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
+import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
 import { get } from 'lodash';
 
 const Tooltip = (title, key, count) => (
@@ -37,12 +37,12 @@ const SummaryPage = ({
   const experimentalStrategyData = get(viewer, 'explore.cases.aggregations.summary__experimental_strategies__experimental_strategy.buckets', []);
 
   const color = scaleOrdinal(schemeCategory20);
-  const dataDecor = (data, name, donut = false) => data.map((el, i) => ({
+  const dataDecor = (data, name, donuts = 0) => data.map((el, i) => ({
     ...el,
     tooltip: Tooltip(name, el.key, el.doc_count),
-    ...donut === 'single' 
+    ...donuts === 1
       ? { color: color(i) } 
-      : donut === 'double' // TODO. 'Primary Sites & Disease Types'
+      : donuts === 2 // TODO. 'Primary Sites & Disease Types'
         ? { color: 'todo' }
         : {},
   }));
@@ -50,7 +50,7 @@ const SummaryPage = ({
   const elementsData = [
     {
       component: SampleTypeCard,
-      data: dataDecor(sampleTypeData, 'Sample Types', 'single'),
+      data: dataDecor(sampleTypeData, 'Sample Types', 1),
       props: { mappingId: 'key' },
       space: 1,
       title: 'Sample Types',
@@ -61,14 +61,13 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: '',
       },
       space: 1,
       title: 'Experimental Strategies',
     },
     {
       component: () => '',
-      data: [], // TODO: donut = 'double'
+      data: [], // TODO: donuts = 2
       space: 1,
       title: 'Primary Sites & Disease Types',
     },
@@ -95,7 +94,6 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: '',
       },
       space: 1,
       title: 'Vital Status',
@@ -106,7 +104,6 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: '',
       },
       space: 1,
       title: 'Race',
@@ -117,7 +114,6 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: '',
       },
       space: 1,
       title: 'Gender',

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -1,3 +1,5 @@
+import { scaleOrdinal, schemeCategory20 } from 'd3';
+
 import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import HistogramCard from '@ncigdc/components/Explore/SummaryPage/HistogramCard';
 import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
@@ -33,16 +35,22 @@ const SummaryPage = ({
   const ageAtDiagnosisData = get(viewer, 'explore.cases.aggregations.diagnoses__age_at_diagnosis.histogram.buckets', []);
   const sampleTypeData = get(viewer, 'explore.cases.aggregations.samples__sample_type.buckets', []);
   const experimentalStrategyData = get(viewer, 'explore.cases.aggregations.summary__experimental_strategies__experimental_strategy.buckets', []);
-  const dataDecor = (data, name) => data.map(el => ({
+
+  const color = scaleOrdinal(schemeCategory20);
+  const dataDecor = (data, name, donut = false) => data.map((el, i) => ({
     ...el,
     tooltip: Tooltip(name, el.key, el.doc_count),
+    ...donut === 'single' 
+      ? { color: color(i) } 
+      : donut === 'double' // TODO. 'Primary Sites & Disease Types'
+        ? { color: 'todo' }
+        : {},
   }));
-
 
   const elementsData = [
     {
       component: SampleTypeCard,
-      data: dataDecor(sampleTypeData, 'Sample Types'),
+      data: dataDecor(sampleTypeData, 'Sample Types', 'single'),
       props: { mappingId: 'key' },
       space: 1,
       title: 'Sample Types',
@@ -60,7 +68,7 @@ const SummaryPage = ({
     },
     {
       component: () => '',
-      data: [],
+      data: [], // TODO: donut = 'double'
       space: 1,
       title: 'Primary Sites & Disease Types',
     },

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -40,7 +40,7 @@ const SummaryPage = ({
   const dataDecor = (data, name, setColor = false) => data.map((datum, i) => ({
     ...datum,
     tooltip: Tooltip(name, datum.key, datum.doc_count),
-    ...setColor ? { color: color(i) } : {}
+    ...setColor && { color: color(i) },
   }));
 
   const elementsData = [

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -37,20 +37,16 @@ const SummaryPage = ({
   const experimentalStrategyData = get(viewer, 'explore.cases.aggregations.summary__experimental_strategies__experimental_strategy.buckets', []);
 
   const color = scaleOrdinal(schemeCategory20);
-  const dataDecor = (data, name, donuts = 0) => data.map((datum, i) => ({
+  const dataDecor = (data, name, setColor = false) => data.map((datum, i) => ({
     ...datum,
     tooltip: Tooltip(name, datum.key, datum.doc_count),
-    ...donuts === 1
-      ? { color: color(i) } 
-      : donuts === 2 // TODO. 'Primary Sites & Disease Types'
-        ? { color: 'todo' }
-        : {},
+    ...setColor ? { color: color(i) } : {}
   }));
 
   const elementsData = [
     {
       component: SampleTypeCard,
-      data: dataDecor(sampleTypeData, 'Sample Types', 1),
+      data: dataDecor(sampleTypeData, 'Sample Types', true),
       props: { mappingId: 'key' },
       space: 1,
       title: 'Sample Types',
@@ -67,7 +63,7 @@ const SummaryPage = ({
     },
     {
       component: () => '',
-      data: [], // TODO: donuts = 2
+      data: [],
       space: 1,
       title: 'Primary Sites & Disease Types',
     },

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -37,9 +37,9 @@ const SummaryPage = ({
   const experimentalStrategyData = get(viewer, 'explore.cases.aggregations.summary__experimental_strategies__experimental_strategy.buckets', []);
 
   const color = scaleOrdinal(schemeCategory20);
-  const dataDecor = (data, name, donuts = 0) => data.map((el, i) => ({
-    ...el,
-    tooltip: Tooltip(name, el.key, el.doc_count),
+  const dataDecor = (data, name, donuts = 0) => data.map((datum, i) => ({
+    ...datum,
+    tooltip: Tooltip(name, datum.key, datum.doc_count),
     ...donuts === 1
       ? { color: color(i) } 
       : donuts === 2 // TODO. 'Primary Sites & Disease Types'

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -19,7 +19,7 @@ const Tooltip = (title, key, count) => (
       {count.toLocaleString()}
       {' '}
       case
-      {count > 1 ? '' : 's'}
+      {count > 1 ? 's' : ''}
     </b>
     <br />
 

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -4,8 +4,8 @@ import { scaleOrdinal, schemeCategory20 } from 'd3';
 import HistogramCard from '@ncigdc/components/Explore/SummaryPage/HistogramCard';
 import SampleTypeCard from '@ncigdc/components/Explore/SummaryPage/SampleTypeCard';
 import SummaryPageQuery from '@ncigdc/components/Explore/SummaryPage/SummaryPage.relay';
-import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
+import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import { get } from 'lodash';
 
 const Tooltip = (title, key, count) => (
@@ -19,7 +19,7 @@ const Tooltip = (title, key, count) => (
       {count.toLocaleString()}
       {' '}
       case
-      {count === 1 ? '' : 's'}
+      {count > 1 ? '' : 's'}
     </b>
     <br />
 

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import HistogramCard from '@ncigdc/components/Explore/SummaryPage/HistogramCard';
+import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
+import React from 'react';
 import SampleTypeCard from '@ncigdc/components/Explore/SummaryPage/SampleTypeCard';
 import SummaryPageQuery from '@ncigdc/components/Explore/SummaryPage/SummaryPage.relay';
-import MasonryLayout from '@ncigdc/components/Layouts/MasonryLayout';
-import CardWrapper from '@ncigdc/components/Explore/SummaryPage/CardWrapper';
 import { get } from 'lodash';
 
 const Tooltip = (title, key, count) => (
@@ -49,14 +49,14 @@ const SummaryPage = ({
     },
     {
       component: HistogramCard,
-      data: dataDecor(experimentalStrategyData, 'Data Types'),
+      data: dataDecor(experimentalStrategyData, 'Experimental Strategies'),
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
         xAxisTitle: 'Experimental Strategy',
       },
       space: 1,
-      title: 'Data Types',
+      title: 'Experimental Strategies',
     },
     {
       component: () => '',

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -17,7 +17,7 @@ const Tooltip = (title, key, count) => (
       {count.toLocaleString()}
       {' '}
       case
-      {count > 1 ? 's' : ''}
+      {count === 1 ? '' : 's'}
     </b>
     <br />
 

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -53,7 +53,7 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: 'Experimental Strategy',
+        xAxisTitle: '',
       },
       space: 1,
       title: 'Experimental Strategies',
@@ -87,7 +87,7 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: 'Vital Status',
+        xAxisTitle: '',
       },
       space: 1,
       title: 'Vital Status',
@@ -98,7 +98,7 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: 'Race',
+        xAxisTitle: '',
       },
       space: 1,
       title: 'Race',
@@ -109,7 +109,7 @@ const SummaryPage = ({
       props: {
         mappingLabel: 'key',
         mappingValue: 'doc_count',
-        xAxisTitle: 'Gender',
+        xAxisTitle: '',
       },
       space: 1,
       title: 'Gender',

--- a/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
+++ b/src/packages/@ncigdc/components/Explore/SummaryPage/index.js
@@ -10,19 +10,9 @@ import { get } from 'lodash';
 
 const Tooltip = (title, key, count) => (
   <span>
-    <b>
-      {title}
-      :
-      {' '}
-      {key}
-      <br />
-      {count.toLocaleString()}
-      {' '}
-      case
-      {count > 1 ? 's' : ''}
-    </b>
+    <b>{key}</b>
     <br />
-
+    {`${count} Case${count > 1 ? 's' : ''}`}
   </span>
 );
 const SummaryPage = ({


### PR DESCRIPTION
## Ticket Number

PRTL-2843

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- rename Data Types to Experimental Strategies
- remove redundant X-axis labels (i.e. Race & Gender have the same title & X-axis)
- set default X-axis prop
- for donut charts, create colours and pass them down with data, and add them to TSV
- update `PieChart` to accept data with color info
- remove tooltip from TSV