### PR TITLE
[PRTL-3093] add Study param to Most Mutated Genes histogram

### DIFF
--- a/src/packages/@ncigdc/components/Explore/GenesTab.js
+++ b/src/packages/@ncigdc/components/Explore/GenesTab.js
@@ -121,7 +121,6 @@ export default compose(
     showingMore,
     state: { loading },
     survivalData,
-    viewer,
   }) => (
     <Column style={styles.card}>
       <h1

--- a/src/packages/@ncigdc/containers/explore/ExplorePage.js
+++ b/src/packages/@ncigdc/containers/explore/ExplorePage.js
@@ -31,7 +31,7 @@ import Button from '@ncigdc/uikit/Button';
 import ResizeDetector from 'react-resize-detector';
 import SummaryPage from '@ncigdc/components/Explore/SummaryPage';
 import withFacetData from '@ncigdc/modern_components/IntrospectiveType/Introspective.relay';
-import { CaseLimitMessages } from '@ncigdc/modern_components/RestrictionMessage';
+import CaseLimitMessages from '@ncigdc/modern_components/RestrictionMessage/CaseLimitMessages';
 import ControlledAccessSwitch from '@ncigdc/components/ControlledAccessSwitch';
 
 import {
@@ -209,7 +209,7 @@ const ExplorePageComponent = ({
                 text: `Cases (${hasCaseHits.toLocaleString()})`,
               },
               {
-                component: isCaseLimitExceeded || controlledStudies
+                component: isCaseLimitExceeded
                   ? (
                     <CaseLimitMessages
                       isCaseLimitExceeded={isCaseLimitExceeded}
@@ -217,7 +217,7 @@ const ExplorePageComponent = ({
                   )
                   : hasGeneHits
                     ? (
-                      <GenesTab viewer={viewerWithCA} />
+                      <GenesTab />
                     )
                     : (
                       <NoResultsMessage>No Genes Found.</NoResultsMessage>
@@ -228,7 +228,7 @@ const ExplorePageComponent = ({
                   : ` (${hasGeneHits.toLocaleString()})`}`,
               },
               {
-                component: isCaseLimitExceeded || controlledStudies
+                component: isCaseLimitExceeded
                   ? (
                     <CaseLimitMessages
                       isCaseLimitExceeded={isCaseLimitExceeded}
@@ -250,7 +250,7 @@ const ExplorePageComponent = ({
                   : ` (${hasSsmsHits.toLocaleString()})`}`,
               },
               {
-                component: isCaseLimitExceeded || controlledStudies
+                component: isCaseLimitExceeded
                   ? (
                     <CaseLimitMessages
                       isCaseLimitExceeded={isCaseLimitExceeded}

--- a/src/packages/@ncigdc/modern_components/GenesBarChart/GenesBarChart.js
+++ b/src/packages/@ncigdc/modern_components/GenesBarChart/GenesBarChart.js
@@ -8,7 +8,7 @@ import { parse } from 'query-string';
 
 import withRouter from '@ncigdc/utils/withRouter';
 import { parseFilterParam, stringifyJSONParam } from '@ncigdc/utils/uri';
-import { viewerQuery } from '@ncigdc/routes/queries';
+import { viewerQueryCA } from '@ncigdc/routes/queries';
 import { makeFilter, removeFilter } from '@ncigdc/utils/filters';
 import { withTheme } from '@ncigdc/theme';
 import { Row, Column } from '@ncigdc/uikit/Flex';
@@ -29,7 +29,7 @@ const COMPONENT_NAME = 'GenesBarChart';
 class Route extends Relay.Route {
   static routeName = COMPONENT_NAME;
 
-  static queries = viewerQuery;
+  static queries = viewerQueryCA;
 
   static prepareParams = ({ location: { search }, defaultFilters = null }) => {
     const q = parse(search);
@@ -95,8 +95,8 @@ const createContainer = Component => Relay.createContainer(Component, {
     // ]),
   },
   fragments: {
-    viewer: () => Relay.QL`
-        fragment on Root {
+    viewerWithCA: () => Relay.QL`
+        fragment RequiresStudy on Root {
           explore {
             cases {
               aggregations(filters: $ssmTested) {
@@ -170,7 +170,7 @@ const Component = compose(
   ({
     projectId = '',
     theme,
-    viewer: {
+    viewerWithCA: {
       explore: { genes = { hits: { edges: [] } }, cases, filteredCases },
     },
     context = 'explore',

--- a/src/packages/@ncigdc/modern_components/RestrictionMessage/index.js
+++ b/src/packages/@ncigdc/modern_components/RestrictionMessage/index.js
@@ -1,5 +1,0 @@
-import CaseLimitMessages from './CaseLimitMessages';
-
-export {
-  CaseLimitMessages,
-};


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa-uat`

## Description of Changes
Adds the Study relay hack to the histogram.
Removes the CA restriction message (as there was no use case for it).