### PR TITLE
[PRTL-3032] Cohort Comparison: make Age @ DX cases match Explore

### DIFF
--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
@@ -236,7 +236,6 @@ export default compose(
                           .histogram.buckets,
                         result2.aggregations.diagnoses__age_at_diagnosis
                           .histogram.buckets,
-                        result1.hits.total,
                       ),
                     },
                     data2: {
@@ -246,7 +245,6 @@ export default compose(
                           .histogram.buckets,
                         result1.aggregations.diagnoses__age_at_diagnosis
                           .histogram.buckets,
-                        result2.hits.total,
                       ),
                     },
                     result1,

--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.js
@@ -38,16 +38,13 @@ const transformAgeAtDiagnosis = (buckets, compareBuckets) => {
         key,
         doc_count: 0,
       };
-    })
-    .map(({ doc_count, key }) => ({
-      doc_count,
-      key: parseInt(key, 10),
-    }));
+    });
 
   const buildDisplayKeyAndFilters = (acc, { doc_count, key }) => {
     const displayRange = `${getLowerAgeYears(key)}${acc.nextAge === 0
       ? '+'
-      : ` - ${getUpperAgeYears(acc.nextAge - 1)}`}`;
+      : ` - ${getUpperAgeYears(acc.nextAge - 0.1)}`}`;
+
     return {
       nextAge: key,
       data: [
@@ -68,7 +65,7 @@ const transformAgeAtDiagnosis = (buckets, compareBuckets) => {
                 op: '<=',
                 content: {
                   field: 'cases.diagnoses.age_at_diagnosis',
-                  value: [acc.nextAge - 1],
+                  value: [acc.nextAge - 0.1],
                 },
               },
             ]),

--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.relay.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.relay.js
@@ -8,6 +8,7 @@ import { get, isEqual } from 'lodash';
 import Query from '@ncigdc/modern_components/Query';
 import withRouter from '@ncigdc/utils/withRouter';
 import { parseJSONParam } from '@ncigdc/utils/uri';
+import { DAYS_IN_YEAR } from '@ncigdc/utils/ageDisplay';
 
 export default (Component: React$Element<*>) =>
   compose(
@@ -63,6 +64,7 @@ export default (Component: React$Element<*>) =>
                 },
               ],
             },
+            interval: 10 * DAYS_IN_YEAR,
           },
         };
       },
@@ -78,6 +80,7 @@ export default (Component: React$Element<*>) =>
             $filter1: FiltersArgument
             $filter2: FiltersArgument
             $facets: [String]!
+            $interval: Float
           ) {
             viewer {
               repository {
@@ -92,7 +95,7 @@ export default (Component: React$Element<*>) =>
                         min
                         max
                       }
-                      histogram(interval: 3652.4444444444) {
+                      histogram(interval: $interval) {
                         buckets {
                           doc_count
                           key
@@ -112,7 +115,7 @@ export default (Component: React$Element<*>) =>
                         min
                         max
                       }
-                      histogram(interval: 3652.4444444444) {
+                      histogram(interval: $interval) {
                         buckets {
                           doc_count
                           key

--- a/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.relay.js
+++ b/src/packages/@ncigdc/modern_components/CohortComparison/CohortComparison.relay.js
@@ -17,7 +17,7 @@ export default (Component: React$Element<*>) =>
         ['sets', 'query.activeFacets'].some(
           k => !isEqual(get(props, k), get(nextProps, k)),
         ),
-      ({ sets, query }) => {
+      ({ query, sets }) => {
         const [[setId1, setName1], [setId2, setName2]] = Object.entries(
           sets.case,
         );
@@ -26,17 +26,17 @@ export default (Component: React$Element<*>) =>
           typeof query.activeFacets !== 'undefined'
             ? parseJSONParam(query.activeFacets)
             : [
-                'demographic.gender',
-                'diagnoses.age_at_diagnosis',
-                'demographic.vital_status',
-              ];
+              'demographic.gender',
+              'diagnoses.age_at_diagnosis',
+              'demographic.vital_status',
+            ];
 
         return {
+          activeFacets,
           setId1,
           setId2,
           setName1,
           setName2,
-          activeFacets,
           variables: {
             facets: activeFacets,
             filter1: {
@@ -70,10 +70,9 @@ export default (Component: React$Element<*>) =>
   )((props: Object) => {
     return (
       <Query
+        Component={Component}
         minHeight={500}
         parentProps={props}
-        variables={props.variables}
-        Component={Component}
         query={graphql`
           query CohortComparison_relayQuery(
             $filter1: FiltersArgument
@@ -126,6 +125,7 @@ export default (Component: React$Element<*>) =>
             }
           }
         `}
-      />
+        variables={props.variables}
+        />
     );
   });


### PR DESCRIPTION
## Ticket Number

PRTL-3032

## Environment to be used in testing

- [x] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes

I changed Cohort Comparison to use 1 decimal point for Age at Diagnosis, as we established in Clinical Analysis.

It was using integers for Explore links and several decimal points for the query, which was creating inconsistencies in the number of cases in each bucket.