### PR TITLE
[PRTL-2828] add download message to double donut & pie chart

### DIFF
--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -118,12 +118,8 @@ const DoubleRingChart = ({
   svg
     .append('text')
     .attr('class', 'svgDownload')
-    .attr('transform', 'rotate(0)')
     .attr('y', radius + 20)
-    .attr('x', 0)
-    .attr('width', width)
     .style('text-anchor', 'middle')
-    .style('fontWeight', '400')
     .text(downloadMessage);
 
   const fill = g

--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -111,6 +111,16 @@ const DoubleRingChart = ({
     .data(dataWithPie)
     .enter()
     .append('g');
+    console.log(diameter);
+
+  svg
+    .append('text')
+    .attr('transform', 'rotate(0)')
+    .attr('y', 0)
+    .attr('x', 0)
+    .style('text-anchor', 'middle')
+    .style('fontWeight', '500')
+    .text('boop');
 
   const fill = g
     .selectAll('path')

--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -10,6 +10,8 @@ import withSize from '@ncigdc/utils/withSize';
 
 const MAX_DIAMETER = 260;
 
+const downloadMessage = 'Please download the TSV to view data for this chart.';
+
 const DoubleRingChart = ({
   data = [],
   margin = 50,
@@ -33,6 +35,7 @@ const DoubleRingChart = ({
     .append('svg')
     .attr('width', diameter)
     .attr('height', diameter)
+    .attr('border', 1)
     .append('g')
     .attr('transform', `translate(${radius}, ${radius})`);
 
@@ -111,16 +114,17 @@ const DoubleRingChart = ({
     .data(dataWithPie)
     .enter()
     .append('g');
-    console.log(diameter);
 
   svg
     .append('text')
+    .attr('class', 'svgDownload')
     .attr('transform', 'rotate(0)')
-    .attr('y', 0)
+    .attr('y', radius + 20)
     .attr('x', 0)
+    .attr('width', width)
     .style('text-anchor', 'middle')
-    .style('fontWeight', '500')
-    .text('boop');
+    .style('fontWeight', '400')
+    .text(downloadMessage);
 
   const fill = g
     .selectAll('path')

--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -10,7 +10,7 @@ import withSize from '@ncigdc/utils/withSize';
 
 const MAX_DIAMETER = 260;
 
-const downloadMessage = 'Please download the TSV to view data for this chart.';
+const downloadMessage = 'To view data for this chart, download the separate TSV file';
 
 const DoubleRingChart = ({
   data = [],

--- a/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
+++ b/src/packages/@ncigdc/components/Charts/DoubleRingChart.js
@@ -35,7 +35,6 @@ const DoubleRingChart = ({
     .append('svg')
     .attr('width', diameter)
     .attr('height', diameter)
-    .attr('border', 1)
     .append('g')
     .attr('transform', `translate(${radius}, ${radius})`);
 

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -20,6 +20,8 @@ const getNestedValue = (item, path) => {
   return getNestedValue(nextItem, path);
 };
 
+const downloadMessage = 'Please download the TSV to view data for this chart.';
+
 const PieChart = ({
   data,
   diameter = 160, // if the pie chart is responsive, this is the MAX diameter
@@ -41,7 +43,8 @@ const PieChart = ({
   const pieDiameter = isResponsive && responsiveDiameter < diameter
     ? responsiveDiameter
     : diameter;
-  const outerRadius = pieDiameter / 2 + 10;
+  const radius = pieDiameter / 2;
+  const outerRadius = radius + 10;
   const innerRadius = enableInnerRadius ? outerRadius / 2 : 0;
 
   const node = ReactFauxDOM.createElement('div');
@@ -63,7 +66,14 @@ const PieChart = ({
     .attr('width', pieDiameter)
     .attr('height', pieDiameter)
     .append('g')
-    .attr('transform', `translate(${pieDiameter / 2}, ${pieDiameter / 2})`);
+    .attr('transform', `translate(${radius}, ${radius})`);
+
+  svg
+    .append('text')
+    .attr('class', 'svgDownload')
+    .attr('y', radius + 20)
+    .style('text-anchor', 'middle')
+    .text(downloadMessage);
 
   const g = svg
     .selectAll('.arc')

--- a/src/packages/@ncigdc/components/Charts/PieChart.js
+++ b/src/packages/@ncigdc/components/Charts/PieChart.js
@@ -20,7 +20,7 @@ const getNestedValue = (item, path) => {
   return getNestedValue(nextItem, path);
 };
 
-const downloadMessage = 'Please download the TSV to view data for this chart.';
+const downloadMessage = 'To view data for this chart, download the separate TSV file';
 
 const PieChart = ({
   data,


### PR DESCRIPTION
## Ticket Number

PRTL-2828

## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa-yellow` (which version?)

## Description of Changes

- add a message to the double donut telling people to download the TSV
- added it to pie chart too