### PR TITLE
[PRTL-2917] stop continuous card remounting

### DIFF
--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ContinuousAggregationQuery.js
@@ -256,30 +256,16 @@ export default compose(
   ),
 )(({
   aggData, hits, isLoading, setId, stats, ...props
-}) => isLoading 
-  ? (
-   <Column
-      className="clinical-analysis-card"
-      style={{
-        ...zDepth1,
-        height: 560,
-        justifyContent: 'center',
-        alignItems: 'center',
-        margin: '0 1rem 1rem',
-      }}
-      >
-        <Spinner />
-    </Column>
-  )
-  : (
-    <ContinuousVariableCard
-      data={{
-        ...aggData,
-        hits,
-      }}
-      setId={setId}
-      stats={stats}
-      {...props}
-      />
+}) => (
+  <ContinuousVariableCard
+    data={{
+      ...aggData,
+      hits,
+    }}
+    isLoading={isLoading}
+    setId={setId}
+    stats={stats}
+    {...props}
+    />
   )
 );


### PR DESCRIPTION
## Ticket Number

PRTL-2917

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

- continuous card was remounting because of conditional rendering, so I removed that
- if you pass down the `isLoading` prop, it will show a spinner icon that is already in the render 