### PR TITLE
[PRTL-2874] ensure primary site pies render properly

### DIFF
--- a/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
+++ b/src/packages/@ncigdc/modern_components/ProjectPrimarySitesTable/ProjectPrimarySitesTable.model.js
@@ -29,7 +29,7 @@ let DataCategoryColumns = withData(props => {
         },
         {
           field: 'cases.primary_site',
-          value: [props.primarySite],
+          value: [props.primarySite.toLowerCase()],
         },
       ]),
     };
@@ -106,7 +106,7 @@ let FilesByPrimarySite = withData(props => {
               },
               {
                 field: 'cases.primary_site',
-                value: [props.primarySite],
+                value: [props.primarySite.toLowerCase()],
               },
             ]),
           }}
@@ -139,7 +139,7 @@ let ExploreByPrimarySiteButton = props => {
               op: 'IN',
               content: {
                 field: 'cases.primary_site',
-                value: [props.primarySite],
+                value: [props.primarySite.toLowerCase()],
               },
             },
           ],
@@ -161,7 +161,7 @@ let CasesByPrimarySite = withData(props => {
       },
       {
         field: 'cases.primary_site',
-        value: [props.primarySite],
+        value: [props.primarySite.toLowerCase()],
       },
     ]),
   };


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes
Though I'm not happy with this solution, I've resorted to this simple manipulation of the query strings at their source to resolve the issue.

A more elegant casing guard applied at the offending component (pie chart) would've created conflicts with the unnormalised data for other pies (e.g. project names); which in turn would've required logic changes beyond the scope of this ticket.