### PR TITLE
[PRTL-3121] update Set Operations Demo, varscan is “deprecated”

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - npm test || travis_terminate 1
   - stage: deploy
     script:
-    - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+    - echo "$QUAY_PASSWORD" | docker login quay.io -u="$QUAY_USERNAME" --password-stdin
     - bash build.sh
     - bash docker.sh
     - bash awgbuild.sh

--- a/src/packages/@ncigdc/components/analysis/availableAnalysis.js
+++ b/src/packages/@ncigdc/components/analysis/availableAnalysis.js
@@ -94,7 +94,7 @@ const availableAnalysis: [TAnalysis] = [
           ],
           op: 'and',
         },
-        'demo-bladder-high-varscan': {
+        'demo-bladder-high-varscan2': {
           content: [
             {
               content: {
@@ -114,7 +114,7 @@ const availableAnalysis: [TAnalysis] = [
               content: {
                 field:
                   'ssms.occurrence.case.observation.variant_calling.variant_caller',
-                value: ['varscan'],
+                value: ['varscan2'],
               },
               op: 'in',
             },
@@ -128,7 +128,7 @@ const availableAnalysis: [TAnalysis] = [
         ssm: {
           'demo-bladder-high-muse': 'Bladder, High impact, Muse',
           'demo-bladder-high-mutect2': 'Bladder, High impact, Mutect2',
-          'demo-bladder-high-varscan': 'Bladder, High impact, Varscan',
+          'demo-bladder-high-varscan2': 'Bladder, High impact, Varscan2',
         },
       },
       type: 'set_operations',


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [x] `dev-oicr`
- [x] `qa-uat`

## Description of Changes
Updates the demo set name, and fixes a travis warning.