### PR TITLE
Removed npm-force-resolutions  from preinstall

### DIFF
--- a/helm-jenkins.sh
+++ b/helm-jenkins.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Skipping helm stage"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23129,9 +23129,9 @@
           },
           "dependencies": {
             "anymatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-              "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
               "dev": true,
               "requires": {
                 "normalize-path": "^3.0.0",
@@ -23164,9 +23164,9 @@
               "optional": true
             },
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"
@@ -23941,9 +23941,9 @@
           },
           "dependencies": {
             "anymatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-              "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
               "dev": true,
               "requires": {
                 "normalize-path": "^3.0.0",
@@ -23976,9 +23976,9 @@
               "optional": true
             },
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23129,9 +23129,9 @@
           },
           "dependencies": {
             "anymatch": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+              "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
               "dev": true,
               "requires": {
                 "normalize-path": "^3.0.0",
@@ -23164,9 +23164,9 @@
               "optional": true
             },
             "glob-parent": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"
@@ -23941,9 +23941,9 @@
           },
           "dependencies": {
             "anymatch": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-              "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+              "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
               "dev": true,
               "requires": {
                 "normalize-path": "^3.0.0",
@@ -23976,9 +23976,9 @@
               "optional": true
             },
             "glob-parent": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-              "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://portal.gdc.cancer.gov/",
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx npm-force-resolutions@0.0.3",
     "start": "concurrently --kill-others 'npm run start-ui' 'npm run relay -- --watch'",
     "start-ui": "BROWSER=none react-app-rewired start --scripts-version react-scripts-ts",
     "build": "npm run relay && react-app-rewired build --scripts-version react-scripts-ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://portal.gdc.cancer.gov/",
   "scripts": {
-    "preinstall": "npx npm-force-resolutions@0.0.3",
+    "force-resolve": "npx npm-force-resolutions",
     "start": "concurrently --kill-others 'npm run start-ui' 'npm run relay -- --watch'",
     "start-ui": "BROWSER=none react-app-rewired start --scripts-version react-scripts-ts",
     "build": "npm run relay && react-app-rewired build --scripts-version react-scripts-ts",


### PR DESCRIPTION
## Ticket Number



## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [x] `qa` (which version?)

## Description of Changes

We use npm-force-resolutions to modify package-lock.json in npm preinstall. This step `npx npm-force-resolutions` has been failing when run from behind our proxy due to (what i think is) this [hard timeout.](https://github.com/rogeriochaves/npm-force-resolutions/blob/master/src/npm_force_resolutions/core.cljs#L70) I believe this is true because the command fails in 8-9secs. Also I when i used an older version of npm-force-resolutions which doesnt have that timeout, it passes. 

Filed issue https://github.com/rogeriochaves/npm-force-resolutions/issues/33 and PR https://github.com/rogeriochaves/npm-force-resolutions/pull/34/files  in upstream repo. 