### PR TITLE
[PRTL-3151] remove stray CA request.

### DIFF
--- a/src/packages/@ncigdc/components/Header/SectionBanner.js
+++ b/src/packages/@ncigdc/components/Header/SectionBanner.js
@@ -26,13 +26,13 @@ const sectionTitles = {
 
 export default compose(
   setDisplayName('EnhancedSectionHeader'),
-  withRouter,
   withControlledAccess,
+  withRouter,
   withPropsOnChange(
     ({
       controlledAccessProps: {
         controlledStudies,
-      },
+      } = {},
       location: {
         pathname,
         state,
@@ -40,7 +40,7 @@ export default compose(
     }, {
       controlledAccessProps: {
         controlledStudies: nextControlledStudies,
-      },
+      } = {},
       location: {
         pathname: nextPathname,
         state: nextState,
@@ -52,8 +52,8 @@ export default compose(
     ),
     ({
       controlledAccessProps: {
-        controlledStudies,
-      },
+        controlledStudies = [],
+      } = {},
       location: {
         pathname,
         state: {

--- a/src/packages/@ncigdc/components/Header/index.js
+++ b/src/packages/@ncigdc/components/Header/index.js
@@ -263,13 +263,13 @@ export default compose(
   withState('headerHeight', 'setHeaderHeight', 0),
   withState('isCollapsed', 'setIsCollapsed', true),
   withState('isInSearchMode', 'setIsInSearchMode', false),
+  withControlledAccess,
   withRouter,
   connect(state => ({
     error: state.error,
     notifications: state.bannerNotification,
     user: state.auth.user,
   })),
-  withControlledAccess,
   withHandlers({
     handleApiError: ({ dispatch }) => ({ status, user }) => {
       if (user && status === 401) {

--- a/src/packages/@ncigdc/components/Modals/ControlledAccess/ControlledAccessModal.js
+++ b/src/packages/@ncigdc/components/Modals/ControlledAccess/ControlledAccessModal.js
@@ -82,7 +82,7 @@ const ControlledAccessModal = ({
           handleProgramSelect,
           selectedStudies,
           setSelectedStudies,
-          studiesList,
+          studiesSummary,
           user,
           userAccessList,
         })}
@@ -105,7 +105,7 @@ const ControlledAccessModal = ({
           <span>
             {'If you don\'t have access, follow the instructions for '}
             <a href="https://gdc.cancer.gov/access-data/obtaining-access-controlled-data" rel="noopener noreferrer" target="_blank">obtaining access to controlled data</a>
-          .
+            .
           </span>
         </RestrictionMessage>
       )}

--- a/src/packages/@ncigdc/utils/withControlledAccess/index.js
+++ b/src/packages/@ncigdc/utils/withControlledAccess/index.js
@@ -32,13 +32,17 @@ import {
 
 export default compose(
   setDisplayName('withControlledAccess'),
+  withRouter,
   connect(state => ({
     token: state.auth.token,
     user: state.auth.user,
     userControlledAccess: state.auth.userControlledAccess,
   })),
-  withRouter,
-  withState('studiesSummary', 'setStudiesSummary', {}),
+  withState('studiesSummary', 'setStudiesSummary', {
+    controlled: [],
+    in_process: [],
+    open: [],
+  }),
   withHandlers({
     clearUserAccess: ({
       dispatch,
@@ -70,6 +74,15 @@ export default compose(
       });
     },
   }),
+  lifecycle({
+    componentDidMount() {
+      const {
+        fetchStudiesList,
+      } = this.props;
+
+      DISPLAY_DAVE_CA && fetchStudiesList();
+    },
+  }),
   withPropsOnChange(
     (
       {
@@ -86,7 +99,7 @@ export default compose(
       storeUserAccess,
       user,
       userControlledAccess,
-    }) => (user
+    }) => (user && DISPLAY_DAVE_CA
       ? userControlledAccess.fetched || (
         IS_DEV || DEV_USER
           ? storeUserAccess(DEV_USER_CA)
@@ -173,29 +186,22 @@ export default compose(
         ),
       });
 
-      return DISPLAY_DAVE_CA && {
-        controlledAccessProps: {
-          controlledStudies,
-          showControlledAccessModal: () => {
-            dispatch(setModal(
-              <ControlledAccessModal
-                activeControlledPrograms={controlledStudies}
-                closeModal={() => dispatch(setModal(null))}
-                studiesSummary={studiesSummary}
-                />,
-            ));
-          },
-        },
+      return {
+        controlledAccessProps: DISPLAY_DAVE_CA
+          ? {
+            controlledStudies,
+            showControlledAccessModal: () => {
+              dispatch(setModal(
+                <ControlledAccessModal
+                  activeControlledPrograms={controlledStudies}
+                  closeModal={() => dispatch(setModal(null))}
+                  studiesSummary={studiesSummary}
+                  />,
+              ));
+            },
+          }
+          : {},
       };
     },
   ),
-  lifecycle({
-    componentDidMount() {
-      const {
-        fetchStudiesList,
-      } = this.props;
-
-      fetchStudiesList();
-    },
-  }),
 );


### PR DESCRIPTION
## Environment to be used in testing

- [x] `prod`
- [x] `dev-oicr`
- [x] `qa-orange`

## Description of Changes
- Removes an unnecessary call to one of the CA endpoints, by putting it behind the corresponding feature flag.
Bonus: a couple other fixes to ensure no crashes happen if the flag is added while the CA endpoints are not available.