### PR TITLE
[PRTL-2886] show overall survival when no plots are selected

### DIFF
--- a/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
+++ b/src/packages/@ncigdc/components/SurvivalPlotWrapper.js
@@ -86,6 +86,7 @@ const Container = ({
 );
 
 const SurvivalPlotWrapper = ({
+  buttonStyle = {},
   height = 0,
   legend = [],
   rawData: {

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -433,7 +433,8 @@ export default compose(
           })
           : [];
 
-      // keep survival in the 'custom' state unless 
+      // once survival has been customized,
+      // retain the 'custom' flag unless
       // the user resets the whole card
       const isUsingCustomSurvival = isSurvivalCustom ||
         customBinMatches.length > 0;

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -433,7 +433,8 @@ export default compose(
           })
           : [];
 
-      const isUsingCustomSurvival = customBinMatches.length > 0;
+      const isUsingCustomSurvival = isSurvivalCustom ||
+        customBinMatches.length > 0;
 
       const survivalBins = (isUsingCustomSurvival
         ? filterSurvivalData(getContinuousBins({
@@ -489,7 +490,8 @@ export default compose(
         variable: {
           customSurvivalPlots: nextCustomSurvivalPlots,
           isSurvivalCustom: isUsingCustomSurvival,
-          showOverallSurvival: false,
+          showOverallSurvival: isUsingCustomSurvival &&
+            survivalBins.length === 0,
         },
       }));
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -433,6 +433,8 @@ export default compose(
           })
           : [];
 
+      // keep survival in the 'custom' state unless 
+      // the user resets the whole card
       const isUsingCustomSurvival = isSurvivalCustom ||
         customBinMatches.length > 0;
 


### PR DESCRIPTION
## Ticket Number

PRTL-2886

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-yellow`

## Description of Changes

- add default for buttonStyle because the page was crashing
- change survival bin custom flag logic: once you select/deselect a plot, survival is flagged 'custom' until the entire card is reset