### PR TITLE
PEAR-861 configure portal to use relative urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.30.0",
+  "version": "1.30.1",
   "repository": "NCI-GDC/portal-ui",
   "name": "portal-ui",
   "author": {

--- a/portal.Dockerfile
+++ b/portal.Dockerfile
@@ -6,9 +6,9 @@ COPY ./ /portal
 WORKDIR /portal
 
 ENV REACT_APP_GDC_DISPLAY_SLIDES=true \
-    REACT_APP_SLIDE_IMAGE_ENDPOINT="https://api.gdc.cancer.gov/tile/" \
-    REACT_APP_GDC_AUTH="https://portal.gdc.cancer.gov/auth/" \
-    REACT_APP_API="https://portal.gdc.cancer.gov/auth/api/v0/" \
+    REACT_APP_SLIDE_IMAGE_ENDPOINT="/auth/api/v0/tile/" \
+    REACT_APP_GDC_AUTH="/auth/" \
+    REACT_APP_API="/auth/api/v0/" \
     GDC_BASE="/" \
     REACT_APP_WEBSITE_NAME=GDC \
     NODE_PATH=src/packages


### PR DESCRIPTION
Previously, the portal used absolute urls for api and auth base urls. This commit changes those to relative urls. This will allow us to deploy the docker image into different environments without needing environnemt specific configs. This change also chages the direct-api call for tiles the portal-proxied api path.

## Ticket Number

e.g. PRTL-0000

## Environment to be used in testing

- [ ] `prod`
- [ ] `dev-oicr`
- [ ] `qa` (which version?)

## Description of Changes
