### PR TITLE
Delete Jenkinsfile.security

### DIFF
--- a/Jenkinsfile.security
+++ b/Jenkinsfile.security
@@ -1,4 +1,0 @@
-#!/usr/bin/env groovy
-library identifier: "jenkins-lib@master" 
-securityPipeline {
-}


### PR DESCRIPTION
Removing the file as Veracode scanning is no more needed and is replaced by Synk

## Ticket Number:
GDCPE- 617
https://jira.opensciencedatacloud.org/browse/GDCPE-617

## Description of Changes
