### PR TITLE
DEV-1822 try to see if this fixes the ID problem

### DIFF
--- a/src/packages/@ncigdc/modern_components/Exists/exists.relay.js
+++ b/src/packages/@ncigdc/modern_components/Exists/exists.relay.js
@@ -10,7 +10,7 @@ export default (Component: ReactClass<*>) => (props: Object) => {
       variables={{ id: btoa(`${props.type}:${props.id}`) }}
       Component={Component}
       query={graphql`
-        query exists_relayQuery($id: ID) {
+        query exists_relayQuery($id: ID!) {
           node(id: $id) {
             id
           }


### PR DESCRIPTION
with the graphene v1.4.1, it is now asking for `id: ID!` for the node field.