### PR TITLE
[PRTL-2865] revert changes in the category object

### DIFF
--- a/src/packages/@ncigdc/utils/constants.js
+++ b/src/packages/@ncigdc/utils/constants.js
@@ -49,75 +49,43 @@ export const LOCAL_STORAGE_API_OVERRIDE = API_OVERRIDE_KEYS.some(
   k => localStorage[k]
 );
 
-const DATA_CATEGORIES_COMMON = {
-  CNV: {
-    abbr: 'CNV',
-    full: 'Copy Number Variation',
+const DATA_CATEGORIES_COMMON = { // this object is "sorted" on purpose, do not rearrange the keys
+  SEQ: {
+    abbr: 'Seq',
+    full: 'Sequencing Reads',
   },
   EXP: {
     abbr: 'Exp',
     full: 'Transcriptome Profiling',
   },
-  METH: {
-    abbr: 'Meth',
-    full: 'DNA Methylation',
-  },
-  SEQ: {
-    abbr: 'Seq',
-    full: 'Sequencing Reads',
-  },
   SNV: {
     abbr: 'SNV',
     full: 'Simple Nucleotide Variation',
+  },
+  CNV: {
+    abbr: 'CNV',
+    full: 'Copy Number Variation',
+  },
+  METH: {
+    abbr: 'Meth',
+    full: 'DNA Methylation',
   },
 };
 
-export const DATA_CATEGORIES = {
-  CNV: {
-    abbr: 'CNV',
-    full: 'Copy Number Variation',
-  },
-  EXP: {
-    abbr: 'Exp',
-    full: 'Transcriptome Profiling',
-  },
-  METH: {
-    abbr: 'Meth',
-    full: 'DNA Methylation',
-  },
-  SEQ: {
-    abbr: 'Seq',
-    full: 'Sequencing Reads',
-  },
-  SNV: {
-    abbr: 'SNV',
-    full: 'Simple Nucleotide Variation',
-  },
+export const DATA_CATEGORIES = { // this object is "sorted" on purpose, do not rearrange the keys
   ...DATA_CATEGORIES_COMMON,
-  BIOSPECIMEN: {
-    abbr: 'Bio',
-    full: 'Biospecimen',
-  },
   CLINICAL: {
     abbr: 'Clinical',
     full: 'Clinical',
   },
+  BIOSPECIMEN: {
+    abbr: 'Bio',
+    full: 'Biospecimen',
+  },
 };
 
-export const DATA_CATEGORIES_FOR_PROJECTS_TABLE = {
+export const DATA_CATEGORIES_FOR_PROJECTS_TABLE = { // this object is "sorted" on purpose, do not rearrange the keys
   ...DATA_CATEGORIES_COMMON,
-  BIOSPECIMEN_METADATA: {
-    abbr: 'Bio',
-    full: '',
-    hasTotalLink: false,
-    tooltip: 'Biospecimen Metadata',
-  },
-  BIOSPECIMEN_SUPPLEMENT: {
-    abbr: 'Bio Supplement',
-    dataCategory: 'Bio',
-    full: 'Biospecimen',
-    tooltip: 'Biospecimen Supplement',
-  },
   CLINICAL_METADATA: {
     abbr: 'Clinical',
     full: '',
@@ -129,6 +97,18 @@ export const DATA_CATEGORIES_FOR_PROJECTS_TABLE = {
     dataCategory: 'Clinical',
     full: 'Clinical',
     tooltip: 'Clinical Supplement',
+  },
+  BIOSPECIMEN_METADATA: {
+    abbr: 'Bio',
+    full: '',
+    hasTotalLink: false,
+    tooltip: 'Biospecimen Metadata',
+  },
+  BIOSPECIMEN_SUPPLEMENT: {
+    abbr: 'Bio Supplement',
+    dataCategory: 'Bio',
+    full: 'Biospecimen',
+    tooltip: 'Biospecimen Supplement',
   },
 };
 


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes
Reverts the "sorting" of the object keys, as the view relies on this faux-order to display some rows and columns in a couple tables.
Must implement an appropriate sorting solution at a later stage.