### PR TITLE
[PRTL-2870] download all svg/png

### DIFF
--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -127,7 +127,7 @@ const SurvivalPlotWrapper = ({
 }: TProps) => {
   const { results = [], overallStats = {} } = rawData || {};
   const { pValue } = overallStats;
-  const plotName = slug || uniqueClass;
+  const plotName = slug === '' ? uniqueClass : slug;
   return (
     <Loader
       className={plotName}

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -127,9 +127,10 @@ const SurvivalPlotWrapper = ({
 }: TProps) => {
   const { results = [], overallStats = {} } = rawData || {};
   const { pValue } = overallStats;
+  const plotName = slug || uniqueClass;
   return (
     <Loader
-      className={uniqueClass}
+      className={plotName}
       height={height}
       loading={survivalPlotLoading}
       >
@@ -147,10 +148,10 @@ const SurvivalPlotWrapper = ({
                 }))}
                 key="download"
                 noText
-                slug={slug || uniqueClass}
+                slug={plotName}
                 stylePrefix={`.${CLASS_NAME}`}
                 svg={() => wrapSvg({
-                  selector: `.${uniqueClass} .${CLASS_NAME} svg`,
+                  selector: `.${plotName} .${CLASS_NAME} svg`,
                   title: plotType === 'mutation' ? TITLE : '',
                   className: CLASS_NAME,
                   embed: {
@@ -158,7 +159,7 @@ const SurvivalPlotWrapper = ({
                       elements: legend
                         .map((l, i) => {
                           const legendItem = document.querySelector(
-                            `.${uniqueClass} .legend-${i}`
+                            `.${plotName} .legend-${i}`
                           ).cloneNode(true);
                           const legendTitle = legendItem.querySelector('span.print-only.inline');
                           if (legendTitle !== null) legendTitle.className = '';
@@ -167,7 +168,7 @@ const SurvivalPlotWrapper = ({
                         .concat(
                           pValue
                             ? document.querySelector(
-                              `.${uniqueClass} .p-value`
+                              `.${plotName} .p-value`
                             )
                             : null
                         ),
@@ -207,7 +208,7 @@ const SurvivalPlotWrapper = ({
               {legend &&
                 legend.map((l, i) => (
                   <div
-                    className={`legend-${i}`}
+                    className={`legend-item legend-${i}`}
                     key={l.key}
                     style={l.style || {}}
                     >

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -147,7 +147,7 @@ const SurvivalPlotWrapper = ({
                 }))}
                 key="download"
                 noText
-                slug={slug || 'survival-plot'}
+                slug={slug || uniqueClass}
                 stylePrefix={`.${CLASS_NAME}`}
                 svg={() => wrapSvg({
                   selector: `.${uniqueClass} .${CLASS_NAME} svg`,

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -124,7 +124,6 @@ const SurvivalPlotWrapper = ({
   ],
   plotType,
   slug = '',
-  buttonStyle,
 }: TProps) => {
   const { results = [], overallStats = {} } = rawData || {};
   const { pValue } = overallStats;

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -123,6 +123,7 @@ const SurvivalPlotWrapper = ({
     textColors[4],
   ],
   plotType,
+  slug = '',
 }: TProps) => {
   const { results = [], overallStats = {} } = rawData || {};
   const { pValue } = overallStats;
@@ -146,7 +147,7 @@ const SurvivalPlotWrapper = ({
                 }))}
                 key="download"
                 noText
-                slug="survival-plot"
+                slug={slug || 'survival-plot'}
                 stylePrefix={`.${CLASS_NAME}`}
                 svg={() => wrapSvg({
                   selector: `.${uniqueClass} .${CLASS_NAME} svg`,

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -139,6 +139,8 @@ const ClinicalAnalysisResult = ({
 }: IAnalysisResultProps) => {
   const downloadSlugs = getDownloadSlugs(displayVariables);
 
+  const getHistogram = getHistogramDownload('gender');
+
   return hits.total === 0
     ? (
       <DeprecatedSetResult
@@ -241,8 +243,8 @@ const ClinicalAnalysisResult = ({
 
                   return chartType === 'box'
                     ? []
-                    // : chartType === 'histogram'
-                    //   ? acc.concat(() => wrapSvg(getHistogramDownload(slug)))
+                    : chartType === 'histogram'
+                      ? acc.concat(() => wrapSvg(getHistogramDownload(fieldName, slug)))
                       : chartType === 'survival'
                         ? acc.concat(() => wrapSvg(getSurvivalDownload(slug)))
                         : [];

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -40,8 +40,8 @@ import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 import DeprecatedSetResult from './DeprecatedSetResult';
 import { 
   getMaxKeyNameLength,
-  makeDownloadSlugs,
-  makeDownloadSvgs,
+  getDownloadSlugs,
+  getDownloadSvgs,
   OVERALL_SURVIVAL_SLUG,
   PLOT_TYPES,
 } from './helpers';
@@ -138,8 +138,8 @@ const ClinicalAnalysisResult = ({
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
   // TODO: get slugs & svgs
-  const downloadSlugs = makeDownloadSlugs(displayVariables);
-  const downloadSvgs = makeDownloadSvgs(displayVariables);
+  const downloadSlugs = getDownloadSlugs(displayVariables);
+  const downloadSvgs = getDownloadSvgs(displayVariables);
   console.log('downloadSvgs', downloadSvgs);
   console.log('downloadSlugs', downloadSlugs);
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -24,7 +24,6 @@ import DownloadVisualizationButton from '@ncigdc/components/DownloadVisualizatio
 import CopyIcon from '@ncigdc/theme/icons/Copy';
 import Hidden from '@ncigdc/components/Hidden';
 import { visualizingButton, zDepth1 } from '@ncigdc/theme/mixins';
-import { humanify } from '@ncigdc/utils/string';
 
 import Input from '@ncigdc/uikit/Form/Input';
 import {
@@ -39,6 +38,13 @@ import tryParseJSON from '@ncigdc/utils/tryParseJSON';
 import { getDefaultCurve } from '@ncigdc/utils/survivalplot';
 import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 import DeprecatedSetResult from './DeprecatedSetResult';
+import { 
+  getMaxKeyNameLength,
+  makeDownloadSlugs,
+  makeDownloadSvgs,
+  OVERALL_SURVIVAL_SLUG,
+  PLOT_TYPES,
+} from './helpers';
 import './print.css';
 import './survivalPlot.css';
 
@@ -54,75 +60,6 @@ interface IAnalysisResultProps {
   Icon: () => React.Component<any>;
   analysis: any;
 }
-
-const plotTypes = {
-  categorical: ['histogram', 'survival'],
-  continuous: [
-    'histogram',
-    'survival',
-    'box',
-  ],
-};
-
-const makeDownloadSlugs = displayVariables => Object.keys(displayVariables)
-  .map(dVar => {
-    const fieldName = dVar.split('.')[1];
-    const chart = displayVariables[dVar].active_chart;
-    return chart === 'histogram'
-      ? `${fieldName}-bar-chart`
-      : chart === 'survival'
-        ? 'survival-plot'
-        : [`qq-plot-${fieldName}`, `boxplot-${fieldName}`];
-  }).reduce((acc, curr) => acc.concat(curr), []);
-
-const getMaxKeyNameLength = bins => (
-  maxBy(bins, item => item.length) || ''
-).length;
-
-const makeDownloadSvgs = displayVariables => Object.keys(displayVariables)
-  .reduce((acc, curr) => {
-    const fieldName = curr.split('.')[1];
-    const chart = displayVariables[curr].active_chart;
-
-    if (chart === 'histogram') {
-      const bins = Object.keys(displayVariables[curr].bins);
-      const maxKeyNameLength = getMaxKeyNameLength(bins);
-      return acc.concat({
-        bottomBuffer: maxKeyNameLength * 3,
-        rightBuffer: maxKeyNameLength * 2, 
-        selector: `#${fieldName}-chart-container .test-bar-chart svg`,
-        title: humanify({ term: fieldName }),
-      });
-    } else if (chart === 'survival') {
-      return acc.concat({
-        selector: `.survival-plot .survival-plot svg`,
-        title: '',
-        // embed: {
-        //   top: {
-        //     elements: legend
-        //       .map((l, i) => {
-        //         const legendItem = document.querySelector(
-        //           `.survivalPlot .legend-${i}`
-        //         ).cloneNode(true);
-        //         const legendTitle = legendItem.querySelector('span.print-only.inline');
-        //         if (legendTitle !== null) legendTitle.className = '';
-        //         return legendItem;
-        //       })
-        //       .concat(
-        //         pValue
-        //           ? document.querySelector(
-        //             `.${uniqueClass} .p-value`
-        //           )
-        //           : null
-        //       ),
-        //   },
-        // },
-      })
-    } else if (chart === 'box') {
-      // console.log('box');
-      return acc;
-    }
-  }, []);
 
 const CopyAnalysisModal = compose(
   setDisplayName('EnhancedCopyAnalysisModal'),
@@ -204,6 +141,7 @@ const ClinicalAnalysisResult = ({
   const downloadSlugs = makeDownloadSlugs(displayVariables);
   const downloadSvgs = makeDownloadSvgs(displayVariables);
   console.log('downloadSvgs', downloadSvgs);
+  console.log('downloadSlugs', downloadSlugs);
 
   return hits.total === 0
     ? (
@@ -378,8 +316,9 @@ const ClinicalAnalysisResult = ({
                     {...overallSurvivalData}
                     height={430}
                     plotType="clinicalOverall"
+                    slug={OVERALL_SURVIVAL_SLUG}
                     survivalPlotLoading={survivalPlotLoading}
-                    uniqueClass="clinical-survival-plot"
+                    uniqueClass={OVERALL_SURVIVAL_SLUG}
                     />
                 </div>
               </Column>
@@ -408,7 +347,7 @@ const ClinicalAnalysisResult = ({
                       id={id}
                       key={varFieldName}
                       overallSurvivalData={overallSurvivalData}
-                      plots={plotTypes[varProperties.plotTypes || 'categorical']}
+                      plots={PLOT_TYPES[varProperties.plotTypes || 'categorical']}
                       setId={setId}
                       stats={parsedFacets[varFieldName].stats}
                       style={{ minWidth: controlPanelExpanded ? 310 : 290 }}
@@ -428,7 +367,7 @@ const ClinicalAnalysisResult = ({
                       id={id}
                       key={varFieldName}
                       overallSurvivalData={overallSurvivalData}
-                      plots={plotTypes[varProperties.plotTypes || 'categorical']}
+                      plots={PLOT_TYPES[varProperties.plotTypes || 'categorical']}
                       setId={setId}
                       style={{ minWidth: controlPanelExpanded ? 310 : 290 }}
                       variable={varProperties}

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -18,9 +18,7 @@ import {
 import { Row, Column } from '@ncigdc/uikit/Flex';
 import Button from '@ncigdc/uikit/Button';
 import { Tooltip } from '@ncigdc/uikit/Tooltip';
-import {
-  PrintIcon,
-} from '@ncigdc/theme/icons';
+import DownloadVisualizationButton from '@ncigdc/components/DownloadVisualizationButton';
 import CopyIcon from '@ncigdc/theme/icons/Copy';
 import Hidden from '@ncigdc/components/Hidden';
 import { visualizingButton, zDepth1 } from '@ncigdc/theme/mixins';
@@ -221,20 +219,29 @@ const ClinicalAnalysisResult = ({
               >
               Copy Analysis
             </Button>
-            <Tooltip Component={<span>Print</span>}>
-              <Button
-                onClick={() => {
-                  window.print();
-                }}
-                style={{
-                  ...visualizingButton,
-                  height: '100%',
-                }}
-                >
-                <PrintIcon />
-                <Hidden>Print</Hidden>
-              </Button>
-            </Tooltip>
+            <DownloadVisualizationButton
+              noText
+              // TODO: get all slugs
+              // slug={[`qq-plot-${fieldName}`, `boxplot-${fieldName}`]}
+              buttonStyle={{
+                ...visualizingButton,
+                height: '100%',
+              }}
+              // TODO: get all SVGs
+              svg={[
+                // () => wrapSvg({
+                //   className: 'qq-plot',
+                //   selector: `#${wrapperId}-qqplot-container .qq-plot svg`,
+                //   title: `${humanify({ term: fieldName })} QQ Plot`,
+                // }),
+                // () => wrapSvg({
+                //   className: `${type.toLowerCase()}-boxplot`,
+                //   selector: `#${wrapperId}-boxplot-container figure svg`,
+                //   title: `${humanify({ term: fieldName })} Box Plot`,
+                // }),
+              ]}
+              tooltipHTML="Download all images"
+              />
           </Row>
         </Row>
         <Row>

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -139,6 +139,10 @@ const ClinicalAnalysisResult = ({
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
   const downloadSlugs = getDownloadSlugs(displayVariables);
+
+  console.log('downloadSlugs', downloadSlugs);
+
+  // console.log('boxDl', boxDl);
   return hits.total === 0
     ? (
       <DeprecatedSetResult
@@ -235,15 +239,21 @@ const ClinicalAnalysisResult = ({
                   const chartType = displayVariables[dVar].active_chart;
                   const slug = downloadSlugs[i+1]; // offset by 1, because the slug for overall survival is at 0 index
 
-                  return ['box', 'histogram', 'survival'].includes(chartType)
-                    ? acc.concat(() => wrapSvg(
-                      chartType === 'box'
-                        ? getBoxQQDownload(fieldName, slug)
-                        : chartType === 'histogram'
-                          ? getHistogramDownload(fieldName, slug)
-                          : getSurvivalDownload(slug)
-                      ))
-                    : acc;
+                  return [
+                    ...acc,
+                    ...['box', 'histogram', 'survival'].includes(chartType) &&
+                      [() => wrapSvg(
+                        chartType === 'box'
+                          ? getBoxQQDownload(fieldName, 'Box')
+                          : chartType === 'histogram'
+                            ? getHistogramDownload(fieldName, slug)
+                            : getSurvivalDownload(slug)
+                      )],
+                    ...chartType === 'box' &&
+                      [() => wrapSvg(
+                        getBoxQQDownload(fieldName, 'QQ')
+                      )],
+                  ];
                 }, 
                 [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))]
               )}

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -41,9 +41,9 @@ import DeprecatedSetResult from './DeprecatedSetResult';
 import { 
   getMaxKeyNameLength,
   getDownloadSlugs,
-  getDownloadSvgs,
   OVERALL_SURVIVAL_SLUG,
   PLOT_TYPES,
+  getSurvivalDownload,
 } from './helpers';
 import './print.css';
 import './survivalPlot.css';
@@ -137,18 +137,7 @@ const ClinicalAnalysisResult = ({
   setId,
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
-  // TODO: get slugs & svgs
   const downloadSlugs = getDownloadSlugs(displayVariables);
-  const downloadSvgs = getDownloadSvgs(displayVariables);
-  console.log('downloadSvgs elements', downloadSvgs[0].embed.top.elements);
-  // console.log('downloadSlugs', downloadSlugs);
-
-  const testing = Array.prototype.map.call(
-    document.querySelectorAll(`.age_at_diagnosis-survival-plot .legend-item`), (l, i) => i);
-  const testing2 = Array.prototype.map.call(
-    document.querySelectorAll(`.age_at_diagnosis-survival-plot .legend-item`), element => element);
-    console.log('testing', testing);
-    console.log('testing2', testing2);
 
   return hits.total === 0
     ? (
@@ -240,50 +229,14 @@ const ClinicalAnalysisResult = ({
                 ...visualizingButton,
                 height: '100%',
               }}
-              // TODO: get all SVGs
-              // onClick={() => 
-              //   getDownloadSvgs(displayVariables)
-              //   .map(dSvg => () => wrapSvg(dSvg))
-              // }
-              // svg={getDownloadSvgs(displayVariables)
-              //   .map(dSvg => () => wrapSvg(dSvg))
-              // }
-              svg={[
-                () => wrapSvg({
-                  className: 'survival-plot',
-                  selector: `.age_at_diagnosis-survival-plot .survival-plot svg`,
-                  slug: 'age_at_diagnosis-survival-plot',
-                  title: '',
-                  embed: {
-                    top: {
-                      elements: [...document.querySelectorAll('.age_at_diagnosis-survival-plot .legend-item')].map((l, i) => {
-                          const legendItem = document.querySelector(
-                            `.age_at_diagnosis-survival-plot .legend-${i}`
-                          ).cloneNode(true);
-                          const legendTitle = legendItem.querySelector('span.print-only.inline');
-                          if (legendTitle !== null) legendTitle.className = '';
-                          console.log('legendItem', legendTitle, legendItem);
-                          console.log('BOOP')
-                          // return 'BOOP';
-                          return legendItem;
-                        })
-                        .concat(document.querySelector(`.age_at_diagnosis-survival-plot .p-value`) || []),
-                    },
-                  },
-                })
-              ]}
-              // svg={[
-                // () => wrapSvg({
-                //   className: 'qq-plot',
-                //   selector: `#${wrapperId}-qqplot-container .qq-plot svg`,
-                //   title: `${humanify({ term: fieldName })} QQ Plot`,
-                // }),
-                // () => wrapSvg({
-                //   className: `${type.toLowerCase()}-boxplot`,
-                //   selector: `#${wrapperId}-boxplot-container figure svg`,
-                //   title: `${humanify({ term: fieldName })} Box Plot`,
-                // }),
-              // ]}
+              svg={Object.keys(displayVariables).reduce((acc, dVar) => {
+                const fieldName = dVar.split('.')[1];
+                const chartType = displayVariables[dVar].active_chart;
+
+                return chartType === 'survival'
+                  ? acc.concat(() => wrapSvg(getSurvivalDownload(fieldName)))
+                  : acc;
+              }, [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))])}
               tooltipHTML="Download all images"
               />
           </Row>

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -39,6 +39,7 @@ import { getDefaultCurve } from '@ncigdc/utils/survivalplot';
 import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 import DeprecatedSetResult from './DeprecatedSetResult';
 import {
+  getBoxQQDownload,
   getDownloadSlugs,
   getHistogramDownload,
   getSurvivalDownload,
@@ -138,9 +139,6 @@ const ClinicalAnalysisResult = ({
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
   const downloadSlugs = getDownloadSlugs(displayVariables);
-
-  const getHistogram = getHistogramDownload('gender');
-
   return hits.total === 0
     ? (
       <DeprecatedSetResult
@@ -237,16 +235,15 @@ const ClinicalAnalysisResult = ({
                   const chartType = displayVariables[dVar].active_chart;
                   const slug = downloadSlugs[i+1]; // offset by 1, because the slug for overall survival is at 0 index
 
-                  // need to repeat `() => wrapSvg(...)` or survival legend
-                  // will not get picked up by wrapSvg
-
-                  return chartType === 'box'
-                    ? []
-                    : chartType === 'histogram'
-                      ? acc.concat(() => wrapSvg(getHistogramDownload(fieldName, slug)))
-                      : chartType === 'survival'
-                        ? acc.concat(() => wrapSvg(getSurvivalDownload(slug)))
-                        : [];
+                  return ['box', 'histogram', 'survival'].includes(chartType)
+                    ? acc.concat(() => wrapSvg(
+                      chartType === 'box'
+                        ? getBoxQQDownload(fieldName, slug)
+                        : chartType === 'histogram'
+                          ? getHistogramDownload(fieldName, slug)
+                          : getSurvivalDownload(slug)
+                      ))
+                    : acc;
                 }, 
                 [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))]
               )}

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -38,12 +38,12 @@ import tryParseJSON from '@ncigdc/utils/tryParseJSON';
 import { getDefaultCurve } from '@ncigdc/utils/survivalplot';
 import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 import DeprecatedSetResult from './DeprecatedSetResult';
-import { 
-  getMaxKeyNameLength,
+import {
   getDownloadSlugs,
+  getHistogramDownload,
+  getSurvivalDownload,
   OVERALL_SURVIVAL_SLUG,
   PLOT_TYPES,
-  getSurvivalDownload,
 } from './helpers';
 import './print.css';
 import './survivalPlot.css';
@@ -229,15 +229,26 @@ const ClinicalAnalysisResult = ({
                 ...visualizingButton,
                 height: '100%',
               }}
-              svg={Object.keys(displayVariables).reduce((acc, dVar) => {
-                const fieldName = dVar.split('.')[1];
-                const chartType = displayVariables[dVar].active_chart;
-                const survivalSlug = `${fieldName}-survival-plot`;
+              svg={Object.keys(displayVariables).sort()
+                .reduce((acc, dVar, i) => {
+                  const fieldName = dVar.split('.')[1];
+                  const chartType = displayVariables[dVar].active_chart;
+                  const slug = downloadSlugs[i+1]; // offset by 1, because the slug for overall survival is at 0 index
+                  console.log('slug', slug);
 
-                return chartType === 'survival'
-                  ? acc.concat(() => wrapSvg(getSurvivalDownload(survivalSlug)))
-                  : acc;
-              }, [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))])}
+                  // need to repeat `() => wrapSvg(...)` or survival legend
+                  // will not get picked up by wrapSvg
+
+                  return chartType === 'box'
+                    ? []
+                    // : chartType === 'histogram'
+                    //   ? acc.concat(() => wrapSvg(getHistogramDownload(slug)))
+                      : chartType === 'survival'
+                        ? acc.concat(() => wrapSvg(getSurvivalDownload(slug)))
+                        : [];
+                }, 
+                [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))]
+              )}
               tooltipHTML="Download all images"
               />
           </Row>

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -142,6 +142,11 @@ const ClinicalAnalysisResult = ({
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
   const downloadSvgInfo = Object.keys(displayVariables).sort()
+    .filter(dVar => {
+      const bins = displayVariables[dVar].bins;
+      return !(bins === undefined ||
+          Object.keys(bins).filter(key => key !== '_missing').length === 0);
+    })
     .map(dVar => {
       const fieldName = dVar.split('.')[1];
       const { active_chart: chart, type, } = displayVariables[dVar];

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -49,6 +49,8 @@ import {
 } from './helpers';
 import './print.css';
 import './survivalPlot.css';
+import './boxplot.css';
+import './qq.css';
 
 import ControlPanel from './ControlPanel';
 import ContinuousAggregationQuery from './ContinuousAggregationQuery';
@@ -142,9 +144,9 @@ const ClinicalAnalysisResult = ({
   const downloadSvgInfo = Object.keys(displayVariables).sort()
     .map(dVar => {
       const fieldName = dVar.split('.')[1];
-      const chartType = displayVariables[dVar].active_chart;
-      const slug = getDownloadSlug(chartType, fieldName);
-      return { chartType, fieldName, slug };
+      const { active_chart: chart, type, } = displayVariables[dVar];
+      const slug = getDownloadSlug(chart, fieldName);
+      return { chart, fieldName, slug, type };
     });
   return hits.total === 0
     ? (
@@ -237,19 +239,19 @@ const ClinicalAnalysisResult = ({
                 height: '100%',
               }}
               svg={downloadSvgInfo
-                .reduce((acc, { chartType, fieldName, slug }) => ([
+                .reduce((acc, { chart, fieldName, slug, type }) => ([
                   ...acc,
-                  ...['box', 'histogram', 'survival'].includes(chartType) &&
+                  ...['box', 'histogram', 'survival'].includes(chart) &&
                     [() => wrapSvg(
-                      chartType === 'box'
-                        ? getBoxQQDownload(fieldName, 'Box')
-                        : chartType === 'histogram'
+                      chart === 'box'
+                        ? getBoxQQDownload(fieldName, 'Box', type)
+                        : chart === 'histogram'
                           ? getHistogramDownload(fieldName)
                           : getSurvivalDownload(slug)
                     )],
-                  ...chartType === 'box' &&
+                  ...chart === 'box' &&
                     [() => wrapSvg(
-                      getBoxQQDownload(fieldName, 'QQ')
+                      getBoxQQDownload(fieldName, 'QQ', type)
                     )],
                 ]), 
                 [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))]

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -236,7 +236,6 @@ const ClinicalAnalysisResult = ({
                   const fieldName = dVar.split('.')[1];
                   const chartType = displayVariables[dVar].active_chart;
                   const slug = downloadSlugs[i+1]; // offset by 1, because the slug for overall survival is at 0 index
-                  console.log('slug', slug);
 
                   // need to repeat `() => wrapSvg(...)` or survival legend
                   // will not get picked up by wrapSvg

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -42,6 +42,7 @@ import {
   getBoxQQDownload,
   getDownloadSlug,
   getDownloadSlugArray,
+  getDownloadSvgInfo,
   getHistogramDownload,
   getSurvivalDownload,
   OVERALL_SURVIVAL_SLUG,
@@ -141,18 +142,7 @@ const ClinicalAnalysisResult = ({
   setId,
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
-  const downloadSvgInfo = Object.keys(displayVariables).sort()
-    .filter(dVar => {
-      const bins = displayVariables[dVar].bins;
-      return !(bins === undefined ||
-          Object.keys(bins).filter(key => key !== '_missing').length === 0);
-    })
-    .map(dVar => {
-      const fieldName = dVar.split('.')[1];
-      const { active_chart: chart, type, } = displayVariables[dVar];
-      const slug = getDownloadSlug(chart, fieldName);
-      return { chart, fieldName, slug, type };
-    });
+  const downloadSvgInfo = getDownloadSvgInfo(displayVariables);
   return hits.total === 0
     ? (
       <DeprecatedSetResult

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -232,9 +232,10 @@ const ClinicalAnalysisResult = ({
               svg={Object.keys(displayVariables).reduce((acc, dVar) => {
                 const fieldName = dVar.split('.')[1];
                 const chartType = displayVariables[dVar].active_chart;
+                const survivalSlug = `${fieldName}-survival-plot`;
 
                 return chartType === 'survival'
-                  ? acc.concat(() => wrapSvg(getSurvivalDownload(fieldName)))
+                  ? acc.concat(() => wrapSvg(getSurvivalDownload(survivalSlug)))
                   : acc;
               }, [() => wrapSvg(getSurvivalDownload(OVERALL_SURVIVAL_SLUG))])}
               tooltipHTML="Download all images"

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import {
   isEqual,
   map,
+  mapKeys,
   trim,
 } from 'lodash';
 
@@ -59,6 +60,18 @@ const plotTypes = {
     'box',
   ],
 };
+
+const makeDownloadSlugs = displayVariables => Object.keys(displayVariables)
+  .map(dVar => {
+    const fieldName = dVar.split('.')[1];
+    const chart = displayVariables[dVar].active_chart;
+
+    return chart === 'histogram'
+      ? `${fieldName}-bar-chart`
+      : chart === 'survival'
+        ? 'survival-plot'
+        : [`qq-plot-${fieldName}`, `boxplot-${fieldName}`];
+  }).reduce((acc, curr) => acc.concat(curr), []);
 
 const CopyAnalysisModal = compose(
   setDisplayName('EnhancedCopyAnalysisModal'),
@@ -136,6 +149,9 @@ const ClinicalAnalysisResult = ({
   setId,
   survivalPlotLoading,
 }: IAnalysisResultProps) => {
+  // TODO: get slugs & svgs
+  const downloadSlugs = makeDownloadSlugs(displayVariables);
+
   return hits.total === 0
     ? (
       <DeprecatedSetResult
@@ -221,8 +237,7 @@ const ClinicalAnalysisResult = ({
             </Button>
             <DownloadVisualizationButton
               noText
-              // TODO: get all slugs
-              // slug={[`qq-plot-${fieldName}`, `boxplot-${fieldName}`]}
+              slug={downloadSlugs}
               buttonStyle={{
                 ...visualizingButton,
                 height: '100%',

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -140,8 +140,15 @@ const ClinicalAnalysisResult = ({
   // TODO: get slugs & svgs
   const downloadSlugs = getDownloadSlugs(displayVariables);
   const downloadSvgs = getDownloadSvgs(displayVariables);
-  console.log('downloadSvgs', downloadSvgs);
-  console.log('downloadSlugs', downloadSlugs);
+  console.log('downloadSvgs elements', downloadSvgs[0].embed.top.elements);
+  // console.log('downloadSlugs', downloadSlugs);
+
+  const testing = Array.prototype.map.call(
+    document.querySelectorAll(`.age_at_diagnosis-survival-plot .legend-item`), (l, i) => i);
+  const testing2 = Array.prototype.map.call(
+    document.querySelectorAll(`.age_at_diagnosis-survival-plot .legend-item`), element => element);
+    console.log('testing', testing);
+    console.log('testing2', testing2);
 
   return hits.total === 0
     ? (
@@ -234,9 +241,37 @@ const ClinicalAnalysisResult = ({
                 height: '100%',
               }}
               // TODO: get all SVGs
-              svg={downloadSvgs
-                .map(dSvg => () => wrapSvg(dSvg))
-              }
+              // onClick={() => 
+              //   getDownloadSvgs(displayVariables)
+              //   .map(dSvg => () => wrapSvg(dSvg))
+              // }
+              // svg={getDownloadSvgs(displayVariables)
+              //   .map(dSvg => () => wrapSvg(dSvg))
+              // }
+              svg={[
+                () => wrapSvg({
+                  className: 'survival-plot',
+                  selector: `.age_at_diagnosis-survival-plot .survival-plot svg`,
+                  slug: 'age_at_diagnosis-survival-plot',
+                  title: '',
+                  embed: {
+                    top: {
+                      elements: [...document.querySelectorAll('.age_at_diagnosis-survival-plot .legend-item')].map((l, i) => {
+                          const legendItem = document.querySelector(
+                            `.age_at_diagnosis-survival-plot .legend-${i}`
+                          ).cloneNode(true);
+                          const legendTitle = legendItem.querySelector('span.print-only.inline');
+                          if (legendTitle !== null) legendTitle.className = '';
+                          console.log('legendItem', legendTitle, legendItem);
+                          console.log('BOOP')
+                          // return 'BOOP';
+                          return legendItem;
+                        })
+                        .concat(document.querySelector(`.age_at_diagnosis-survival-plot .p-value`) || []),
+                    },
+                  },
+                })
+              ]}
               // svg={[
                 // () => wrapSvg({
                 //   className: 'qq-plot',

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -321,7 +321,6 @@ const ClinicalAnalysisResult = ({
                     plotType="clinicalOverall"
                     slug={OVERALL_SURVIVAL_SLUG}
                     survivalPlotLoading={survivalPlotLoading}
-                    uniqueClass={OVERALL_SURVIVAL_SLUG}
                     />
                 </div>
               </Column>

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
@@ -230,6 +230,10 @@ const ClinicalVariableCard = ({
       .map(d => d.fullLabel), (item) => item.length) || ''
   ).length;
 
+  // console.log('histogramData', histogramData.map(d => d.fullLabel))
+
+  // console.log('maxKeyNameLength', maxKeyNameLength);
+
   const tsvSubstring = fieldName.replace(/\./g, '-');
   const cardFilters = getCardFilters(
     variable.plotTypes, selectedBins, fieldName, filters

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
@@ -230,10 +230,6 @@ const ClinicalVariableCard = ({
       .map(d => d.fullLabel), (item) => item.length) || ''
   ).length;
 
-  // console.log('histogramData', histogramData.map(d => d.fullLabel))
-
-  // console.log('maxKeyNameLength', maxKeyNameLength);
-
   const tsvSubstring = fieldName.replace(/\./g, '-');
   const cardFilters = getCardFilters(
     variable.plotTypes, selectedBins, fieldName, filters

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ClinicalVariableCard.js
@@ -241,6 +241,8 @@ const ClinicalVariableCard = ({
   const disabledCharts = plotType => isEmpty(tableData) &&
     plotType !== 'delete';
 
+  const downloadChartName = fieldName.split('.')[1];
+
   return (
     <Column
       className="clinical-analysis-card"
@@ -371,7 +373,7 @@ const ClinicalVariableCard = ({
                       onClick={(e) => {
                         e.preventDefault();
                       }}
-                      slug={`${fieldName}-bar-chart`}
+                      slug={`${downloadChartName}-bar-chart`}
                       style={{
                         float: 'right',
                         marginRight: 2,
@@ -391,6 +393,7 @@ const ClinicalVariableCard = ({
               {variable.active_chart === 'histogram' && (
                 <ClinicalHistogram
                   active_calculation={variable.active_calculation}
+                  downloadChartName={downloadChartName}
                   histogramData={histogramData}
                   histogramStyles={styles.histogram}
                   theme={theme}
@@ -400,6 +403,7 @@ const ClinicalVariableCard = ({
 
               {variable.active_chart === 'survival' && (
                 <ClinicalSurvivalPlot
+                  downloadChartName={downloadChartName}
                   plotType={selectedSurvivalBins.length === 0
                     ? 'clinicalOverall'
                     : 'categorical'}
@@ -415,6 +419,7 @@ const ClinicalVariableCard = ({
                   boxPlotValues={boxPlotValues}
                   cardFilters={cardFilters}
                   dataBuckets={dataBuckets}
+                  downloadChartName={downloadChartName}
                   fieldName={fieldName}
                   qqData={qqData}
                   setId={setId}

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
@@ -23,6 +23,7 @@ const ClinicalBoxPlot = ({
   boxPlotValues,
   cardFilters,
   dataBuckets,
+  downloadChartName,
   fieldName,
   qqData,
   setId,
@@ -30,7 +31,7 @@ const ClinicalBoxPlot = ({
   setQQDataIsSet,
   theme,
   totalDocs,
-  type,
+  type = '',
   wrapperId,
 }) => (
   <Column
@@ -81,7 +82,10 @@ const ClinicalBoxPlot = ({
         <DownloadVisualizationButton
           data={qqData}
           noText
-          slug={[`qq-plot-${fieldName}`, `boxplot-${fieldName}`]}
+          slug={[
+            `${downloadChartName}-qq-plot`,
+            `${downloadChartName}-box-plot`,
+          ]}
           style={{
             float: 'right',
             marginRight: 2,
@@ -89,12 +93,12 @@ const ClinicalBoxPlot = ({
           svg={[
             () => wrapSvg({
               className: 'qq-plot',
-              selector: `#${wrapperId}-qqplot-container .qq-plot svg`,
+              selector: `#${downloadChartName}-qqplot-container .qq-plot svg`,
               title: `${humanify({ term: fieldName })} QQ Plot`,
             }),
             () => wrapSvg({
               className: `${type.toLowerCase()}-boxplot`,
-              selector: `#${wrapperId}-boxplot-container figure svg`,
+              selector: `#${downloadChartName}-box-plot-container figure svg`,
               title: `${humanify({ term: fieldName })} Box Plot`,
             }),
           ]}
@@ -110,7 +114,7 @@ const ClinicalBoxPlot = ({
       }}
       >
       <Column
-        id={`${wrapperId}-boxplot-container`}
+        id={`${downloadChartName}-box-plot-container`}
         style={{
           height: CHART_HEIGHT + 10,
           maxHeight: CHART_HEIGHT + 10,
@@ -126,7 +130,7 @@ const ClinicalBoxPlot = ({
         </TooltipInjector>
       </Column>
       <Column
-        id={`${wrapperId}-qqplot-container`}
+        id={`${downloadChartName}-qq-plot-container`}
         style={{
           height: CHART_HEIGHT + 10,
           maxHeight: CHART_HEIGHT + 10,

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
@@ -13,9 +13,6 @@ import QQPlotQuery from '@ncigdc/modern_components/QQPlot/QQPlotQuery';
 
 import { CHART_HEIGHT } from '../helpers';
 
-import '../../boxplot.css';
-import '../../qq.css';
-
 const QQ_PLOT_RATIO = '70%';
 const BOX_PLOT_RATIO = '30%';
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
@@ -93,11 +93,11 @@ const ClinicalBoxPlot = ({
           svg={[
             () => wrapSvg({
               className: 'qq-plot',
-              selector: `#${downloadChartName}-qqplot-container .qq-plot svg`,
+              selector: `#${downloadChartName}-qq-plot-container .qq-plot svg`,
               title: `${humanify({ term: fieldName })} QQ Plot`,
             }),
             () => wrapSvg({
-              className: `${type.toLowerCase()}-boxplot`,
+              className: `${type.toLowerCase()}-box-plot`,
               selector: `#${downloadChartName}-box-plot-container figure svg`,
               title: `${humanify({ term: fieldName })} Box Plot`,
             }),

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
@@ -5,34 +5,31 @@ import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 import '../../survivalPlot.css';
 
 const ClinicalSurvivalPlot = ({
+  downloadChartName,
   plotType,
   survivalData: { id, legend, rawData },
   survivalPlotLoading,
-}) => {
-  const survivalPlotSlug = id && `${id.split('.')[1]}-survival-plot`;
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flex: '0 0 auto',
-        flexDirection: 'column',
-        height: '265px',
-        justifyContent: 'center',
-        margin: '5px 2px 10px',
-      }}
-      >
-      <SurvivalPlotWrapper
-        height={202}
-        id={id}
-        legend={legend}
-        plotType={plotType}
-        rawData={rawData}
-        slug={survivalPlotSlug}
-        survivalPlotLoading={survivalPlotLoading}
-        uniqueClass={survivalPlotSlug}
-        />
-    </div>
-  )
-};
+}) => (
+  <div
+    style={{
+      display: 'flex',
+      flex: '0 0 auto',
+      flexDirection: 'column',
+      height: '265px',
+      justifyContent: 'center',
+      margin: '5px 2px 10px',
+    }}
+    >
+    <SurvivalPlotWrapper
+      height={202}
+      id={id}
+      legend={legend}
+      plotType={plotType}
+      rawData={rawData}
+      slug={`${downloadChartName}-survival-plot`}
+      survivalPlotLoading={survivalPlotLoading}
+      />
+  </div>
+);
 
 export default ClinicalSurvivalPlot;

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
@@ -3,14 +3,13 @@ import React from 'react';
 import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 
 import '../../survivalPlot.css';
+import { OVERALL_SURVIVAL_SLUG } from '../../helpers';
 
 const ClinicalSurvivalPlot = ({
   plotType,
   survivalData: { id, legend, rawData },
   survivalPlotLoading,
-}) => {
-  // console.log('id', id);
-  return (
+}) => (
   <div
     style={{
       display: 'flex',
@@ -27,10 +26,11 @@ const ClinicalSurvivalPlot = ({
       legend={legend}
       plotType={plotType}
       rawData={rawData}
+      slug={OVERALL_SURVIVAL_SLUG}
       survivalPlotLoading={survivalPlotLoading}
-      uniqueClass="clinical-survival-plot"
+      uniqueClass={OVERALL_SURVIVAL_SLUG}
       />
   </div>
-)};
+);
 
 export default ClinicalSurvivalPlot;

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
@@ -8,7 +8,9 @@ const ClinicalSurvivalPlot = ({
   plotType,
   survivalData: { id, legend, rawData },
   survivalPlotLoading,
-}) => (
+}) => {
+  // console.log('id', id);
+  return (
   <div
     style={{
       display: 'flex',
@@ -29,6 +31,6 @@ const ClinicalSurvivalPlot = ({
       uniqueClass="clinical-survival-plot"
       />
   </div>
-);
+)};
 
 export default ClinicalSurvivalPlot;

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalSurvivalPlot.js
@@ -3,34 +3,36 @@ import React from 'react';
 import SurvivalPlotWrapper from '@ncigdc/components/SurvivalPlotWrapper';
 
 import '../../survivalPlot.css';
-import { OVERALL_SURVIVAL_SLUG } from '../../helpers';
 
 const ClinicalSurvivalPlot = ({
   plotType,
   survivalData: { id, legend, rawData },
   survivalPlotLoading,
-}) => (
-  <div
-    style={{
-      display: 'flex',
-      flex: '0 0 auto',
-      flexDirection: 'column',
-      height: '265px',
-      justifyContent: 'center',
-      margin: '5px 2px 10px',
-    }}
-    >
-    <SurvivalPlotWrapper
-      height={202}
-      id={id}
-      legend={legend}
-      plotType={plotType}
-      rawData={rawData}
-      slug={OVERALL_SURVIVAL_SLUG}
-      survivalPlotLoading={survivalPlotLoading}
-      uniqueClass={OVERALL_SURVIVAL_SLUG}
-      />
-  </div>
-);
+}) => {
+  const survivalPlotSlug = id && `${id.split('.')[1]}-survival-plot`;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flex: '0 0 auto',
+        flexDirection: 'column',
+        height: '265px',
+        justifyContent: 'center',
+        margin: '5px 2px 10px',
+      }}
+      >
+      <SurvivalPlotWrapper
+        height={202}
+        id={id}
+        legend={legend}
+        plotType={plotType}
+        rawData={rawData}
+        slug={survivalPlotSlug}
+        survivalPlotLoading={survivalPlotLoading}
+        uniqueClass={survivalPlotSlug}
+        />
+    </div>
+  )
+};
 
 export default ClinicalSurvivalPlot;

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/boxplot.css
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/boxplot.css
@@ -1,37 +1,37 @@
-.boxplot .axis path,
-.boxplot .axis line,
-.boxplot .decadeBar path {
+.box-plot .axis path,
+.box-plot .axis line,
+.box-plot .decadeBar path {
   stroke: #ccc;
   shape-rendering: crispEdges;
 }
 
-.boxplot g text {
+.box-plot g text {
   fill: #888;
 }
 
-.boxplot .axis .tick text,
-.boxplot .axis text {
+.box-plot .axis .tick text,
+.box-plot .axis text {
   fill: #ccc;
   font-size: 1rem;
 }
 
-.boxplot .whisker path {
+.box-plot .whisker path {
   stroke: #333;
 }
-.demographic-boxplot .box line {
+.demographic-box-plot .box line {
   stroke: #1f77b4;
 }
-.diagnosis-boxplot .box line {
+.diagnosis-box-plot .box line {
   stroke: #ff7f0e;
 }
-.treatment-boxplot .box line {
+.treatment-box-plot .box line {
   stroke: #2ca02c;
 }
 
-.exposure-boxplot .box line {
+.exposure-box-plot .box line {
   stroke: #9467bd;
 }
 
-.boxplot .point {
+.box-plot .point {
   color: #333;
 }

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,42 +23,34 @@ const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-// const maxKeyNameLength = (
-//   maxBy(histogramData
-//     .map(d => d.fullLabel), (item) => item.length) || ''
-// ).length;
-
 export const getSurvivalDownload = slug => {
   const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
   return ({
-  className: 'survival-plot',
-  selector: `.${slug} .survival-plot svg`,
-  slug,
-  title: '',
-  embed: {
-    top: {
-      elements: legend.map((l, i) => {
-        const legendItem = document.querySelector(
-          `.${slug} .legend-${i}`
-        ).cloneNode(true);
-        const legendTitle = legendItem.querySelector('span.print-only.inline');
-        if (legendTitle !== null) legendTitle.className = '';
-        return legendItem;
-      })
-      .concat(document.querySelector(`.${slug} .p-value`) || []),
+    className: 'survival-plot',
+    selector: `.${slug} .survival-plot svg`,
+    slug,
+    title: '',
+    embed: {
+      top: {
+        elements: legend.map((l, i) => {
+          const legendItem = document.querySelector(
+            `.${slug} .legend-${i}`
+          ).cloneNode(true);
+          const legendTitle = legendItem.querySelector('span.print-only.inline');
+          if (legendTitle !== null) legendTitle.className = '';
+          return legendItem;
+        })
+        .concat(document.querySelector(`.${slug} .p-value`) || []),
+      },
     },
-  },
-})};
+  });
+};
 
 export const getHistogramDownload = (fieldName, slug) => {
   const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
   const labelElements = [...document.querySelectorAll(`${selector} .svgDownload .tick text`)];
   const labels = labelElements.map(el => el.textContent);
   const maxKeyNameLength = getMaxKeyNameLength(labels);
-  // const maxKeyNameLength = 100;
-  // const human = humanify(s
-  console.log('labels', labels);
-  console.log('maxKeyNameLength', maxKeyNameLength)
   return ({
     bottomBuffer: maxKeyNameLength * 3,
     rightBuffer: maxKeyNameLength * 2,

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,10 +23,9 @@ export const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-const getSurvivalDownload = slug => {
+export const getSurvivalDownload = fieldName => {
+  const slug = `${fieldName}-survival-plot`;
   const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
-  console.log('getSurvivalDownload slug', slug);
-  console.log('getSurvivalDownload legend', legend);
   return ({
   className: 'survival-plot',
   selector: `.${slug} .survival-plot svg`,
@@ -40,9 +39,7 @@ const getSurvivalDownload = slug => {
           ).cloneNode(true);
           const legendTitle = legendItem.querySelector('span.print-only.inline');
           if (legendTitle !== null) legendTitle.className = '';
-          console.log('legendItem', legendTitle, legendItem);
-          return 'BOOP';
-          // return legendItem;
+          return legendItem;
         })
         .concat(document.querySelector(`.${slug} .p-value`) || []),
     },
@@ -61,33 +58,4 @@ export const getDownloadSlugs = displayVariables => Object.keys(displayVariables
       ? `${fieldName}-survival-plot`
       :[];
   //     : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
-// }).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
-}).reduce((acc, curr) => acc.concat(curr), []);
-
-export const getDownloadSvgs = displayVariables => Object.keys(displayVariables)
-  .reduce((acc, curr) => {
-    const fieldName = curr.split('.')[1];
-    const chartType = displayVariables[curr].active_chart;
-    console.log('when is this firing');
-
-    if (chartType === 'histogram') {
-      return acc;
-      // const bins = Object.keys(displayVariables[curr].bins);
-      // const maxKeyNameLength = getMaxKeyNameLength(bins);
-      // return acc.concat({
-      //   bottomBuffer: maxKeyNameLength * 3,
-      //   rightBuffer: maxKeyNameLength * 2, 
-      //   selector: `#${fieldName}-chart-container .test-bar-chart svg`,
-      //   title: humanify({ term: fieldName }),
-      // });
-    } else if (chartType === 'survival') {
-      // const survivalSlug =`${fieldName}-survival-plot`;
-      const survivalSlug = `${fieldName}-survival-plot`;
-      console.log('survivalSlug', survivalSlug);
-      return acc.concat(getSurvivalDownload(survivalSlug));
-    } else if (chartType === 'box') {
-      return acc;
-    }
-  // }, [getSurvivalDownload(OVERALL_SURVIVAL_SLUG)]
-}, []
-);
+}).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -1,0 +1,59 @@
+import {
+  isEqual,
+  map,
+  mapKeys,
+  maxBy,
+  trim,
+} from 'lodash';
+import { humanify } from '@ncigdc/utils/string';
+
+export const PLOT_TYPES = {
+  categorical: ['histogram', 'survival'],
+  continuous: [
+    'histogram',
+    'survival',
+    'box',
+  ],
+};
+
+// helpers for downloading SVGs/PNGs
+
+export const OVERALL_SURVIVAL_SLUG = 'clinical-overall-survival-plot';
+export const getMaxKeyNameLength = bins => (
+  maxBy(bins, item => item.length) || ''
+).length;
+
+export const makeDownloadSlugs = displayVariables => Object.keys(displayVariables)
+.map(dVar => {
+  const fieldName = dVar.split('.')[1];
+  const chart = displayVariables[dVar].active_chart;
+  return chart === 'histogram'
+    ? `${fieldName}-bar-chart`
+    : chart === 'survival'
+      ? 'survival-plot'
+      : [`qq-plot-${fieldName}`, `boxplot-${fieldName}`];
+}).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+
+export const makeDownloadSvgs = displayVariables => Object.keys(displayVariables)
+.reduce((acc, curr) => {
+  const fieldName = curr.split('.')[1];
+  const chart = displayVariables[curr].active_chart;
+
+  if (chart === 'histogram') {
+    const bins = Object.keys(displayVariables[curr].bins);
+    const maxKeyNameLength = getMaxKeyNameLength(bins);
+    return acc.concat({
+      bottomBuffer: maxKeyNameLength * 3,
+      rightBuffer: maxKeyNameLength * 2, 
+      selector: `#${fieldName}-chart-container .test-bar-chart svg`,
+      title: humanify({ term: fieldName }),
+    });
+  } else if (chart === 'survival') {
+    return acc.concat('survival');
+  } else if (chart === 'box') {
+    return acc.concat('box');
+  }
+}, [{
+  selector: `.${OVERALL_SURVIVAL_SLUG} .survival-plot svg`,
+  slug: OVERALL_SURVIVAL_SLUG,
+}]);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,8 +23,7 @@ export const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-export const getSurvivalDownload = fieldName => {
-  const slug = `${fieldName}-survival-plot`;
+export const getSurvivalDownload = slug => {
   const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
   return ({
   className: 'survival-plot',

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,6 +23,44 @@ const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
+export const getDownloadSlugs = displayVariables =>
+  Object.keys(displayVariables).sort()
+    .map(dVar => {
+      const fieldName = dVar.split('.')[1];
+      const chartType = displayVariables[dVar].active_chart;
+      return chartType === 'box'
+        ? [`${fieldName}-box-plot`, `${fieldName}-qq-plot`]
+        : chartType === 'histogram'
+          ? `${fieldName}-bar-chart`
+          : chartType === 'survival'
+            ? `${fieldName}-survival-plot`
+            : [];
+    })
+    .reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+
+export const getBoxQQDownload = (fieldName, slug) => ['Box', 'QQ']
+  .map((type, i) => ({
+    selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
+      type === 'QQ' ? '.qq-plot' : 'figure'
+    } svg`,
+    slug,
+    title: `${humanify({ term: fieldName })} ${type} Plot`,
+  }));
+
+export const getHistogramDownload = (fieldName, slug) => {
+  const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
+  const labelElements = [...document.querySelectorAll(`${selector} .svgDownload .tick text`)];
+  const labels = labelElements.map(el => el.textContent);
+  const maxKeyNameLength = getMaxKeyNameLength(labels);
+  return ({
+    bottomBuffer: maxKeyNameLength * 3,
+    rightBuffer: maxKeyNameLength * 2,
+    selector,
+    slug,
+    title: humanify({term: fieldName}),
+  });
+};
+
 export const getSurvivalDownload = slug => {
   const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
   return ({
@@ -45,33 +83,3 @@ export const getSurvivalDownload = slug => {
     },
   });
 };
-
-export const getHistogramDownload = (fieldName, slug) => {
-  const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
-  const labelElements = [...document.querySelectorAll(`${selector} .svgDownload .tick text`)];
-  const labels = labelElements.map(el => el.textContent);
-  const maxKeyNameLength = getMaxKeyNameLength(labels);
-  return ({
-    bottomBuffer: maxKeyNameLength * 3,
-    rightBuffer: maxKeyNameLength * 2,
-    selector,
-    title: humanify({term: fieldName}),
-  });
-};
-
-export const getDownloadSlugs = displayVariables =>
-  Object.keys(displayVariables).sort()
-    .map(dVar => {
-      const fieldName = dVar.split('.')[1];
-      const chartType = displayVariables[dVar].active_chart;
-      // return [];
-      return chartType === 'box'
-        ? []
-        // ? [`${fieldName}-qq-plot`, `${fieldName}-box-plot`]
-        : chartType === 'histogram'
-          ? `${fieldName}-bar-chart`
-          : chartType === 'survival'
-            ? `${fieldName}-survival-plot`
-            : [];
-    })
-    .reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -39,18 +39,15 @@ export const getDownloadSlugArray = obj => obj
     [OVERALL_SURVIVAL_SLUG]
   );
 
-export const getBoxQQDownload = (fieldName, plot, type) => {
-  console.log('getBoxQQDownload', fieldName, type);
-  return ({
-    className: `${plot === 'Box' 
-      ? type.toLowerCase() + '-' 
-      : ''}${plot.toLowerCase()}-plot`,
-    selector: `#${fieldName}-${plot.toLowerCase()}-plot-container ${
-      plot === 'Box' ? 'figure' : '.qq-plot'
-    } svg`,
-    title: `${humanify({ term: fieldName })} ${plot} Plot`,
-  });
-};
+export const getBoxQQDownload = (fieldName, chart, type) => ({
+  className: `${chart === 'Box' 
+    ? type.toLowerCase() + '-' 
+    : ''}${chart.toLowerCase()}-plot`,
+  selector: `#${fieldName}-${chart.toLowerCase()}-plot-container ${
+    chart === 'Box' ? 'figure' : '.qq-plot'
+  } svg`,
+  title: `${humanify({ term: fieldName })} ${chart} Plot`,
+});
 
 export const getHistogramDownload = fieldName => {
   const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
@@ -87,3 +84,17 @@ export const getSurvivalDownload = slug => {
     },
   });
 };
+
+export const getDownloadSvgInfo = displayVariables =>
+  Object.keys(displayVariables).sort()
+    .filter(dVar => {
+      const bins = displayVariables[dVar].bins;
+      return !(bins === undefined ||
+          Object.keys(bins).filter(key => key !== '_missing').length === 0);
+    })
+    .map(dVar => {
+      const fieldName = dVar.split('.')[1];
+      const { active_chart: chart, type, } = displayVariables[dVar];
+      const slug = getDownloadSlug(chart, fieldName);
+      return { chart, fieldName, slug, type };
+    });

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -30,8 +30,8 @@ export const makeDownloadSlugs = displayVariables => Object.keys(displayVariable
   return chart === 'histogram'
     ? `${fieldName}-bar-chart`
     : chart === 'survival'
-      ? 'survival-plot'
-      : [`qq-plot-${fieldName}`, `boxplot-${fieldName}`];
+      ? `${fieldName}-survival-plot`
+      : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
 }).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
 
 export const makeDownloadSvgs = displayVariables => Object.keys(displayVariables)
@@ -49,11 +49,14 @@ export const makeDownloadSvgs = displayVariables => Object.keys(displayVariables
       title: humanify({ term: fieldName }),
     });
   } else if (chart === 'survival') {
-    return acc.concat('survival');
+    return acc;
   } else if (chart === 'box') {
-    return acc.concat('box');
+    return acc;
   }
-}, [{
-  selector: `.${OVERALL_SURVIVAL_SLUG} .survival-plot svg`,
-  slug: OVERALL_SURVIVAL_SLUG,
-}]);
+}, 
+[]
+// [{
+//   selector: `.${OVERALL_SURVIVAL_SLUG} .survival-plot svg`,
+//   slug: OVERALL_SURVIVAL_SLUG,
+// }]
+);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -50,17 +50,20 @@ export const getSurvivalDownload = slug => {
   },
 })};
 
-export const getHistogramDownload = slug => {
-  // const maxKeyNameLength = getMaxKeyNameLength(bins);
-  const maxKeyNameLength = 100;
-  const human = humanify(slug);
-  console.log('humanify', human);
-  // need to get bottom/right buffer...
+export const getHistogramDownload = (fieldName, slug) => {
+  const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
+  const labelElements = [...document.querySelectorAll(`${selector} .svgDownload .tick text`)];
+  const labels = labelElements.map(el => el.textContent);
+  const maxKeyNameLength = getMaxKeyNameLength(labels);
+  // const maxKeyNameLength = 100;
+  // const human = humanify(s
+  console.log('labels', labels);
+  console.log('maxKeyNameLength', maxKeyNameLength)
   return ({
     bottomBuffer: maxKeyNameLength * 3,
     rightBuffer: maxKeyNameLength * 2,
-    selector: `#${slug}-chart-container .test-bar-chart svg`,
-    title: humanify(slug),
+    selector,
+    title: humanify({term: fieldName}),
   });
 };
 
@@ -73,8 +76,8 @@ export const getDownloadSlugs = displayVariables =>
       return chartType === 'box'
         ? []
         // ? [`${fieldName}-qq-plot`, `${fieldName}-box-plot`]
-        // : chartType === 'histogram'
-        //   ? `${fieldName}-bar-chart`
+        : chartType === 'histogram'
+          ? `${fieldName}-bar-chart`
           : chartType === 'survival'
             ? `${fieldName}-survival-plot`
             : [];

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,59 +23,71 @@ export const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-const getSurvivalDownload = slug => ({
-  className: 'survival-plot', // for print styling
+const getSurvivalDownload = slug => {
+  const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
+  console.log('getSurvivalDownload slug', slug);
+  console.log('getSurvivalDownload legend', legend);
+  return ({
+  className: 'survival-plot',
   selector: `.${slug} .survival-plot svg`,
   slug,
-  title: '', // hide title
+  title: '',
   embed: {
     top: {
-      elements: Array.prototype.map.call(document.querySelectorAll(`.${slug} .legend-item`), (l, i) => {
+      elements: legend.map((l, i) => {
           const legendItem = document.querySelector(
             `.${slug} .legend-${i}`
           ).cloneNode(true);
           const legendTitle = legendItem.querySelector('span.print-only.inline');
           if (legendTitle !== null) legendTitle.className = '';
-          return legendItem;
+          console.log('legendItem', legendTitle, legendItem);
+          return 'BOOP';
+          // return legendItem;
         })
         .concat(document.querySelector(`.${slug} .p-value`) || []),
     },
   },
-});
+})};
 
 export const getDownloadSlugs = displayVariables => Object.keys(displayVariables)
 .map(dVar => {
   const fieldName = dVar.split('.')[1];
   const chart = displayVariables[dVar].active_chart;
-  return [];
-  // return chart === 'histogram'
-  //   ? `${fieldName}-bar-chart`
-  //   : chart === 'survival'
-  //     ? `${fieldName}-survival-plot`
+  // return [];
+  return chart === 'histogram'
+    ? []
+    // ? `${fieldName}-bar-chart`
+    : chart === 'survival'
+      ? `${fieldName}-survival-plot`
+      :[];
   //     : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
-}).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+// }).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+}).reduce((acc, curr) => acc.concat(curr), []);
 
 export const getDownloadSvgs = displayVariables => Object.keys(displayVariables)
-.reduce((acc, curr) => {
-  const fieldName = curr.split('.')[1];
-  const chart = displayVariables[curr].active_chart;
+  .reduce((acc, curr) => {
+    const fieldName = curr.split('.')[1];
+    const chartType = displayVariables[curr].active_chart;
+    console.log('when is this firing');
 
-  if (chart === 'histogram') {
-    return acc;
-    // const bins = Object.keys(displayVariables[curr].bins);
-    // const maxKeyNameLength = getMaxKeyNameLength(bins);
-    // return acc.concat({
-    //   bottomBuffer: maxKeyNameLength * 3,
-    //   rightBuffer: maxKeyNameLength * 2, 
-    //   selector: `#${fieldName}-chart-container .test-bar-chart svg`,
-    //   title: humanify({ term: fieldName }),
-    // });
-  } else if (chart === 'survival') {
-    return acc;
-  } else if (chart === 'box') {
-    return acc;
-  }
-}, 
-// []
-[getSurvivalDownload(OVERALL_SURVIVAL_SLUG)]
+    if (chartType === 'histogram') {
+      return acc;
+      // const bins = Object.keys(displayVariables[curr].bins);
+      // const maxKeyNameLength = getMaxKeyNameLength(bins);
+      // return acc.concat({
+      //   bottomBuffer: maxKeyNameLength * 3,
+      //   rightBuffer: maxKeyNameLength * 2, 
+      //   selector: `#${fieldName}-chart-container .test-bar-chart svg`,
+      //   title: humanify({ term: fieldName }),
+      // });
+    } else if (chartType === 'survival') {
+      // const survivalSlug =`${fieldName}-survival-plot`;
+      const survivalSlug = `${fieldName}-survival-plot`;
+      console.log('survivalSlug', survivalSlug);
+      return acc.concat(getSurvivalDownload(survivalSlug));
+    } else if (chartType === 'box') {
+      return acc;
+    }
+  // }, [getSurvivalDownload(OVERALL_SURVIVAL_SLUG)]
+}, []
 );

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -24,12 +24,12 @@ const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-export const getDownloadSlug = (chartType, fieldName) => 
-  chartType === 'box'
+export const getDownloadSlug = (chart, fieldName) => 
+  chart === 'box'
     ? [`${fieldName}-box-plot`, `${fieldName}-qq-plot`]
-    : chartType === 'histogram'
+    : chart === 'histogram'
       ? `${fieldName}-bar-chart`
-      : chartType === 'survival'
+      : chart === 'survival'
         ? `${fieldName}-survival-plot`
         : [];
 
@@ -39,14 +39,17 @@ export const getDownloadSlugArray = obj => obj
     [OVERALL_SURVIVAL_SLUG]
   );
 
-export const getBoxQQDownload = (fieldName, type) => {
+export const getBoxQQDownload = (fieldName, plot, type) => {
   console.log('getBoxQQDownload', fieldName, type);
   return ({
-    selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
-      type === 'Box' ? 'figure' : '.qq-plot'
+    className: `${plot === 'Box' 
+      ? type.toLowerCase() + '-' 
+      : ''}${plot.toLowerCase()}-plot`,
+    selector: `#${fieldName}-${plot.toLowerCase()}-plot-container ${
+      plot === 'Box' ? 'figure' : '.qq-plot'
     } svg`,
-    title: `${humanify({ term: fieldName })} ${type} Plot`,
-  })
+    title: `${humanify({ term: fieldName })} ${plot} Plot`,
+  });
 };
 
 export const getHistogramDownload = fieldName => {

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -45,14 +45,15 @@ export const getSurvivalDownload = slug => {
   },
 })};
 
+
 export const getDownloadSlugs = displayVariables => Object.keys(displayVariables)
 .map(dVar => {
   const fieldName = dVar.split('.')[1];
   const chart = displayVariables[dVar].active_chart;
   // return [];
   return chart === 'histogram'
-    ? []
-    // ? `${fieldName}-bar-chart`
+    // ? []
+    ? `${fieldName}-bar-chart`
     : chart === 'survival'
       ? `${fieldName}-survival-plot`
       :[];

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -19,9 +19,14 @@ export const PLOT_TYPES = {
 // helpers for downloading SVGs/PNGs
 
 export const OVERALL_SURVIVAL_SLUG = 'clinical-overall-survival-plot';
-export const getMaxKeyNameLength = bins => (
+const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
+
+// const maxKeyNameLength = (
+//   maxBy(histogramData
+//     .map(d => d.fullLabel), (item) => item.length) || ''
+// ).length;
 
 export const getSurvivalDownload = slug => {
   const legend = [...document.querySelectorAll(`.${slug} .legend-item`)];
@@ -33,29 +38,45 @@ export const getSurvivalDownload = slug => {
   embed: {
     top: {
       elements: legend.map((l, i) => {
-          const legendItem = document.querySelector(
-            `.${slug} .legend-${i}`
-          ).cloneNode(true);
-          const legendTitle = legendItem.querySelector('span.print-only.inline');
-          if (legendTitle !== null) legendTitle.className = '';
-          return legendItem;
-        })
-        .concat(document.querySelector(`.${slug} .p-value`) || []),
+        const legendItem = document.querySelector(
+          `.${slug} .legend-${i}`
+        ).cloneNode(true);
+        const legendTitle = legendItem.querySelector('span.print-only.inline');
+        if (legendTitle !== null) legendTitle.className = '';
+        return legendItem;
+      })
+      .concat(document.querySelector(`.${slug} .p-value`) || []),
     },
   },
 })};
 
+export const getHistogramDownload = slug => {
+  // const maxKeyNameLength = getMaxKeyNameLength(bins);
+  const maxKeyNameLength = 100;
+  const human = humanify(slug);
+  console.log('humanify', human);
+  // need to get bottom/right buffer...
+  return ({
+    bottomBuffer: maxKeyNameLength * 3,
+    rightBuffer: maxKeyNameLength * 2,
+    selector: `#${slug}-chart-container .test-bar-chart svg`,
+    title: humanify(slug),
+  });
+};
 
-export const getDownloadSlugs = displayVariables => Object.keys(displayVariables)
-.map(dVar => {
-  const fieldName = dVar.split('.')[1];
-  const chart = displayVariables[dVar].active_chart;
-  // return [];
-  return chart === 'histogram'
-    // ? []
-    ? `${fieldName}-bar-chart`
-    : chart === 'survival'
-      ? `${fieldName}-survival-plot`
-      :[];
-  //     : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
-}).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+export const getDownloadSlugs = displayVariables =>
+  Object.keys(displayVariables).sort()
+    .map(dVar => {
+      const fieldName = dVar.split('.')[1];
+      const chartType = displayVariables[dVar].active_chart;
+      // return [];
+      return chartType === 'box'
+        ? []
+        // ? [`${fieldName}-qq-plot`, `${fieldName}-box-plot`]
+        // : chartType === 'histogram'
+        //   ? `${fieldName}-bar-chart`
+          : chartType === 'survival'
+            ? `${fieldName}-survival-plot`
+            : [];
+    })
+    .reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -23,40 +23,59 @@ export const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-export const makeDownloadSlugs = displayVariables => Object.keys(displayVariables)
+const getSurvivalDownload = slug => ({
+  className: 'survival-plot', // for print styling
+  selector: `.${slug} .survival-plot svg`,
+  slug,
+  title: '', // hide title
+  embed: {
+    top: {
+      elements: Array.prototype.map.call(document.querySelectorAll(`.${slug} .legend-item`), (l, i) => {
+          const legendItem = document.querySelector(
+            `.${slug} .legend-${i}`
+          ).cloneNode(true);
+          const legendTitle = legendItem.querySelector('span.print-only.inline');
+          if (legendTitle !== null) legendTitle.className = '';
+          return legendItem;
+        })
+        .concat(document.querySelector(`.${slug} .p-value`) || []),
+    },
+  },
+});
+
+export const getDownloadSlugs = displayVariables => Object.keys(displayVariables)
 .map(dVar => {
   const fieldName = dVar.split('.')[1];
   const chart = displayVariables[dVar].active_chart;
-  return chart === 'histogram'
-    ? `${fieldName}-bar-chart`
-    : chart === 'survival'
-      ? `${fieldName}-survival-plot`
-      : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
+  return [];
+  // return chart === 'histogram'
+  //   ? `${fieldName}-bar-chart`
+  //   : chart === 'survival'
+  //     ? `${fieldName}-survival-plot`
+  //     : [`${fieldName}-qq-plot`, `${fieldName}-box-plot`];
 }).reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
 
-export const makeDownloadSvgs = displayVariables => Object.keys(displayVariables)
+export const getDownloadSvgs = displayVariables => Object.keys(displayVariables)
 .reduce((acc, curr) => {
   const fieldName = curr.split('.')[1];
   const chart = displayVariables[curr].active_chart;
 
   if (chart === 'histogram') {
-    const bins = Object.keys(displayVariables[curr].bins);
-    const maxKeyNameLength = getMaxKeyNameLength(bins);
-    return acc.concat({
-      bottomBuffer: maxKeyNameLength * 3,
-      rightBuffer: maxKeyNameLength * 2, 
-      selector: `#${fieldName}-chart-container .test-bar-chart svg`,
-      title: humanify({ term: fieldName }),
-    });
+    return acc;
+    // const bins = Object.keys(displayVariables[curr].bins);
+    // const maxKeyNameLength = getMaxKeyNameLength(bins);
+    // return acc.concat({
+    //   bottomBuffer: maxKeyNameLength * 3,
+    //   rightBuffer: maxKeyNameLength * 2, 
+    //   selector: `#${fieldName}-chart-container .test-bar-chart svg`,
+    //   title: humanify({ term: fieldName }),
+    // });
   } else if (chart === 'survival') {
     return acc;
   } else if (chart === 'box') {
     return acc;
   }
 }, 
-[]
-// [{
-//   selector: `.${OVERALL_SURVIVAL_SLUG} .survival-plot svg`,
-//   slug: OVERALL_SURVIVAL_SLUG,
-// }]
+// []
+[getSurvivalDownload(OVERALL_SURVIVAL_SLUG)]
 );

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -19,39 +19,37 @@ export const PLOT_TYPES = {
 // helpers for downloading SVGs/PNGs
 
 export const OVERALL_SURVIVAL_SLUG = 'clinical-overall-survival-plot';
+
 const getMaxKeyNameLength = bins => (
   maxBy(bins, item => item.length) || ''
 ).length;
 
-export const getDownloadSlugs = displayVariables =>
-  Object.keys(displayVariables).sort()
-    .reduce((acc, dVar) => {
-      const fieldName = dVar.split('.')[1];
-      const chartType = displayVariables[dVar].active_chart;
-      return [
-        ...acc, 
-        ...['box', 'histogram', 'survival'].includes(chartType) &&
-          [
-            chartType === 'box'
-              ? null
-              : chartType === 'histogram'
-                ? `${fieldName}-bar-chart`
-                : `${fieldName}-survival-plot`
-          ]
-      ];
-    },
-    [OVERALL_SURVIVAL_SLUG]);
+export const getDownloadSlug = (chartType, fieldName) => 
+  chartType === 'box'
+    ? [`${fieldName}-box-plot`, `${fieldName}-qq-plot`]
+    : chartType === 'histogram'
+      ? `${fieldName}-bar-chart`
+      : chartType === 'survival'
+        ? `${fieldName}-survival-plot`
+        : [];
+
+export const getDownloadSlugArray = obj => obj
+  .reduce((acc, { slug }) => 
+    acc.concat(slug),
+    [OVERALL_SURVIVAL_SLUG]
+  );
 
 export const getBoxQQDownload = (fieldName, type) => {
+  console.log('getBoxQQDownload', fieldName, type);
   return ({
-  selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
-    type === 'Box' ? 'figure' : '.qq-plot'
-  } svg`,
-  slug: `${fieldName}-${type.toLowerCase()}-plot`,
-  title: `${humanify({ term: fieldName })} ${type} Plot`,
-})};
+    selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
+      type === 'Box' ? 'figure' : '.qq-plot'
+    } svg`,
+    title: `${humanify({ term: fieldName })} ${type} Plot`,
+  })
+};
 
-export const getHistogramDownload = (fieldName, slug) => {
+export const getHistogramDownload = fieldName => {
   const selector = `#${fieldName}-chart-container .test-bar-chart svg`;
   const labelElements = [...document.querySelectorAll(`${selector} .svgDownload .tick text`)];
   const labels = labelElements.map(el => el.textContent);
@@ -60,7 +58,6 @@ export const getHistogramDownload = (fieldName, slug) => {
     bottomBuffer: maxKeyNameLength * 3,
     rightBuffer: maxKeyNameLength * 2,
     selector,
-    slug,
     title: humanify({term: fieldName}),
   });
 };

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/helpers.js
@@ -25,27 +25,31 @@ const getMaxKeyNameLength = bins => (
 
 export const getDownloadSlugs = displayVariables =>
   Object.keys(displayVariables).sort()
-    .map(dVar => {
+    .reduce((acc, dVar) => {
       const fieldName = dVar.split('.')[1];
       const chartType = displayVariables[dVar].active_chart;
-      return chartType === 'box'
-        ? [`${fieldName}-box-plot`, `${fieldName}-qq-plot`]
-        : chartType === 'histogram'
-          ? `${fieldName}-bar-chart`
-          : chartType === 'survival'
-            ? `${fieldName}-survival-plot`
-            : [];
-    })
-    .reduce((acc, curr) => acc.concat(curr), [OVERALL_SURVIVAL_SLUG]);
+      return [
+        ...acc, 
+        ...['box', 'histogram', 'survival'].includes(chartType) &&
+          [
+            chartType === 'box'
+              ? null
+              : chartType === 'histogram'
+                ? `${fieldName}-bar-chart`
+                : `${fieldName}-survival-plot`
+          ]
+      ];
+    },
+    [OVERALL_SURVIVAL_SLUG]);
 
-export const getBoxQQDownload = (fieldName, slug) => ['Box', 'QQ']
-  .map((type, i) => ({
-    selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
-      type === 'QQ' ? '.qq-plot' : 'figure'
-    } svg`,
-    slug,
-    title: `${humanify({ term: fieldName })} ${type} Plot`,
-  }));
+export const getBoxQQDownload = (fieldName, type) => {
+  return ({
+  selector: `#${fieldName}-${type.toLowerCase()}-plot-container ${
+    type === 'Box' ? 'figure' : '.qq-plot'
+  } svg`,
+  slug: `${fieldName}-${type.toLowerCase()}-plot`,
+  title: `${humanify({ term: fieldName })} ${type} Plot`,
+})};
 
 export const getHistogramDownload = (fieldName, slug) => {
   const selector = `#${fieldName}-chart-container .test-bar-chart svg`;


### PR DESCRIPTION
## Ticket Number

PRTL-2870

## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa-yellow`

## Description of Changes

- change the `print` button at the top right of clinical analysis to `download all images`
- add a slug to survival plot, so survival plot images have unique file names and are easier to select with CSS selectors