### PR TITLE
[PRTL-2856] reduce restrictive lifecycle check

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ControlPanel/ControlPanelNode.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ControlPanel/ControlPanelNode.js
@@ -393,13 +393,13 @@ export default compose(
   ),
   lifecycle({
     shouldComponentUpdate({
-      currentAnalysis: { displayVariables: nextDisplayVariables },
+      currentAnalysis: nextCurrentAnalysis,
       searchValue: nextSearchValue,
       totalClinicalAnalysisFields: nextTotalClinicalAnalysisFields,
       totalUsefulFacets: nextTotalUsefulFacets,
     }) {
       const {
-        currentAnalysis: { displayVariables },
+        currentAnalysis,
         searchValue: prevSearchValue,
         totalClinicalAnalysisFields,
         totalUsefulFacets,
@@ -407,7 +407,7 @@ export default compose(
 
       return !(
         nextTotalClinicalAnalysisFields === totalClinicalAnalysisFields &&
-        isEqual(nextDisplayVariables, displayVariables) &&
+        isEqual(nextCurrentAnalysis, currentAnalysis) &&
         nextSearchValue === prevSearchValue &&
         nextTotalUsefulFacets === totalUsefulFacets
       );


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes
This check didn’t account for the current_analysis ID being changed for some unexplainable reason (which is truly a symptom of a deeper problem).
To keep this issue’s scope, I’m just loosening the check. 
The source problem, remains as technical debt.
