### PR TITLE
[PRTL-3095] add Study param to Genes Survival plot

### DIFF
--- a/src/packages/@ncigdc/components/Explore/GenesTab.js
+++ b/src/packages/@ncigdc/components/Explore/GenesTab.js
@@ -4,6 +4,8 @@ import { get } from 'lodash';
 import {
   compose, withState, withProps, withHandlers,
 } from 'recompose';
+
+import { withControlledAccessNetworkLayer } from '@ncigdc/utils/withControlledAccess';
 import { Row, Column } from '@ncigdc/uikit/Flex';
 import { getDefaultCurve, enoughData } from '@ncigdc/utils/survivalplot';
 import withFilters from '@ncigdc/utils/withFilters';
@@ -45,8 +47,10 @@ export default compose(
   withState('selectedSurvivalData', 'setSelectedSurvivalData', {}),
   withState('showingMore', 'setShowingMore', false),
   withState('state', 'setState', initialState),
+  withControlledAccessNetworkLayer,
   withProps(
     ({
+      addControlledAccessParams,
       defaultSurvivalData,
       filters,
       selectedSurvivalData,
@@ -60,8 +64,9 @@ export default compose(
       },
       updateData: async () => {
         const survivalData = await getDefaultCurve({
+          addControlledAccessParams,
           currentFilters: filters,
-          slug: 'Explore',
+          slug: 'ExploreGenesSurvivalPlot',
         });
 
         setDefaultSurvivalData(survivalData);


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes
Adds the Study param functionality to all survival plots, and enables it for the one in Exploration's Genes tab.