### PR TITLE
[PRTL-2928] ensure the analysis container adjusts to the screen size

### DIFF
--- a/src/packages/@ncigdc/components/analysis/AnalysisResult.js
+++ b/src/packages/@ncigdc/components/analysis/AnalysisResult.js
@@ -69,7 +69,7 @@ function undoNotification(dispatch, analysis) {
         </Column>
       ),
       id: `${new Date().getTime()}`,
-    })
+    }),
   );
 }
 
@@ -83,11 +83,9 @@ const AnalysisResult = ({
   const analysisId = query.analysisId || '';
   const currentIndex = Math.max(
     analyses.findIndex(a => a.id === analysisId),
-    0
+    0,
   );
-  const analysisType = analyses[currentIndex].type;
-  const tabMinWidth =
-    analysisType === 'clinical_data' ? { minWidth: 1200 } : {};
+
   return (
     <TabbedLinks
       defaultIndex={currentIndex}
@@ -155,10 +153,7 @@ const AnalysisResult = ({
       }}
       queryParam="analysisId"
       side
-      style={{
-        padding: '1rem 0.7rem',
-        ...tabMinWidth,
-      }}
+      style={{ padding: '1rem 0.7rem' }}
       tabToolbar={(
         <Button
           onClick={() => {
@@ -192,5 +187,5 @@ export default compose(
       return !isEqual(nextAnalyses, analyses);
     },
   }),
-  withRouter
+  withRouter,
 )(pure(AnalysisResult));

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalVariableCard/components/ClinicalBoxPlot.js
@@ -40,7 +40,7 @@ const ClinicalBoxPlot = ({
       minWidth: 300,
     }}
     >
-    <Row 
+    <Row
       className="print-w500"
       style={{ width: '100%' }}
       >
@@ -141,7 +141,7 @@ const ClinicalBoxPlot = ({
         style={{
           height: CHART_HEIGHT + 10,
           maxHeight: CHART_HEIGHT + 10,
-          width: QQ_PLOT_RATIO,
+          width: 'calc(100% - 150px)',
         }}
         >
         <QQPlotQuery


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa` (any version)

## Description of Changes
Removes an unnecessary minimum width enforcement, thus unblocking the container resizing.