### PR TITLE
DEV-524 support range facet for doubles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4555,19 +4555,30 @@
           }
         },
         "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
+            "readdirp": "~3.5.0"
+          },
+          "dependencies": {
+            "readdirp": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+              "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
+            }
           }
         },
         "fill-range": {
@@ -4578,6 +4589,13 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
         },
         "glob-parent": {
           "version": "5.1.1",
@@ -4628,7 +4646,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
           "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -8437,27 +8454,36 @@
           }
         },
         "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
+            "readdirp": "~3.5.0"
           },
           "dependencies": {
             "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+              "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
               "dev": true,
               "optional": true
+            },
+            "readdirp": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+              "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
             }
           }
         },
@@ -8537,7 +8563,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
           "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -14201,8 +14226,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "2.3.0",
@@ -23089,19 +23113,19 @@
           }
         },
         "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
+            "readdirp": "~3.5.0"
           },
           "dependencies": {
             "anymatch": {
@@ -23133,9 +23157,9 @@
               }
             },
             "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+              "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
               "dev": true,
               "optional": true
             },
@@ -23168,6 +23192,15 @@
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
               "dev": true
+            },
+            "readdirp": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+              "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
             },
             "to-regex-range": {
               "version": "5.0.1",
@@ -23447,7 +23480,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
           "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -23893,19 +23925,19 @@
           }
         },
         "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
+            "readdirp": "~3.5.0"
           },
           "dependencies": {
             "anymatch": {
@@ -23937,9 +23969,9 @@
               }
             },
             "fsevents": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+              "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
               "dev": true,
               "optional": true
             },
@@ -23972,6 +24004,15 @@
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
               "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
               "dev": true
+            },
+            "readdirp": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+              "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
             },
             "to-regex-range": {
               "version": "5.0.1",
@@ -24323,7 +24364,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
           "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
           }

--- a/src/packages/@ncigdc/components/FacetWrapper.js
+++ b/src/packages/@ncigdc/components/FacetWrapper.js
@@ -49,7 +49,7 @@ const fieldNameToTitle = fieldName => fieldName
   )
   .join(' ');
 
-const getFacetType = facet => {
+export const getFacetType = facet => {
   if (_.includes(facet.field, 'datetime')) {
     return 'datetime';
   } if (facet.type === 'terms') {
@@ -67,7 +67,7 @@ const getFacetType = facet => {
     ], idSuffix => _.includes(facet.field, idSuffix))
   ) {
     return 'exact';
-  } if (facet.type === 'long' || facet.type === 'float') {
+  } if (facet.type === 'long' || facet.type === 'float' || facet.type === 'double') {
     return 'range';
   }
   return 'terms';

--- a/src/packages/@ncigdc/components/__tests__/FacetWrapper.tests.js
+++ b/src/packages/@ncigdc/components/__tests__/FacetWrapper.tests.js
@@ -1,0 +1,17 @@
+import { getFacetType } from '@ncigdc/components/FacetWrapper';
+
+describe('getFacetType', () => {
+  describe('returns "range"', () => {
+    it('for long types', () => {
+      expect(getFacetType({ type: 'long' })).toBe('range');
+    });
+
+    it('for float types', () => {
+      expect(getFacetType({ type: 'float' })).toBe('range');
+    });
+
+    it('for double types', () => {
+      expect(getFacetType({ type: 'double' })).toBe('range');
+    });
+  });
+});

--- a/src/packages/@ncigdc/containers/FileAggregations.js
+++ b/src/packages/@ncigdc/containers/FileAggregations.js
@@ -147,7 +147,7 @@ export type TProps = {
     doc_type: String,
     field: String,
     full: String,
-    type: 'id' | 'string' | 'long',
+    type: 'id' | 'string' | 'long' | 'float' | 'double',
   }>,
   handleSelectFacet: Function,
   handleResetFacets: Function,


### PR DESCRIPTION
In DR 27, we updated some of mapping property types to double. This
was needed to perform aggregation without bucketing into integers.
As a result, custom facets broke because they did not support doubles.
