### PR TITLE
Removing Jenkinsfile.security

### DIFF
--- a/Jenkinsfile.security
+++ b/Jenkinsfile.security
@@ -1,4 +1,0 @@
-#!/usr/bin/env groovy
-library identifier: "jenkins-lib@master" 
-securityPipeline {
-}


### PR DESCRIPTION
Ticket: https://jira.opensciencedatacloud.org/browse/GDCPE-617
Removing Jenkinsfile.security as it is no more required. The file was being used by Veracode to scan code but we have moved to Synk for code scanning now
