### PR TITLE
[PRTL-2968] clear lolliplot collisions

### DIFF
--- a/src/packages/@ncigdc/modern_components/Lolliplot/Lolliplot.js
+++ b/src/packages/@ncigdc/modern_components/Lolliplot/Lolliplot.js
@@ -187,6 +187,7 @@ export default compose(
                 if (lolliplotCollisions[`${d.x},${d.y}`]) {
                   selectCollisions(lolliplotCollisions[`${d.x},${d.y}`]);
                 } else {
+                  selectCollisions([]);
                   push(`/ssms/${d.id}`);
                 }
               }}


### PR DESCRIPTION
## Ticket Number

PRTL-2968

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

if you click a single point in lolliplot, clear any point collisions in state, so the message showing the previously selected points will go away.