### PR TITLE
[PRTL-3233] improve GeneEx loading spinner

### DIFF
--- a/src/packages/@ncigdc/modern_components/GeneExpression/GeneExpression.js
+++ b/src/packages/@ncigdc/modern_components/GeneExpression/GeneExpression.js
@@ -156,6 +156,7 @@ export default compose(
       loadingHandler: ({
         setIsLoading,
       }) => chartIsLoading => {
+        // This is for future implementation, to allow InchLib to change the message. "Loading heatmap"
         setIsLoading(chartIsLoading);
       },
     };

--- a/src/packages/@ncigdc/modern_components/GeneExpression/GeneExpressionChart.js
+++ b/src/packages/@ncigdc/modern_components/GeneExpression/GeneExpressionChart.js
@@ -40,10 +40,12 @@ class GeneExpressionChart extends Component {
     const {
       handleClickInchlibLink,
       handleFileDownloads,
+      handleLoading,
       visualizationData,
     } = this.props;
     this.handlers = {
       handleFileDownloads,
+      handleLoading,
     };
     this.options = {
       ...options,

--- a/src/packages/@ncigdc/modern_components/GeneExpression/inchlib/index.js
+++ b/src/packages/@ncigdc/modern_components/GeneExpression/inchlib/index.js
@@ -3915,23 +3915,29 @@ import { getLowerAgeYears } from '@ncigdc/utils/ageDisplay';
     */
   InCHlib.prototype.init = function () {
     const self = this;
-    // setTimeout is used to force synchronicity in canvas
-    const loading_div = $('<div style="width: 300px; height: 300px; display: flex; align-items: center; justify-content: center;"></div>').html('<i class="fa fa-spinner fa-pulse" style="font-size: 32px"></i>');
-    self.$element.after(loading_div);
-    self.$element.hide();
-
-    setTimeout(function () {
+    if (self.extHandlers.handleLoading) {
       self.read_data(self.options.data);
       self.draw();
-    }, 50);
+      self.extHandlers.handleLoading(false);
+    } else {
+      // setTimeout is used to force synchronicity in canvas
+      const loading_div = $('<div style="width: 300px; height: 300px; display: flex; align-items: center; justify-content: center;"></div>').html('<i class="fa fa-spinner fa-pulse" style="font-size: 32px"></i>');
+      self.$element.after(loading_div);
+      self.$element.hide();
 
-    setTimeout(function () {
-      loading_div.fadeOut().remove();
-      self.$element.show();
-    }, 50);
+      setTimeout(function () {
+        self.read_data(self.options.data);
+        self.draw();
+      }, 50);
+
+      setTimeout(function () {
+        loading_div.fadeOut().remove();
+        self.$element.show();
+      }, 50);
+    }
   };
 
-  $.fn[plugin_name] = function (options, extHandlers) {
+  $.fn[plugin_name] = function (options = {}, extHandlers = {}) {
     // note: this plugin only supports ONE instance
     return this.each(function () {
       if ($.data(this, 'plugin_' + plugin_name)) {

--- a/src/packages/@ncigdc/modern_components/GeneExpression/inchlib/index.js
+++ b/src/packages/@ncigdc/modern_components/GeneExpression/inchlib/index.js
@@ -3918,6 +3918,7 @@ import { getLowerAgeYears } from '@ncigdc/utils/ageDisplay';
     if (self.extHandlers.handleLoading) {
       self.read_data(self.options.data);
       self.draw();
+      // Future implementation: passing a string here could update the message in the loader. "Loading heatmap"
       self.extHandlers.handleLoading(false);
     } else {
       // setTimeout is used to force synchronicity in canvas

--- a/src/packages/@ncigdc/modern_components/GeneExpression/index.ts
+++ b/src/packages/@ncigdc/modern_components/GeneExpression/index.ts
@@ -1,4 +1,1 @@
-import GeneExpression from './GeneExpression';
-// import createRenderer from './GeneExpression.relay';
-
-export default GeneExpression;
+export { default } from './GeneExpression';


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-purple`

## Description of Changes
Adds a loading spinner on first render, remains while the data is being gathered and processed, and removed once inchlib is ready to be displayed.