### PR TITLE
[PRTL-2855] add color to x-axis of bar chart

### DIFF
--- a/src/packages/@ncigdc/components/Charts/BarChart.js
+++ b/src/packages/@ncigdc/components/Charts/BarChart.js
@@ -162,6 +162,10 @@ const BarChart = ({
     .text(d => d)
     .attr('transform', 'rotate(45)');
 
+  hiddenXG.selectAll('path').style('stroke', xAxisStyle.stroke);
+    
+  hiddenXG.selectAll('line').style('stroke', xAxisStyle.stroke);
+
   // display x axis
   const xG = svg
     .append('g')

--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -108,6 +108,7 @@ const Container = ({
 );
 
 const SurvivalPlotWrapper = ({
+  buttonStyle = {},
   height = 0,
   legend = [],
   rawData,


### PR DESCRIPTION
## Ticket Number

PRTL-2855

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- add color to borders in bar chart download (same as the display version of the chart)
- add a default prop for `buttonStyle` because clinical analysis is crashing on `develop` branch