### PR TITLE
[PRTL-3289] handle empty TSV rows for scRNA

### DIFF
--- a/src/packages/@ncigdc/modern_components/SCRNASeq/helpers.js
+++ b/src/packages/@ncigdc/modern_components/SCRNASeq/helpers.js
@@ -32,30 +32,31 @@ export const shapeClusteringData = (parsedChunk, existingData) => (
         const cluster = parsedRow.seurat_cluster;
         const currentCluster = data[cluster] || rowBaseTemplate(is3D);
 
-
-        return ({
-          ...acc,
-          [simplifiedMethodName]: {
-            ...previous,
-            data: Object.values({
-              ...data,
-              [cluster]: {
-                ...currentCluster,
-                name: `${Number(cluster)} - ${(currentCluster.x || []).length} cells`,
-                x: (currentCluster.x || [])
-                  .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_1`]),
-                y: (currentCluster.y || [])
-                  .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_2`]),
-                ...is3D
-                  ? {
-                    z: (currentCluster.z || [])
-                      .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_3`]),
-                  }
-                  : {},
-              },
-            }),
-          },
-        });
+        return cluster
+          ? ({
+            ...acc,
+            [simplifiedMethodName]: {
+              ...previous,
+              data: Object.values({
+                ...data,
+                [cluster]: {
+                  ...currentCluster,
+                  name: `${Number(cluster)} - ${(currentCluster.x || []).length} cells`,
+                  x: (currentCluster.x || [])
+                    .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_1`]),
+                  y: (currentCluster.y || [])
+                    .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_2`]),
+                  ...is3D
+                    ? {
+                      z: (currentCluster.z || [])
+                        .concat(parsedRow[`${headerNormaliser(simplifiedMethodName)}_3`]),
+                    }
+                    : {},
+                },
+              }),
+            },
+          })
+          : acc;
       },
       newState,
     )


### PR DESCRIPTION
## Ticket Number

e.g. PRTL-0000

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa-yellow`

## Description of Changes
Parses the TSV stream, ignoring empty rows.