### PR TITLE
Change jenkins to use master branch of jenkins-lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!groovy
 
-library identifier: "jenkins-lib@fix/build-fix"
+library identifier: "jenkins-lib@master"
 dockerPipeline{
+    tagSource = "semver"
     // testBranches = '(develop|master|release.*)'
 }


### PR DESCRIPTION
### Description of Changes
Changing Jenkinsfile to use the develop branch of the Jenkins pipelines. 
