### PR TITLE
[PRTL-2873] fix primary site data table on project page

### DIFF
--- a/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
+++ b/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
@@ -13,7 +13,7 @@ import ExploreLink from '@ncigdc/components/Links/ExploreLink';
 let DataCategoryColumns = withData(props => {
   var dataColumns = Object.keys(DATA_CATEGORIES).reduce((acc, dataCategory) => {
     const type = props.repository.cases.aggregations.files__data_category.buckets
-      .find(({ key: key = '' }) =>
+      .find(({ key = '' } = {}) =>
         key.toLowerCase() === DATA_CATEGORIES[dataCategory].full.toLowerCase()
     );
     const linkQuery = {

--- a/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
+++ b/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
@@ -11,9 +11,10 @@ import Tooltip from '@ncigdc/uikit/Tooltip/Tooltip';
 import ExploreLink from '@ncigdc/components/Links/ExploreLink';
 
 let DataCategoryColumns = withData(props => {
-  var dataColumns = Object.keys(DATA_CATEGORIES).reduce((acc, k) => {
-    const type = props.repository.cases.aggregations.files__data_category.buckets.find(
-      item => item.key === DATA_CATEGORIES[k].full,
+  var dataColumns = Object.keys(DATA_CATEGORIES).reduce((acc, dataCategory) => {
+    const type = props.repository.cases.aggregations.files__data_category.buckets
+      .find(({ key: key = '' }) =>
+        key.toLowerCase() === DATA_CATEGORIES[dataCategory].full.toLowerCase()
     );
     const linkQuery = {
       searchTableTab: 'cases',
@@ -22,7 +23,10 @@ let DataCategoryColumns = withData(props => {
           field: 'cases.project.project_id',
           value: props.projectId,
         },
-        { field: 'files.data_category', value: DATA_CATEGORIES[k].full },
+        { 
+          field: 'files.data_category', 
+          value: DATA_CATEGORIES[dataCategory].full,
+        },
         {
           field: 'cases.primary_site',
           value: [props.primarySite],
@@ -38,7 +42,7 @@ let DataCategoryColumns = withData(props => {
           alignItems: 'center',
           minWidth: '40px',
         }}
-        key={k}
+        key={dataCategory}
       >
         {type ? (
           <RepositoryFilesLink query={linkQuery}>


### PR DESCRIPTION
## Ticket Number

PRTL-2873

## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa-yellow`

## Description of Changes

- check for graphql response & make the check case-agnostic
- renamed unclear `k` variable
- counts in table should now be the same on prod, dev-oicr, and qa-yellow