### PR TITLE
[PRTL-3128] add CA hack for demo CA studies

### DIFF
--- a/src/packages/@ncigdc/components/Modals/ControlledAccess/ControlledAccessModal.js
+++ b/src/packages/@ncigdc/components/Modals/ControlledAccess/ControlledAccessModal.js
@@ -9,6 +9,7 @@ import {
   withState,
 } from 'recompose';
 
+import { isDemoHack } from '@ncigdc/utils/withControlledAccess';
 import BaseModal from '@ncigdc/components/Modals/BaseModal';
 import LoginButton from '@ncigdc/components/LoginButton';
 import ExploreLink from '@ncigdc/components/Links/ExploreLink';
@@ -54,7 +55,7 @@ const ControlledAccessModal = ({
                   op: 'IN',
                   content: {
                     field: 'cases.project.program.name',
-                    value: selectedStudiesUpperCase,
+                    value: isDemoHack(selectedStudiesUpperCase),
                   },
                 },
               ],

--- a/src/packages/@ncigdc/utils/constants.js
+++ b/src/packages/@ncigdc/utils/constants.js
@@ -397,6 +397,14 @@ export const DEV_USER_CA = [ // controlled access mock
   {
     programs: [
       {
+        name: 'HCMI_DEMO',
+        projects: ['HCMI_DEMO-CMDC'],
+      },
+    ],
+  },
+  {
+    programs: [
+      {
         name: 'TARGET',
         projects: ['TARGET-ALL-P2', 'TARGET-OS'],
       },

--- a/src/packages/@ncigdc/utils/withControlledAccess/helpers.js
+++ b/src/packages/@ncigdc/utils/withControlledAccess/helpers.js
@@ -6,6 +6,10 @@ export const checkUserAccess = (
   programs: userStudies[study],
 }));
 
+export const isDemoHack = selectedStudies => selectedStudies.map(study => (
+  study.replace('_DEMO', '').replace('_demo', '') // casing-agnostic
+));
+
 export const reshapeSummary = controlledAccessSummary => (
   [ // Sorting order for the modal, as per requirement
     'controlled',

--- a/src/packages/@ncigdc/utils/withControlledAccess/index.js
+++ b/src/packages/@ncigdc/utils/withControlledAccess/index.js
@@ -30,9 +30,14 @@ import {
 
 import {
   checkUserAccess,
+  isDemoHack,
   reshapeSummary,
   reshapeUserAccess,
 } from './helpers';
+
+export {
+  isDemoHack,
+};
 
 const CONTROLLED_ACCESS_CONTEXT = {
   controlledAccessProps: PropTypes.object,


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-uat`

## Description of Changes
Adds helper to check if any CA study includes the prefix "_demo" (casing-agnostically), and removes it when autoselecting the corresponding filter.