### PR TITLE
DEV-1042: Update Ensembl links in portal

### DIFF
--- a/src/packages/@ncigdc/utils/externalReferenceLinks.js
+++ b/src/packages/@ncigdc/utils/externalReferenceLinks.js
@@ -15,10 +15,10 @@ export default {
   cosm: id => `http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=${id}`,
   cosn: id => `http://cancer.sanger.ac.uk/cosmic/ncv/overview?id=${id}`,
   dbsnp: id => `https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=${id}`,
-  ensembl: id => `http://may2015.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
+  ensembl: id => `http://nov2020.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=${id}`,
   entrez_gene: id => `http://www.ncbi.nlm.nih.gov/gene/${id}`,
   hgnc: id => `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${id}`,
   omim_gene: id => `http://omim.org/entry/${id}`,
-  transcript: id => `http://feb2014.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=${id}`,
+  transcript: id => `http://nov2020.archive.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=${id}`,
   uniprotkb_swissprot: id => `http://www.uniprot.org/uniprot/${id}`,
 };


### PR DESCRIPTION
Update Ensembl links to point to release 102 (november 2020 archive) which corresponds to the GENCODE v36 release
