### PR TITLE
GDCDEVOPS-535: Using latest nginx-extras image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ncigdc/nginx-extras:1.10.3-redfish
+FROM docker.osdc.io/ncigdc/nginx-extras:1.1.0
 
 RUN rm -v /etc/nginx/sites-enabled/default
 

--- a/awgportal.Dockerfile
+++ b/awgportal.Dockerfile
@@ -21,7 +21,7 @@ RUN export REACT_APP_COMMIT_HASH=`git rev-parse --short HEAD` && export REACT_AP
 RUN npm install
 RUN npm run build
 
-FROM quay.io/ncigdc/nginx-extras:1.10.3-redfish
+FROM docker.osdc.io/ncigdc/nginx-extras:1.1.0
 
 RUN rm -v /etc/nginx/sites-enabled/default
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,7 +47,7 @@ proxy:
   replicaCount: 1
   image: 
     repository: docker.osdc.io/ncigdc/nginx-extras
-    tag: 1.10.3-pinwheel
+    tag: 1.1.0
   ingress:
     enabled: true
     annotations: {}

--- a/portal.Dockerfile
+++ b/portal.Dockerfile
@@ -18,7 +18,7 @@ RUN export REACT_APP_COMMIT_HASH=`git rev-parse --short HEAD` && export REACT_AP
 RUN npm install
 RUN npm run build
 
-FROM quay.io/ncigdc/nginx-extras:1.10.3-redfish
+FROM docker.osdc.io/ncigdc/nginx-extras:1.1.0
 
 RUN rm -v /etc/nginx/sites-enabled/default
 


### PR DESCRIPTION
## Ticket Number

GDCDEVOPS-535

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
- Updating dockerfile to use latest nginx-extras container 