### PR TITLE
PEAR-861 use relative urls in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Copied from tungsten
 export REACT_APP_GDC_DISPLAY_SLIDES=true
-export REACT_APP_SLIDE_IMAGE_ENDPOINT="https://api.gdc.cancer.gov/tile/"
+export REACT_APP_SLIDE_IMAGE_ENDPOINT="/auth/api/v0/tile/"
 export REACT_APP_COMMIT_HASH=`git rev-parse --short HEAD`
 export REACT_APP_COMMIT_TAG=`git tag -l --points-at HEAD`
-export REACT_APP_API="https://portal.gdc.cancer.gov/auth/api/v0/"
-export REACT_APP_GDC_AUTH="https://portal.gdc.cancer.gov/auth/"
+export REACT_APP_API="/auth/api/v0/"
+export REACT_APP_GDC_AUTH="/auth/"
 export GDC_BASE="/"
 export NODE_ENV=production
 export REACT_APP_COMMIT_HASH=$TRAVIS_COMMIT


### PR DESCRIPTION
A previous commit updated the portal.Dockerfile to use relative urls. That is the file used by Jenkins. This travis build uses the build.sh script and Dockerfile. For this commit, I'm updating the build script. I am not changing the way different build systems orchestrate their builds.
