### PR TITLE
[PRTL-2840] correct collapse method and state for dbSNP facet

### DIFF
--- a/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
+++ b/src/packages/@ncigdc/components/Aggregations/NotMissingFacet.js
@@ -10,7 +10,7 @@ import { Row, Column } from '@ncigdc/uikit/Flex';
 import CountBubble from '@ncigdc/uikit/CountBubble';
 import styled from '@ncigdc/theme/styled';
 
-import { Container, BucketLink } from './';
+import { Container, BucketLink } from '.';
 
 type TProps = {
   field: string,
@@ -24,8 +24,12 @@ const BucketRow = styled(Row, {
   padding: '0.3rem 0',
 });
 
-const NotMissingFacet = (props: TProps) => {
-  const { collapsed, field, notMissingDocCount, style, title } = props
+const NotMissingFacet = ({
+  field,
+  notMissingDocCount,
+  style,
+  title,
+}: TProps) => {
   const dotField = field.replace(/__/g, '.');
   return (
     <LocationSubscriber>
@@ -35,55 +39,56 @@ const NotMissingFacet = (props: TProps) => {
             parseFilterParam((ctx.query || {}).filters, {}).content) ||
           [];
         return (
-          <Container style={style} className="test-not-missing-facet">
-            {!collapsed && (
-              <Column>
-                <BucketRow>
-                  <BucketLink
-                    merge="toggle"
-                    query={{
-                      offset: 0,
-                      filters: {
-                        op: 'and',
-                        content: [
-                          {
-                            op: 'not',
-                            content: { field: dotField, value: ['missing'] },
+          <Container className="test-not-missing-facet" style={style}>
+            <Column>
+              <BucketRow>
+                <BucketLink
+                  merge="toggle"
+                  query={{
+                    offset: 0,
+                    filters: {
+                      op: 'and',
+                      content: [
+                        {
+                          op: 'not',
+                          content: {
+                            field: dotField,
+                            value: ['missing'],
                           },
-                        ],
-                      },
-                    }}
+                        },
+                      ],
+                    },
+                  }}
                   >
-                    <input
-                      readOnly
-                      type="checkbox"
-                      style={{
-                        pointerEvents: 'none',
-                        marginRight: '5px',
-                        verticalAlign: 'middle',
-                      }}
-                      checked={currentFilters.some(
-                        ({ op, content: { field, value } }) =>
-                          op === 'not' &&
-                          field === dotField &&
-                          value.includes('missing'),
-                      )}
-                      id={`input-${title}-not-missing`}
-                      name={`input-${title}-not-missing`}
+                  <input
+                    checked={currentFilters.some(
+                      ({ content: { field, value }, op }) =>
+                        op === 'not' &&
+                        field === dotField &&
+                        value.includes('missing'),
+                    )}
+                    id={`input-${title}-not-missing`}
+                    name={`input-${title}-not-missing`}
+                    readOnly
+                    style={{
+                      pointerEvents: 'none',
+                      marginRight: '5px',
+                      verticalAlign: 'middle',
+                    }}
+                    type="checkbox"
                     />
-                    <label
-                      htmlFor={`input-${title}-not-missing`}
-                      style={{ verticalAlign: 'middle' }}
+                  <label
+                    htmlFor={`input-${title}-not-missing`}
+                    style={{ verticalAlign: 'middle' }}
                     >
-                      Not Missing
-                    </label>
-                  </BucketLink>
-                  <CountBubble>
-                    {notMissingDocCount.toLocaleString()}
-                  </CountBubble>
-                </BucketRow>
-              </Column>
-            )}
+                    Not Missing
+                  </label>
+                </BucketLink>
+                <CountBubble>
+                  {notMissingDocCount.toLocaleString()}
+                </CountBubble>
+              </BucketRow>
+            </Column>
           </Container>
         );
       }}

--- a/src/packages/@ncigdc/containers/explore/SSMAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/SSMAggregations.js
@@ -198,8 +198,8 @@ export const SSMAggregationsComponent = compose(
         collapsed={props.cosmicIdCollapsed}
         field="ssms.cosmic_id"
         setCollapsed={props.setCosmicIdCollapsed}
-        title="COSMIC ID"
         style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
+        title="COSMIC ID"
         />
       <NotMissingFacet
         collapsed={props.cosmicIdCollapsed}
@@ -208,11 +208,11 @@ export const SSMAggregationsComponent = compose(
         title="COSMIC ID"
         />
       <FacetHeader
-        collapsed={props.cosmicIdCollapsed}
+        collapsed={props.dbSNPCollapsed}
         field="ssms.consequence.transcript.annotation.dbsnp_rs"
-        setCollapsed={props.setCosmicIdCollapsed}
+        setCollapsed={props.setDbSNPCollapsed}
+        style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
         title="dbSNP rs ID"
-        style={{borderTop: `1px solid ${props.theme.greyScale5}`}}
         />
       <NotMissingFacet
         collapsed={props.dbSNPCollapsed}

--- a/src/packages/@ncigdc/containers/explore/SSMAggregations.js
+++ b/src/packages/@ncigdc/containers/explore/SSMAggregations.js
@@ -201,12 +201,13 @@ export const SSMAggregationsComponent = compose(
         style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
         title="COSMIC ID"
         />
-      <NotMissingFacet
-        collapsed={props.cosmicIdCollapsed}
-        field="ssms.cosmic_id"
-        notMissingDocCount={props.ssms.cosmic_id_not_missing.total}
-        title="COSMIC ID"
-        />
+      {props.cosmicIdCollapsed || (
+        <NotMissingFacet
+          field="ssms.cosmic_id"
+          notMissingDocCount={props.ssms.cosmic_id_not_missing.total}
+          title="COSMIC ID"
+          />
+      )}
       <FacetHeader
         collapsed={props.dbSNPCollapsed}
         field="ssms.consequence.transcript.annotation.dbsnp_rs"
@@ -214,12 +215,13 @@ export const SSMAggregationsComponent = compose(
         style={{ borderTop: `1px solid ${props.theme.greyScale5}` }}
         title="dbSNP rs ID"
         />
-      <NotMissingFacet
-        collapsed={props.dbSNPCollapsed}
-        field="ssms.consequence.transcript.annotation.dbsnp_rs"
-        notMissingDocCount={props.ssms.dbsnp_rs_not_missing.total}
-        title="dbSNP rs ID"
-        />
+      {props.dbSNPCollapsed || (
+        <NotMissingFacet
+          field="ssms.consequence.transcript.annotation.dbsnp_rs"
+          notMissingDocCount={props.ssms.dbsnp_rs_not_missing.total}
+          title="dbSNP rs ID"
+          />
+      )}
     </div>
   </div>
 ));


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes
The facets have independent methods per facet, rather than detecting the facet's identifier in a DRY manner. Thus, when adding this facet, the method for cosmic was copy-pasted, without updating the to the right method.