### PR TITLE
[PRTL-2614] fix styling overlaps in exploration

### DIFF
--- a/src/packages/@ncigdc/components/Aggregations/FacetHeader.js
+++ b/src/packages/@ncigdc/components/Aggregations/FacetHeader.js
@@ -30,7 +30,6 @@ const Header = styled(Row, {
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '1rem 1.2rem 0.5rem 1.2rem',
-  backgroundColor: 'white',
 });
 
 const IconsRow = styled(Row, {

--- a/src/packages/@ncigdc/components/Aggregations/index.js
+++ b/src/packages/@ncigdc/components/Aggregations/index.js
@@ -7,7 +7,6 @@ import Link from '@ncigdc/components/Links/Link';
 
 export const Container = styled(Column, {
   padding: '0 1.2rem 1rem 1.2rem',
-  backgroundColor: 'white',
 });
 
 export const InputLabel = styled.label({

--- a/src/packages/@ncigdc/uikit/Form/Input.js
+++ b/src/packages/@ncigdc/uikit/Form/Input.js
@@ -15,7 +15,7 @@ const styles = {
     boxShadow: 'inset 0 1px 1px rgba(0, 0, 0, 0.075)',
     color: '#555555',
     fontSize: '14px',
-    height: '34px',
+    height: '3.4rem',
     lineHeight: '1.42857143',
     minWidth: 0,
     padding: '6px 12px',


### PR DESCRIPTION
## Ticket Number

PRTL-2614

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- remove backgrounds so that backgrounds & borders don't overlap when zoomed @ 80%
- change px to rem to make form inputs consistent with form buttons