### PR TITLE
[PRTL-3153] add codeguard to restore slide viewer

### DIFF
--- a/src/packages/@ncigdc/components/ZoomableImage.js
+++ b/src/packages/@ncigdc/components/ZoomableImage.js
@@ -68,9 +68,12 @@ const enhance = compose(
             viewer.addControl(document.querySelector('#details-button'), {
               anchor: OpenSeadragon.ControlAnchor.TOP_LEFT,
             });
-            // an empty label that 508 scan doesnt like
-            document.querySelector('.openseadragon-container label').remove();
+
             setViewer(viewer);
+
+            // an empty label that 508 scan doesnt like
+            document.querySelector('.openseadragon-container label') &&
+              document.querySelector('.openseadragon-container label').remove();
           }
         });
     },


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa-orange`

## Description of Changes
Adds a codeguard to a piece of code that was stopping script execution, and relocated the conflicting function down in the script, where it wouldn't conflict if the codeguard is insufficient.