### PR TITLE
[PRTL-2869] make svg/png title normal weight

### DIFF
--- a/src/packages/@ncigdc/utils/wrapSvg.js
+++ b/src/packages/@ncigdc/utils/wrapSvg.js
@@ -188,7 +188,7 @@ const wrapSvg = ({
       <g transform="translate(0, ${margins.top || 0})">
         <text x="${width /
     2}" y="0" text-anchor="middle" dominant-baseline="hanging">
-          <tspan style="font-size: 1.4rem; font-weight: 300; color: rgb(61,61,61);">${title}</tspan>
+          <tspan style="font-size: 1.4rem; font-weight: 400; color: rgb(61,61,61);">${title}</tspan>
         </text>
       </g>
       ${beforeObject.html}


### PR DESCRIPTION
## Ticket Number

PRTL-2869

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

made svg download titles 400 weight instead of 300