### PR TITLE
[PRTL-2910] only make survival API requests when survival is active

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/CategoricalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/CategoricalVariableCard.js
@@ -152,8 +152,8 @@ export default compose(
         return {
           survivalPlotValues: [],
           survivalTableValues: [],
-        }
-      };
+        };
+      }
 
       const binDataSelected = isSurvivalCustom
         ? binData.filter(bin => {

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/CategoricalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/CategoricalVariableCard.js
@@ -141,9 +141,20 @@ export default compose(
       fieldName,
       id,
       variable: {
-        customSurvivalPlots, isSurvivalCustom,
+        active_chart,
+        customSurvivalPlots,
+        isSurvivalCustom,
       },
     }) => {
+      // prevent survival API requests on mount
+      // when a different plot is selected
+      if (active_chart !== 'survival') {
+        return {
+          survivalPlotValues: [],
+          survivalTableValues: [],
+        }
+      };
+
       const binDataSelected = isSurvivalCustom
         ? binData.filter(bin => {
           return find(customSurvivalPlots, ['keyName', bin.key]);

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -395,7 +395,7 @@ export default compose(
     (props, nextProps) => nextProps.variable.active_chart === 'survival' && !(
       isEqual(props.selectedSurvivalBins, nextProps.selectedSurvivalBins) &&
       isEqual(props.variable.bins, nextProps.variable.bins) &&
-      isEqual(props.variable.customSurvivalPlots, props.variable.customSurvivalPlots) &&
+      isEqual(props.variable.customSurvivalPlots, nextProps.variable.customSurvivalPlots) &&
       props.setId === nextProps.setId &&
       props.variable.active_chart === nextProps.variable.active_chart &&
       props.variable.isSurvivalCustom === nextProps.variable.isSurvivalCustom

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -420,8 +420,8 @@ export default compose(
         return {
           survivalPlotValues: [],
           survivalTableValues: [],
-        }
-      };
+        };
+      }
 
       const binsWithNames = Object.keys(bins).map(bin => ({
         ...bins[bin],

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/ContinuousVariableCard.js
@@ -407,12 +407,22 @@ export default compose(
       setId,
       totalDocs,
       variable: {
+        active_chart,
         bins = {},
         continuousBinType,
         customSurvivalPlots,
         isSurvivalCustom,
       },
     }) => {
+      // prevent survival API requests on mount
+      // when a different plot is selected
+      if (active_chart !== 'survival') {
+        return {
+          survivalPlotValues: [],
+          survivalTableValues: [],
+        }
+      };
+
       const binsWithNames = Object.keys(bins).map(bin => ({
         ...bins[bin],
         displayName: continuousBinType === 'default'

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/EnhancedClinicalVariableCard.js
@@ -136,8 +136,12 @@ export default compose(
       !isEqual(props.variable.bins, nextProps.variable.bins) ||
       (props.variable.isSurvivalCustom !== nextProps.variable.isSurvivalCustom &&
         !nextProps.variable.isSurvivalCustom)),
-    ({ populateSurvivalData }) => {
-      populateSurvivalData();
+    ({ populateSurvivalData, variable: { active_chart } }) => {
+      if (active_chart === 'survival') {
+        // prevent survival loading on mount
+        // when a different plot is selected
+        populateSurvivalData();
+      }
     }
   ),
   withPropsOnChange(


### PR DESCRIPTION
## Ticket Number

PRTL-2910

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-yellow`

## Description of Changes

if survival isn't active when a clinical analysis card mounts, return empty arrays for the plot & table, and don't populate the card with any survival data.

this will prevent the cards from making unnecessary requests to the survival endpoint.

also I noticed one of the props/nextProps checks had a typo so I fixed it.