### PR TITLE
[PRTL-3236] remove malfunctioning dispatch thens

### DIFF
--- a/src/packages/@ncigdc/components/CreateOrOpenAnalysis.js
+++ b/src/packages/@ncigdc/components/CreateOrOpenAnalysis.js
@@ -51,16 +51,16 @@ const CreateOrOpenAnalysis = ({
             type,
             created,
           }),
-        ).then(() => {
-          window.open(
-            `analysis?${queryString.stringify({
-              analysisTableTab: 'result',
-              analysisId: id,
-            })}`,
-          );
-        });
+        );
+
+        window.open(
+          `analysis?${queryString.stringify({
+            analysisTableTab: 'result',
+            analysisId: id,
+          })}`,
+        );
       }}
-    >
+      >
       {children}
     </UnstyledButton>
   );

--- a/src/packages/@ncigdc/components/analysis/CreateAnalysis.js
+++ b/src/packages/@ncigdc/components/analysis/CreateAnalysis.js
@@ -53,18 +53,21 @@ const CreateAnalysis = ({
 
             dispatch(
               addAnalysis({
-                analysisInfo: { ...selectedCase, ...selectedFile },
+                analysisInfo: {
+                  ...selectedCase,
+                  ...selectedFile,
+                },
                 created,
                 id,
                 type: analysis.type,
               }),
-            ).then(() => {
-              push({
-                query: {
-                  analysisId: id,
-                  analysisTableTab: 'result',
-                },
-              });
+            );
+
+            push({
+              query: {
+                analysisId: id,
+                analysisTableTab: 'result',
+              },
             });
           }}
           />
@@ -88,13 +91,13 @@ const CreateAnalysis = ({
                   name: `Custom Analysis ${numAnalysis + 1}`,
                 },
               }),
-            ).then(() => {
-              push({
-                query: {
-                  analysisId: id,
-                  analysisTableTab: 'result',
-                },
-              });
+            );
+
+            push({
+              query: {
+                analysisId: id,
+                analysisTableTab: 'result',
+              },
             });
           }}
           />

--- a/src/packages/@ncigdc/components/analysis/DemoButton.js
+++ b/src/packages/@ncigdc/components/analysis/DemoButton.js
@@ -41,21 +41,22 @@ const DemoButton = ({
             value: demoData.displayVariables,
             property: 'displayVariables',
             id,
-          })
+          }),
         );
       }
+
       pushToResultTab(id);
     } else {
       dispatch(
         addAnalysis({
           id,
-          type: type,
+          type,
           created: new Date().toISOString(),
           ...demoData,
         }),
-      ).then(() => {
-        pushToResultTab(id);
-      });
+      );
+
+      pushToResultTab(id);
     }
   };
 

--- a/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
+++ b/src/packages/@ncigdc/modern_components/ClinicalAnalysis/ClinicalAnalysisResult.js
@@ -87,20 +87,21 @@ const CopyAnalysisModal = compose(
     onClose={() => {
       const created = new Date().toISOString();
       const id = created;
+
       dispatch(
         addAnalysis({
           ...analysis,
           created,
           id,
           name: modalInputValue,
-        })
-      ).then(() => {
-        push({
-          query: {
-            analysisId: id,
-            analysisTableTab: 'result',
-          },
-        });
+        }),
+      );
+
+      push({
+        query: {
+          analysisId: id,
+          analysisTableTab: 'result',
+        },
       });
     }}
     title="Copy Analysis"


### PR DESCRIPTION
## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-purple`

## Description of Changes

TL;DR: a few Redux action dispatchers were being incorrectly used as `thenables`, even though they were all dispatching a thunk without returning a promise.

Checked all dispatchers throughout the app, to ensure their validity.
Found only 4 offending dispatchers, all of which used the same single action thunk related to analyses.
...

Explanation of the bug: In order for a Redux dispatch to be made "thenable", the action creator MUST return a promise (and may be done with observables?); which was never the case in the codebase, yet somehow worked until now. ¯\(ツ)/¯

Such dispatchers stopped working as a result of updating some dependencies when working on AWG token renewal (needed to correct a race condition that blocked implementation).

Redux-api-middleware, in an outdated beta version, while fixing a bug they introduced now enforces the correct dispatch behaviour (i.e. it was erroneously returning promises, [as seen here](https://github.com/agraboso/redux-api-middleware/pull/167/files)).
That bug not being introduced anymore by the middleware, our faulty segments of code was "held accountable".